### PR TITLE
Update OpenLine.cs

### DIFF
--- a/Technical/OpenLine.cs
+++ b/Technical/OpenLine.cs
@@ -82,6 +82,11 @@ namespace ATAS.Indicators.Technical
 			});
 		}
 
+  		[Display(ResourceType = typeof(Strings), Name = nameof(Strings.ExtendLast),
+		GroupName = nameof(Strings.Drawing), Description = nameof(Strings.ExtendLastDescription),
+		Order = 63)]
+		public bool ExtendLastLineToRight { get; set; } = true;
+
         #region Hidden
 
         [Obsolete]
@@ -194,10 +199,30 @@ namespace ATAS.Indicators.Technical
 
                 context.DrawLine(LinePen.RenderObject, x1, y, x2, y);
 
+                // Show text only for past sessions (not the last one)
+                if (session != _lastSession || !ExtendLastLineToRight)
+                {
+                    var stringSize = context.MeasureString(OpenCandleText, _font);
+                    context.DrawString(OpenCandleText, _font, LinePen.RenderObject.Color, x2 - stringSize.Width, y - stringSize.Height - Offset - 3);
+                }
+            }
+
+            // --- DRAW EXTENDED LINE FOR LAST SESSION ---
+	    // Even if it has already been touched, and even if its opening candle is not visible
+            if (_lastSession != null && ExtendLastLineToRight)
+            {
+                var xStart = ChartInfo.GetXByBar(_lastSession.StartBar, false);
+                var xEnd = context.ClipBounds.Right; ; // Borde derecho del gráfico
+                var y = ChartInfo.GetYByPrice(_lastSession.OpenPrice, false);
+
+                context.DrawLine(LinePen.RenderObject, xStart, y, xEnd, y);
+
                 var stringSize = context.MeasureString(OpenCandleText, _font);
-                context.DrawString(OpenCandleText, _font, LinePen.RenderObject.Color, x2 - stringSize.Width, y - stringSize.Height - Offset - 3);
+                context.DrawString(OpenCandleText, _font, LinePen.RenderObject.Color, xEnd - stringSize.Width, y - stringSize.Height - Offset - 3);
             }
         }
+
+        
 
 		protected override void OnCalculate(int bar, decimal value)
 		{


### PR DESCRIPTION
Enhance session-based line rendering and text display behavior

- Added support to extend the last session's line to the right of the chart
- Conditional rendering of session text labels: only shown for past sessions unless extension is enabled
- Ensured lines are drawn even if the opening candle of the last session is out of view
- Improved visual alignment of text for extended lines
- Added safeguards to avoid drawing duplicated labels