### PR TITLE
Update InitialBalance.cs

### DIFF
--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -11,8 +11,11 @@ using ATAS.Indicators.Drawing;
 using OFT.Attributes;
 using OFT.Localization;
 using OFT.Rendering.Settings;
+using OFT.Rendering.Context;
+using OFT.Rendering.Tools;
 
 using Pen = System.Drawing.Pen;
+using CrossColor = System.Windows.Media.Color;
 
 [DisplayName("Initial Balance")]
 [Display(ResourceType = typeof(Strings), Description = nameof(Strings.InitialBalanceIndDescription))]
@@ -34,814 +37,1100 @@ public class InitialBalance : Indicator
 
 	#region Fields
 
-	private readonly ValueDataSeries _ibh = new("Ibh", "IBH")
-	{
-		Color = DefaultColors.Blue.Convert(),
-		LineDashStyle = LineDashStyle.Dash,
-		VisualType = VisualMode.Square,
-		Width = 1,
-		DescriptionKey = nameof(Strings.TopBandDscription)
-	};
+	// ==========================
+    // Main price level series
+    // ==========================
 
-	private readonly ValueDataSeries _ibhx1 = new("Ibhx1", "IBHX1")
-	{
-		Color = DefaultColors.Fuchsia.Convert(),
-		LineDashStyle = LineDashStyle.Dash,
-		VisualType = VisualMode.Square,
-		Width = 1
-	};
+    private ValueDataSeries _ibh;
+    private ValueDataSeries _ibhx1;
+    private ValueDataSeries _ibhx2;
+    private ValueDataSeries _ibhx3;
+    private ValueDataSeries _ibl;
+    private ValueDataSeries _iblx1;
+    private ValueDataSeries _iblx2;
+    private ValueDataSeries _iblx3;
+    private ValueDataSeries _ibm;
+    private ValueDataSeries _mid;
 
-	private readonly ValueDataSeries _ibhx2 = new("Ibhx2", "IBHX2")
-	{
-		Color = DefaultColors.Fuchsia.Convert(),
-		LineDashStyle = LineDashStyle.Dash,
-		VisualType = VisualMode.Square,
-		Width = 1
-	};
+    // ==========================
+    // Value area series (between price levels)
+    // ==========================
 
-	private readonly ValueDataSeries _ibhx3 = new("Ibhx3", "IBHX3")
-	{
-		Color = DefaultColors.Fuchsia.Convert(),
-		LineDashStyle = LineDashStyle.Dash,
-		VisualType = VisualMode.Square,
-		Width = 1
-	};
+    private RangeDataSeries _ibhx32;
+    private RangeDataSeries _ibhx21;
+    private RangeDataSeries _ibhx1h;
+    private RangeDataSeries _ibHm;
+    private RangeDataSeries _ibMl;
+    private RangeDataSeries _ibl1;
+    private RangeDataSeries _iblx12;
+    private RangeDataSeries _iblx23;
 
-	private readonly ValueDataSeries _ibl = new("Ibl", "IBL")
-	{
-		Color = DefaultColors.Red.Convert(),
-		LineDashStyle = LineDashStyle.Dash,
-		VisualType = VisualMode.Square,
-		Width = 1,
-        DescriptionKey = nameof(Strings.BottomBandDscription)
-    };
-
-	private readonly ValueDataSeries _iblx1 = new("Iblx1", "IBLX1")
-	{
-		Color = DefaultColors.Purple.Convert(),
-		LineDashStyle = LineDashStyle.Dash,
-		VisualType = VisualMode.Square,
-		Width = 1
-	};
-
-	private readonly ValueDataSeries _iblx2 = new("Iblx2", "IBLX2")
-	{
-		Color = DefaultColors.Purple.Convert(),
-		LineDashStyle = LineDashStyle.Dash,
-		VisualType = VisualMode.Square,
-		Width = 1
-	};
-
-	private readonly ValueDataSeries _iblx3 = new("Iblx3", "IBLX3")
-	{
-		Color = DefaultColors.Purple.Convert(),
-		LineDashStyle = LineDashStyle.Dash,
-		VisualType = VisualMode.Square,
-		Width = 1
-	};
-
-	private readonly ValueDataSeries _ibm = new("Ibm", "IBM")
-	{
-		Color = DefaultColors.Green.Convert(),
-		LineDashStyle = LineDashStyle.Dash,
-		VisualType = VisualMode.Square,
-		Width = 1,
-        DescriptionKey = nameof(Strings.MidBandDescription)
-    };
-
-	private readonly ValueDataSeries _mid = new("MidId", "Mid")
-	{
-		Color = CrossColor.FromArgb(0, 0, 255, 0),
-		LineDashStyle = LineDashStyle.Solid,
-		VisualType = VisualMode.Square,
-		Width = 1,
-        DescriptionKey = nameof(Strings.SessionAveragePriceDescription)
-    };
-
-	private RangeDataSeries _ibhx32 = new("Ibhx32", "ibhx32")
-	{
-		RangeColor = System.Drawing.Color.Transparent.Convert(),
-		DrawAbovePrice = false,
-		IsHidden = true
-	};
-	private RangeDataSeries _ibhx21 = new("Ibhx21", "ibhx21")
-	{
-		RangeColor = System.Drawing.Color.Transparent.Convert(),
-        DrawAbovePrice = false,
-        IsHidden = true
-	};
-	private RangeDataSeries _ibhx1h = new("Ibhx1h", "ibhx1h")
-	{
-		RangeColor = System.Drawing.Color.Transparent.Convert(),
-        DrawAbovePrice = false,
-        IsHidden = true
-	};
-	private RangeDataSeries _ibHm = new("IbHm", "ibHm")
-	{
-		RangeColor = System.Drawing.Color.Transparent.Convert(),
-        DrawAbovePrice = false,
-        IsHidden = true
-	};
-	private RangeDataSeries _ibMl = new("IbM1", "ibM1")
-	{
-		RangeColor = System.Drawing.Color.Transparent.Convert(),
-        DrawAbovePrice = false,
-        IsHidden = true
-	};
-	private RangeDataSeries _ibl1 = new("Ibl1", "ibl1")
-	{
-		RangeColor = System.Drawing.Color.Transparent.Convert(),
-        DrawAbovePrice = false,
-        IsHidden = true
-	};
-	private RangeDataSeries _iblx12 = new("Ibl12", "ibl12")
-	{
-		RangeColor = System.Drawing.Color.Transparent.Convert(),
-        DrawAbovePrice = false,
-        IsHidden = true
-	};
-	private RangeDataSeries _iblx23 = new("Ibl23", "ibl23")
-	{
-		RangeColor = System.Drawing.Color.Transparent.Convert(),
-        DrawAbovePrice = false,
-        IsHidden = true
-	};
+    // ==========================
+    // Style and display parameters
+    // ==========================
 
     private CrossColor _borderColor = DefaultColors.Red.Convert();
-	private int _borderWidth = 1;
-	private bool _calculate;
-	private bool _customSessionStart;
-	private int _days = 20;
+    private CrossColor _fillColor = DefaultColors.Yellow.Convert();
+    private int _borderWidth = 1;
+    private RenderFont _font;
+    private float _fontSize = 12.0f;
     private bool _drawText = true;
-	private TimeSpan _endDate;
-	private DateTime _endTime = DateTime.MaxValue;
-	private CrossColor _fillColor = DefaultColors.Yellow.Convert();
-	private bool _highLowIsSet;
-	private decimal _ibMax = decimal.MinValue;
-	private decimal _ibMin = decimal.MaxValue;
-	private decimal _ibmValue = decimal.Zero;
+    private bool _calculate;
+    private bool _customSessionStart;
+    private bool _highLowIsSet;
+    private bool _initialized;
+    private bool _isStarted;
 
-	private bool _initialized;
-	private int _lastStartBar = -1;
-	private decimal _maxValue = decimal.MinValue;
-	private decimal _minValue = decimal.MaxValue;
-	private int _period = 60;
-	private PeriodType _periodMode = PeriodType.Minutes;
-	private DrawingRectangle _rectangle = new(0, 0, 0, 0, Pens.Gray, new SolidBrush(DefaultColors.Yellow));
-	private bool _showOpenRange = true;
-	private TimeSpan _startDate = new(9, 0, 0);
-	private int _targetBar;
-	private decimal _x1 = 1m;
-	private decimal _x2 = 2m;
-	private decimal _x3 = 3m;
-	private decimal ibhx1 = decimal.Zero;
-	private decimal ibhx2 = decimal.Zero;
-	private decimal ibhx3 = decimal.Zero;
-	private decimal iblx1 = decimal.Zero;
-	private decimal iblx2 = decimal.Zero;
-	private decimal iblx3 = decimal.Zero;
-	private decimal mid = decimal.Zero;
+    // ==========================
+    // Time and session management
+    // ==========================
 
-	private bool _isStarted;
+    private int _days = 20;
+    private int _period = 60;
+    private TimeSpan _startDate = new(9, 0, 0);
+    private TimeSpan _endDate;
+    private DateTime _endTime = DateTime.MaxValue;
+    private PeriodType _periodMode = PeriodType.Minutes;
+    private DrawingRectangle _rectangle = new(0, 0, 0, 0, Pens.Gray, new SolidBrush(DefaultColors.Yellow));
+
+    // ==========================
+    // Bar and value tracking
+    // ==========================
+
+    private int _lastStartBar = -1;
+    private int _lastEndBar = -1;
+    private int _targetBar;
+    private decimal _maxValue = decimal.MinValue;
+    private decimal _minValue = decimal.MaxValue;
+    private decimal _ibMax = decimal.MinValue;
+    private decimal _ibMin = decimal.MaxValue;
+    private decimal _ibmValue;
+    private decimal mid;
+    private decimal ibhx1;
+    private decimal ibhx2;
+    private decimal ibhx3;
+    private decimal iblx1;
+    private decimal iblx2;
+    private decimal iblx3;
+
+    // ==========================
+    // Range multipliers (IBHX / IBLX)
+    // ==========================
+    private decimal _x1 = 1m;
+    private decimal _x2 = 2m;
+    private decimal _x3 = 3m;
+
+    // ==========================
+    // Advanced visual configuration
+    // ==========================
+
+    private bool _showOpenRange = false;
+    private bool _showDuringFormation = false;
+    private readonly Dictionary<ValueDataSeries, CrossColor> _originalColors = new();
+
+    // ==========================
+    // Custom session management
+    // ==========================
+
+    private class Session
+    {
+        public int StartBar;
+        public int EndBar;
+        public DateTime StartTime;
+        public DateTime EndTime;
+        public bool IsCalculationComplete;
+    }
+
+    private readonly List<Session> _sessions = new();
+    private Session _currentSession;
 
     #endregion
 
     #region Properties
 
-    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Calculation), 
-		Name = nameof(Strings.DaysLookBack), Order = int.MaxValue, Description = nameof(Strings.DaysLookBackDescription))]
-    [Range(0, 1000)]
-    public int Days
-	{
-		get => _days;
-		set
-		{
-			_days = value;
-			RecalculateValues();
-		}
-	}
+// Number of days to look back to display previous sessions.
+[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Calculation),
+    Name = nameof(Strings.DaysLookBack), Order = int.MaxValue, Description = nameof(Strings.DaysLookBackDescription))]
+[Range(0, 1000)]
+public int Days
+{
+    get => _days;
+    set
+    {
+        _days = value;
+        RecalculateValues();
+    }
+}
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Show),
-		GroupName = nameof(Strings.OpenRange), Description = nameof(Strings.ShowOpenRangeDescription), Order = 10)]
-	public bool ShowOpenRange
-	{
-		get => _showOpenRange;
-		set
-		{
-			_showOpenRange = value;
-			RecalculateValues();
-		}
-	}
+// ==========================
+// Visual configuration of the Open Range rectangle
+// ==========================
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.BorderWidth),
-		GroupName = nameof(Strings.OpenRange), Description = nameof(Strings.BorderWidthPixelDescription), Order = 20)]
-	[Range(1, 100)]
-	public int BorderWidth
-	{
-		get => _borderWidth;
-		set
-		{
-			_borderWidth = value;
-			RecalculateValues();
-		}
-	}
+// Show or hide the Open Range rectangle
+[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Show),
+    GroupName = nameof(Strings.OpenRange), Description = nameof(Strings.ShowOpenRangeDescription), Order = 10)]
+public bool ShowOpenRange
+{
+    get => _showOpenRange;
+    set
+    {
+        _showOpenRange = value;
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.BorderColor),
-		GroupName = nameof(Strings.OpenRange), Description = nameof(Strings.BorderColorDescription),Order = 30)]
-	public CrossColor BorderColor
-	{
-		get => _borderColor;
-		set
-		{
-			_borderColor = value;
-			RecalculateValues();
-		}
-	}
+        if (!_showOpenRange)
+        {
+            // Clear rectangle from the chart
+            Rectangles.Clear();
+        }
+        else
+        {
+            // Redraw the rectangle if there are valid values
+            if (_lastEndBar > 0)
+                DrawOpenRangeRectangle(_lastEndBar);
+            else if (_calculate && ShowDuringFormation)
+                DrawOpenRangeRectangle(CurrentBar - 1);
+        }
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.FillColor),
-		GroupName = nameof(Strings.OpenRange), Description = nameof(Strings.FillColorDescription),Order = 40)]
-	public CrossColor FillColor
-	{
-		get => _fillColor;
-		set
-		{
-			_fillColor = value;
-			RecalculateValues();
-		}
-	}
+        RecalculateValues();
+        RedrawChart();
+    }
+}
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.CustomSession),
-		GroupName = nameof(Strings.SessionTime), Description = nameof(Strings.IsCustomSessionDescription),Order = 10)]
-	public bool CustomSessionStart
-	{
-		get => _customSessionStart;
-		set
-		{
-			_customSessionStart = value;
-			RecalculateValues();
-		}
-	}
+// Border thickness of the Open Range rectangle
+[Display(ResourceType = typeof(Strings), Name = nameof(Strings.BorderWidth),
+    GroupName = nameof(Strings.OpenRange), Description = nameof(Strings.BorderWidthPixelDescription), Order = 20)]
+[Range(1, 100)]
+public int BorderWidth
+{
+    get => _borderWidth;
+    set
+    {
+        _borderWidth = value;
+        RecalculateValues();
+        RedrawChart();
+    }
+}
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.StartTime),
-		GroupName = nameof(Strings.SessionTime), Description = nameof(Strings.StartTimeDescription), Order = 20)]
-	public TimeSpan StartDate
-	{
-		get => _startDate;
-		set
-		{
-			_startDate = value;
-			RecalculateValues();
-		}
-	}
+// Border color of the Open Range rectangle
+[Display(ResourceType = typeof(Strings), Name = nameof(Strings.BorderColor),
+    GroupName = nameof(Strings.OpenRange), Description = nameof(Strings.BorderColorDescription), Order = 30)]
+public CrossColor BorderColor
+{
+    get => _borderColor;
+    set
+    {
+        _borderColor = value;
+        RecalculateValues();
+        RedrawChart();
+    }
+}
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.EndTime),
-		GroupName = nameof(Strings.SessionTime), Description = nameof(Strings.EndTimeDescription), Order = 20)]
-	public TimeSpan EndDate
-	{
-		get => _endDate;
-		set
-		{
-			_endDate = value;
-			RecalculateValues();
-		}
-	}
+// Fill color of the Open Range rectangle
+[Display(ResourceType = typeof(Strings), Name = nameof(Strings.FillColor),
+    GroupName = nameof(Strings.OpenRange), Description = nameof(Strings.FillColorDescription), Order = 40)]
+public CrossColor FillColor
+{
+    get => _fillColor;
+    set
+    {
+        _fillColor = value;
+        RecalculateValues();
+        RedrawChart();
+    }
+}
 
-    [Parameter]
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Period),
-		GroupName = nameof(Strings.SessionTime), Description = nameof(Strings.PeriodDescription), Order = 30)]
-	[Range(1, 10000)]
-	public int Period
-	{
-		get => _period;
-		set
-		{
-			_period = value;
-			RecalculateValues();
-		}
-	}
+// ==========================
+// Custom Session Configuration
+// ==========================
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.PeriodType),
-		GroupName = nameof(Strings.SessionTime), Description = nameof(Strings.PeriodTypeDescription), Order = 40)]
-	public PeriodType PeriodMode
-	{
-		get => _periodMode;
-		set
-		{
-			_periodMode = value;
-			RecalculateValues();
-		}
-	}
+// Enables or disables the use of a custom session
+[Display(ResourceType = typeof(Strings), Name = nameof(Strings.CustomSession),
+    GroupName = nameof(Strings.SessionTime), Description = nameof(Strings.IsCustomSessionDescription), Order = 10)]
+public bool CustomSessionStart
+{
+    get => _customSessionStart;
+    set
+    {
+        _customSessionStart = value;
+        RecalculateValues();
+    }
+}
 
-    [Parameter]
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Multiplier1),
-		GroupName = nameof(Strings.Multiplier), Description = nameof(Strings.MultiplierDescription), Order = 100)]
-	public decimal X1
-	{
-		get => _x1;
-		set
-		{
-			_x1 = value;
-			RecalculateValues();
-		}
-	}
+// Start time of the custom session
+[Display(ResourceType = typeof(Strings), Name = nameof(Strings.StartTime),
+    GroupName = nameof(Strings.SessionTime), Description = nameof(Strings.StartTimeDescription), Order = 20)]
+public TimeSpan StartDate
+{
+    get => _startDate;
+    set
+    {
+        _startDate = value;
+        RecalculateValues();
+    }
+}
 
-    [Parameter]
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Multiplier2),
-		GroupName = nameof(Strings.Multiplier), Description = nameof(Strings.MultiplierDescription),Order = 110)]
-	public decimal X2
-	{
-		get => _x2;
-		set
-		{
-			_x2 = value;
-			RecalculateValues();
-		}
-	}
+// End time of the custom session
+[Display(ResourceType = typeof(Strings), Name = nameof(Strings.EndTime),
+    GroupName = nameof(Strings.SessionTime), Description = nameof(Strings.EndTimeDescription), Order = 20)]
+public TimeSpan EndDate
+{
+    get => _endDate;
+    set
+    {
+        _endDate = value;
+        RecalculateValues();
+    }
+}
 
-    [Parameter]
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Multiplier3),
-		GroupName = nameof(Strings.Multiplier), Description = nameof(Strings.MultiplierDescription), Order = 120)]
-	public decimal X3
-	{
-		get => _x3;
-		set
-		{
-			_x3 = value;
-			RecalculateValues();
-		}
-	}
+// ==========================
+// Initial Balance Calculation Parameters
+// ==========================
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Text),
-		GroupName = nameof(Strings.Show), Description = nameof(Strings.IsNeedShowLabelDescription), Order = 130)]
-	public bool DrawText
-	{
-		get => _drawText;
-		set
-		{
-			_drawText = value;
-			RecalculateValues();
-		}
-	}
+// Duration of the Initial Balance period
+[Parameter]
+[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Period),
+    GroupName = nameof(Strings.SessionTime), Description = nameof(Strings.PeriodDescription), Order = 30)]
+[Range(1, 10000)]
+public int Period
+{
+    get => _period;
+    set
+    {
+        _period = value;
+        RecalculateValues();
+    }
+}
 
- 	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.FontSize),
-		GroupName = nameof(Strings.Show), Description = nameof(Strings.TextSizeDescription), Order = 140)]
-		[Range(6, 48)]
-	public float FontSize { get; set; } = 12.0f;
+// Type of Initial Balance period (minutes or bars)
+[Display(ResourceType = typeof(Strings), Name = nameof(Strings.PeriodType),
+    GroupName = nameof(Strings.SessionTime), Description = nameof(Strings.PeriodTypeDescription), Order = 40)]
+public PeriodType PeriodMode
+{
+    get => _periodMode;
+    set
+    {
+        _periodMode = value;
+        RecalculateValues();
+    }
+}
 
-   	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.ExtendLast),
-		GroupName = nameof(Strings.Drawing), Description = nameof(Strings.ExtendLastDescription), Order = 150)]
-	public bool ExtendLastLineToRight { get; set; } = true;
+// ==========================
+// Initial Balance Expansion Multipliers
+// ==========================
 
- 	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.ShowDuringFormation),
-	GroupName = nameof(Strings.Show), Description = nameof(Strings.ShowDuringFormationDescription), Order = 160)]
-	public bool ShowDuringFormation { get; set; } = false;
+[Parameter]
+[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Multiplier1),
+    GroupName = nameof(Strings.Multiplier), Description = nameof(Strings.MultiplierDescription), Order = 100)]
+public decimal X1
+{
+    get => _x1;
+    set
+    {
+        _x1 = value;
+        RecalculateValues();
+    }
+}
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBHX32), 
-		GroupName = nameof(Strings.BackGround), Description = nameof(Strings.AreaColorDescription), Order = 200)]
-	public CrossColor Ibhx32
-	{
-		get=>_ibhx32.RangeColor; 
-		set=>_ibhx32.RangeColor = value;
-	}
+[Parameter]
+[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Multiplier2),
+    GroupName = nameof(Strings.Multiplier), Description = nameof(Strings.MultiplierDescription), Order = 110)]
+public decimal X2
+{
+    get => _x2;
+    set
+    {
+        _x2 = value;
+        RecalculateValues();
+    }
+}
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBHX21),
-		GroupName = nameof(Strings.BackGround), Description = nameof(Strings.AreaColorDescription),Order = 210)]
-	public CrossColor Ibhx21 
-	{
-		get => _ibhx21.RangeColor;
-		set => _ibhx21.RangeColor = value;
-	}
+[Parameter]
+[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Multiplier3),
+    GroupName = nameof(Strings.Multiplier), Description = nameof(Strings.MultiplierDescription), Order = 120)]
+public decimal X3
+{
+    get => _x3;
+    set
+    {
+        _x3 = value;
+        RecalculateValues();
+    }
+}
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBHX1H),
-		GroupName = nameof(Strings.BackGround), Description = nameof(Strings.AreaColorDescription), Order = 220)]
-	public CrossColor Ibhx1h 
-	{
-		get => _ibhx1h.RangeColor;
-		set => _ibhx1h.RangeColor = value;
-	}
+// ==========================
+// Visual settings for lines and labels
+// ==========================
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBHM), 
-		GroupName = nameof(Strings.BackGround), Description = nameof(Strings.AreaColorDescription), Order = 230)]
-	public CrossColor IbHm
-	{
-		get => _ibHm.RangeColor;
-		set => _ibHm.RangeColor = value;
-	}
+// Show labels at the end of lines
+[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Text),
+    GroupName = nameof(Strings.Show), Description = nameof(Strings.IsNeedShowLabelDescription), Order = 130)]
+public bool DrawText
+{
+    get => _drawText;
+    set
+    {
+        _drawText = value;
+        RecalculateValues();
+        RedrawChart();
+    }
+}
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBML), 
-		GroupName = nameof(Strings.BackGround), Description = nameof(Strings.AreaColorDescription), Order = 240)]
-	public CrossColor IbMl
-	{
-		get => _ibMl.RangeColor;
-		set => _ibMl.RangeColor = value;
-	}
+// Font size for labels
+[Display(ResourceType = typeof(Strings), Name = nameof(Strings.FontSize),
+   GroupName = nameof(Strings.Show), Description = nameof(Strings.TextSizeDescription), Order = 140)]
+[Range(6, 48)]
+public float FontSize
+{
+    get => _fontSize;
+    set
+    {
+        _fontSize = value;
+        _font = new RenderFont("Arial", _fontSize); // Updated when changed
+        RecalculateValues();
+    }
+}
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBL1), 
-		GroupName = nameof(Strings.BackGround), Description = nameof(Strings.AreaColorDescription), Order = 250)]
-	public CrossColor Ibl1
-	{
-		get => _ibl1.RangeColor;
-		set => _ibl1.RangeColor = value;
-	}
+// Extend lines to the right edge of the chart
+[Display(ResourceType = typeof(Strings), Name = nameof(Strings.ExtendLast),
+ GroupName = nameof(Strings.Drawing), Description = nameof(Strings.ExtendLastDescription), Order = 150)]
+public bool ExtendLastLineToRight { get; set; } = true;
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBLX12),
-		GroupName = nameof(Strings.BackGround), Description = nameof(Strings.AreaColorDescription), Order = 260)]
-	public CrossColor Iblx12
-	{
-		get => _iblx12.RangeColor;
-		set => _iblx12.RangeColor = value;
-	}
+// Show levels during Initial Balance formation
+[Display(ResourceType = typeof(Strings), Name = "Show During Formation",
+GroupName = nameof(Strings.Show), Description = "Show IB lines during first hour", Order = 160)]
+public bool ShowDuringFormation
+{
+    get => _showDuringFormation;
+    set
+    {
+        _showDuringFormation = value;
+        // Update line background color
+        UpdateSeriesVisibility();
+        RecalculateValues();
+        RedrawChart();
+    }
+}
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBLX23),
-		GroupName = nameof(Strings.BackGround), Description = nameof(Strings.AreaColorDescription), Order = 270)]
-	public CrossColor Iblx23
-	{
-		get => _iblx23.RangeColor;
-		set => _iblx23.RangeColor = value;
-	}
+// ==========================
+// Background colors of Initial Balance expansion zones
+// ==========================
 
-    #endregion
+[Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBHX32),
+GroupName = nameof(Strings.BackGround), Description = nameof(Strings.AreaColorDescription), Order = 200)]
+public CrossColor Ibhx32
+{
+    get => _ibhx32.RangeColor;
+    set => _ibhx32.RangeColor = value;
+}
+
+[Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBHX21),
+    GroupName = nameof(Strings.BackGround), Description = nameof(Strings.AreaColorDescription), Order = 210)]
+public CrossColor Ibhx21
+{
+    get => _ibhx21.RangeColor;
+    set => _ibhx21.RangeColor = value;
+}
+
+[Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBHX1H),
+    GroupName = nameof(Strings.BackGround), Description = nameof(Strings.AreaColorDescription), Order = 220)]
+public CrossColor Ibhx1h
+{
+    get => _ibhx1h.RangeColor;
+    set => _ibhx1h.RangeColor = value;
+}
+
+[Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBHM),
+    GroupName = nameof(Strings.BackGround), Description = nameof(Strings.AreaColorDescription), Order = 230)]
+public CrossColor IbHm
+{
+    get => _ibHm.RangeColor;
+    set => _ibHm.RangeColor = value;
+}
+
+[Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBML),
+    GroupName = nameof(Strings.BackGround), Description = nameof(Strings.AreaColorDescription), Order = 240)]
+public CrossColor IbMl
+{
+    get => _ibMl.RangeColor;
+    set => _ibMl.RangeColor = value;
+}
+
+[Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBL1),
+    GroupName = nameof(Strings.BackGround), Description = nameof(Strings.AreaColorDescription), Order = 250)]
+public CrossColor Ibl1
+{
+    get => _ibl1.RangeColor;
+    set => _ibl1.RangeColor = value;
+}
+
+[Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBLX12),
+    GroupName = nameof(Strings.BackGround), Description = nameof(Strings.AreaColorDescription), Order = 260)]
+public CrossColor Iblx12
+{
+    get => _iblx12.RangeColor;
+    set => _iblx12.RangeColor = value;
+}
+
+[Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBLX23),
+    GroupName = nameof(Strings.BackGround), Description = nameof(Strings.AreaColorDescription), Order = 270)]
+public CrossColor Iblx23
+{
+    get => _iblx23.RangeColor;
+    set => _iblx23.RangeColor = value;
+}
+
+#endregion
+
 	
-    #region ctor
+   #region ctor
 
-    public InitialBalance()
-		: base(true)
-	{
-		DenyToChangePanel = true;
+public InitialBalance()
+    : base(true)
+{
+    DenyToChangePanel = true;
+    EnableCustomDrawing = true;
+    SubscribeToDrawingEvents(DrawingLayouts.Final);
+    _font = new RenderFont("Arial", _fontSize);
 
-        DataSeries[0] = _mid;
-        DataSeries.Add(_ibh);
-		DataSeries.Add(_ibl);
-		DataSeries.Add(_ibm);
-		DataSeries.Add(_ibhx1);
-		DataSeries.Add(_ibhx2);
-		DataSeries.Add(_ibhx3);
-		DataSeries.Add(_iblx1);
-		DataSeries.Add(_iblx2);
-		DataSeries.Add(_iblx3);
+    // ==========================
+    // Initialization of ValueDataSeries
+    // ==========================
 
-		DataSeries.Add(_ibhx32);
-		DataSeries.Add(_ibhx21);
-		DataSeries.Add(_ibhx1h);
-		DataSeries.Add(_ibHm);
-		DataSeries.Add(_ibMl);
-		DataSeries.Add(_ibl1);
-		DataSeries.Add(_iblx12);
-		DataSeries.Add(_iblx23);
+    _mid = CreateValueSeries("Mid", CrossColor.FromArgb(0, 0, 255, 0), LineDashStyle.Solid);
+    _ibh = CreateValueSeries("IBH", DefaultColors.Blue.Convert());
+    _ibl = CreateValueSeries("IBL", DefaultColors.Red.Convert());
+    _ibm = CreateValueSeries("IBM", DefaultColors.Green.Convert());
+    _ibhx1 = CreateValueSeries("IBHX1", DefaultColors.Fuchsia.Convert());
+    _ibhx2 = CreateValueSeries("IBHX2", DefaultColors.Fuchsia.Convert());
+    _ibhx3 = CreateValueSeries("IBHX3", DefaultColors.Fuchsia.Convert());
+    _iblx1 = CreateValueSeries("IBLX1", DefaultColors.Purple.Convert());
+    _iblx2 = CreateValueSeries("IBLX2", DefaultColors.Purple.Convert());
+    _iblx3 = CreateValueSeries("IBLX3", DefaultColors.Purple.Convert());
 
-		_ibh.PropertyChanged += DataSeriesPropertyChanged;
-		_ibl.PropertyChanged += DataSeriesPropertyChanged;
-		_ibm.PropertyChanged += DataSeriesPropertyChanged;
-		_ibhx1.PropertyChanged += DataSeriesPropertyChanged;
-		_ibhx2.PropertyChanged += DataSeriesPropertyChanged;
-		_ibhx3.PropertyChanged += DataSeriesPropertyChanged;
-		_iblx1.PropertyChanged += DataSeriesPropertyChanged;
-		_iblx2.PropertyChanged += DataSeriesPropertyChanged;
-		_iblx3.PropertyChanged += DataSeriesPropertyChanged;
-	}
+    // Add ValueDataSeries to the indicator's DataSeries collection
+    DataSeries[0] = _mid;
+    DataSeries.AddRange(new[]
+    {
+        _ibh, _ibl, _ibm,
+        _ibhx1, _ibhx2, _ibhx3,
+        _iblx1, _iblx2, _iblx3
+    });
 
-	#endregion
+    // ==========================
+    // Initialization of RangeDataSeries
+    // ==========================
+
+    _ibhx32 = CreateRangeSeries("IBHX32");
+    _ibhx21 = CreateRangeSeries("IBHX21");
+    _ibhx1h = CreateRangeSeries("IBHX1H");
+    _ibHm = CreateRangeSeries("IBHM");
+    _ibMl = CreateRangeSeries("IBML");
+    _ibl1 = CreateRangeSeries("IBL1");
+    _iblx12 = CreateRangeSeries("IBLX12");
+    _iblx23 = CreateRangeSeries("IBLX23");
+
+    // Add RangeDataSeries to the indicator's DataSeries collection
+    DataSeries.AddRange(new[]
+    {
+        _ibhx32, _ibhx21, _ibhx1h,
+        _ibHm, _ibMl, _ibl1,
+        _iblx12, _iblx23
+    });
+
+    // ==========================
+    // Subscribe to property changes
+    // ==========================
+
+    foreach (var series in new[]
+    {
+        _ibh, _ibl, _ibm,
+        _ibhx1, _ibhx2, _ibhx3,
+        _iblx1, _iblx2, _iblx3
+    })
+    {
+        _originalColors[series] = series.Color;
+        series.PropertyChanged += DataSeriesPropertyChanged;
+    }
+}
+
+#endregion
+
 
 	#region Protected methods
 
-	protected override void OnCalculate(int bar, decimal value)
-	{
-		if (bar == 0)
-		{
-			DataSeries.ForEach(x => x.Clear());
-			ibhx1 = decimal.Zero;
-			ibhx2 = decimal.Zero;
-			ibhx3 = decimal.Zero;
-			iblx1 = decimal.Zero;
-			iblx2 = decimal.Zero;
-			iblx3 = decimal.Zero;
-			mid = decimal.Zero;
-			_maxValue = decimal.MinValue;
-			_minValue = decimal.MaxValue;
-			_ibMax = decimal.MinValue;
-			_ibMin = decimal.MaxValue;
-			_ibmValue = decimal.Zero;
-			_highLowIsSet = false;
-			_lastStartBar = -1;
-			_endTime = DateTime.MaxValue;
-			_calculate = false;
-			_initialized = false;
-			_targetBar = 0;
-			_isStarted = false;
-
-            if (_days <= 0)
-				return;
-
-			var days = 0;
-
-			for (var i = CurrentBar - 1; i >= 0; i--)
-			{
-				_targetBar = i;
-
-				if (!IsNewSession(i))
-					continue;
-
-				days++;
-
-				if (days == _days)
-					break;
-			}
-		}
-
-		if (bar < _targetBar)
-			return;
-
-		_initialized = true;
-		var candle = GetCandle(bar);
-
-		var time = candle.Time.AddHours(InstrumentInfo.TimeZone).TimeOfDay;
-		var lastTime = candle.LastTime.AddHours(InstrumentInfo.TimeZone).TimeOfDay;
-		
-        if (CustomSessionStart)
-		{
-			bool inSession;
-
-            if (StartDate < EndDate)
-				inSession = (time >= StartDate || lastTime >= StartDate) && time < EndDate;
-			else if (StartDate > EndDate)
-			{
-				inSession = ((time >= StartDate || lastTime >= StartDate) && time > EndDate)
-						 || ((time <= EndDate || lastTime <= EndDate) && time < EndDate);
-            }
-			else
-				inSession = true;
-
-            if (!inSession)
-			{
-				_isStarted = false;
-
-                foreach (var dataSeries in DataSeries)
-					if (dataSeries is ValueDataSeries series)
-						series.SetPointOfEndLine(bar - 1);
-                return;
-			}
-		}
-
-        var candleFullDateTime = candle.Time.AddHours(InstrumentInfo.TimeZone);
-		var isStart = false;
-		var isEnd = false;
-
-        if (!_isStarted)
-		{
-			isStart = _customSessionStart
-				   ? bar != 0 && (time >= StartDate || lastTime >= StartDate) && (GetPrevDateTime(bar).TimeOfDay < StartDate || GetPrevDateTime(bar).Date < candleFullDateTime.Date)
-				   : IsNewSession(bar);
-        }
-
-        if (_isStarted)
-		{
-			isEnd = (PeriodMode is PeriodType.Minutes && candleFullDateTime >= _endTime && GetPrevDateTime(bar) < _endTime)
-				 || (PeriodMode is PeriodType.Bars && bar - _lastStartBar >= Period);
-        }           
-
-		if (isStart)
-		{
-			//Clear all values
-			_maxValue = decimal.MinValue;
-			_minValue = decimal.MaxValue;
-			_ibMax = decimal.MinValue;
-			_ibMin = decimal.MaxValue;
-			_ibmValue = decimal.Zero;
-			ibhx1 = decimal.Zero;
-			ibhx2 = decimal.Zero;
-			ibhx3 = decimal.Zero;
-			iblx1 = decimal.Zero;
-			iblx2 = decimal.Zero;
-			iblx3 = decimal.Zero;
-			_calculate = true;
-			_highLowIsSet = false;
-			_lastStartBar = bar;
-			_endTime = candleFullDateTime.AddMinutes(_period);
-            _isStarted = true;
-
-            foreach (var dataSeries in DataSeries)
-                if (dataSeries is ValueDataSeries series)
-                    series.SetPointOfEndLine(bar - 1);
-
-            if (ShowOpenRange && (!_calculate || ShowDuringFormation))
-			{
-				var pen = new Pen(ConvertColor(_borderColor))
-				{
-					Width = _borderWidth
-				};
-				var brush = new SolidBrush(ConvertColor(_fillColor));
-
-				_rectangle = new DrawingRectangle(bar, decimal.Zero, bar, decimal.Zero, pen, brush);
-
-				if (Rectangles.LastOrDefault()?.FirstBar == bar)
-					Rectangles.RemoveAt(Rectangles.Count - 1);
-
-				Rectangles.Add(_rectangle);
-			}
-		}
-		else if (isEnd)
-		{
-			_calculate = _isStarted = false;
-        }
-
-		if (_calculate)
-		{
-			if (candle.High > _maxValue)
-			{
-				_highLowIsSet = true;
-				_ibMax = _maxValue = candle.High;
-			}
-
-			if (candle.Low < _minValue)
-			{
-				_highLowIsSet = true;
-				_ibMin = _minValue = candle.Low;
-			}
-
-			if (ShowOpenRange)
-			{
-				_rectangle.SecondBar = bar;
-				_rectangle.FirstPrice = _ibMax;
-				_rectangle.SecondPrice = _ibMin;
-			}
-		}
-
-		if (candle.High > _maxValue)
-			_maxValue = candle.High;
-
-		if (candle.Low < _minValue)
-			_minValue = candle.Low;
-
-		if (!_highLowIsSet)
-			return;
-
-   		if (!_calculate || ShowDuringFormation)
-		{
-
-			_mid[bar] = mid = (_minValue + _maxValue) / 2m;
-			_ibh[bar] = _ibMax;
-			_ibl[bar] = _ibMin;
-			_ibmValue = _ibm[bar] = (_ibMin + _ibMax) / 2m;
-			var diff = _ibMax - _ibMin;
-
-			ibhx1 = _ibhx1[bar] = _ibMax + diff * _x1;
-			ibhx2 = _ibhx2[bar] = _ibMax + diff * _x2;
-			ibhx3 = _ibhx3[bar] = _ibMax + diff * _x3;
-			iblx1 = _iblx1[bar] = _ibMin - diff * _x1;
-			iblx2 = _iblx2[bar] = _ibMin - diff * _x2;
-			iblx3 = _iblx3[bar] = _ibMin - diff * _x3;
-
-			_ibhx32[bar].Upper = ibhx3;
-			_ibhx32[bar].Lower = _ibhx21[bar].Upper = ibhx2;
-			_ibhx21[bar].Lower = _ibhx1h[bar].Upper = ibhx1;
-			_ibhx1h[bar].Lower = _ibHm[bar].Upper = _ibh[bar];
-			_ibHm[bar].Lower = _ibMl[bar].Upper = _ibm[bar];
-			_ibMl[bar].Lower = _ibl1[bar].Upper = _ibl[bar];
-			_ibl1[bar].Lower = _iblx12[bar].Upper = iblx1;
-			_iblx12[bar].Lower = _iblx23[bar].Upper = iblx2;
-			_iblx23[bar].Lower = iblx3;
-
-        		if (DrawText)
-			{
-				AddText(_lastStartBar + "Mid", "Mid", true, bar, mid, 0, 0, ConvertColor(_mid.Color), System.Drawing.Color.Transparent,
-					System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
-
-				AddText(_lastStartBar + "IBH", "IBH", true, bar, _ibMax, 0, 0, ConvertColor(_ibh.Color), System.Drawing.Color.Transparent,
-					System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
-
-				AddText(_lastStartBar + "IBL", "IBL", true, bar, _ibMin, 0, 0, ConvertColor(_ibl.Color), System.Drawing.Color.Transparent,
-					System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
-
-				AddText(_lastStartBar + "IBM", "IBM", true, bar, _ibmValue, 0, 0, ConvertColor(_ibm.Color), System.Drawing.Color.Transparent,
-					System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
-
-				AddText(_lastStartBar + "IBHX1", "IBHX1", true, bar, ibhx1, 0, 0, ConvertColor(_ibhx1.Color), System.Drawing.Color.Transparent,
-					System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
-
-				AddText(_lastStartBar + "IBHX2", "IBHX2", true, bar, ibhx2, 0, 0, ConvertColor(_ibhx2.Color), System.Drawing.Color.Transparent,
-					System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
-
-				AddText(_lastStartBar + "IBHX3", "IBHX3", true, bar, ibhx3, 0, 0, ConvertColor(_ibhx3.Color), System.Drawing.Color.Transparent,
-					System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
-
-				AddText(_lastStartBar + "IBLX1", "IBLX1", true, bar, iblx1, 0, 0, ConvertColor(_iblx1.Color), System.Drawing.Color.Transparent,
-					System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
-
-				AddText(_lastStartBar + "IBLX2", "IBLX2", true, bar, iblx2, 0, 0, ConvertColor(_iblx2.Color), System.Drawing.Color.Transparent,
-					System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
-
-				AddText(_lastStartBar + "IBLX3", "IBLX3", true, bar, iblx3, 0, 0, ConvertColor(_iblx3.Color), System.Drawing.Color.Transparent,
-					System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
-			}
-  		}
-	}
-
-    protected override void OnRender(GraphicsContext context, object[] parameters)
-	{
-	base.OnRender(context, parameters);
-
-	if (!ExtendLastLineToRight || !_isStarted || _calculate)
-		return;
-
-	if (!ChartInfo.BarsCoordinates.TryGetValue(_lastStartBar, out var startCoord))
-		return;
-
-	var x1 = startCoord.X;
-	var x2 = (int)context.ClipBounds.Right;
-
-	// Lista de niveles a extender: (color, dashStyle, grosor, valorY)
-	var levels = new[]
-	{
-		(_ibh.Color, _ibh.LineDashStyle, _ibh.Width, _ibMax),
-		(_ibl.Color, _ibl.LineDashStyle, _ibl.Width, _ibMin),
-		(_ibm.Color, _ibm.LineDashStyle, _ibm.Width, _ibmValue),
-		(_mid.Color, _mid.LineDashStyle, _mid.Width, mid),
-		(_ibhx1.Color, _ibhx1.LineDashStyle, _ibhx1.Width, ibhx1),
-		(_ibhx2.Color, _ibhx2.LineDashStyle, _ibhx2.Width, ibhx2),
-		(_ibhx3.Color, _ibhx3.LineDashStyle, _ibhx3.Width, ibhx3),
-		(_iblx1.Color, _iblx1.LineDashStyle, _iblx1.Width, iblx1),
-		(_iblx2.Color, _iblx2.LineDashStyle, _iblx2.Width, iblx2),
-		(_iblx3.Color, _iblx3.LineDashStyle, _iblx3.Width, iblx3),
-	};
-
-	foreach (var (color, dash, width, price) in levels)
-	{
-		var y = context.BarsY(price);
-
-		var pen = new Pen(ConvertColor(color), width)
-		{
-			DashStyle = ConvertDashStyle(dash)
-		};
-
-		context.DrawLine(pen, x1, y, x2, y);
-	}
-
-	// Crear fuente con tamaño configurable
-	var _font = new Font("Arial", FontSize, FontStyle.Regular);
-
-	// Lista de textos y niveles
-	var labels = new[]
-	{
-	("IBH", _ibh.Color, _ibMax),
-	("IBL", _ibl.Color, _ibMin),
-	("IBM", _ibm.Color, _ibmValue),
-	("MID", _mid.Color, mid),
-	("IBHX1", _ibhx1.Color, ibhx1),
-	("IBHX2", _ibhx2.Color, ibhx2),
-	("IBHX3", _ibhx3.Color, ibhx3),
-	("IBLX1", _iblx1.Color, iblx1),
-	("IBLX2", _iblx2.Color, iblx2),
-	("IBLX3", _iblx3.Color, iblx3)
-	};
-
-	// Offset en píxeles para que el texto no se solape con la línea
-	const int offset = 2;
-
-	foreach (var (label, color, price) in labels)
-	{
-		var y = context.BarsY(price);
-		var brush = new SolidBrush(ConvertColor(color));
-
-		var stringSize = context.MeasureString(label, _font);
-		context.DrawString(label, _font, brush,
-			x2 - stringSize.Width - 2, // alineado a la derecha con pequeño margen
-			y - stringSize.Height - offset); // justo encima de la línea
-	}	
-	}
-    
-    private DateTime GetPrevDateTime(int bar)
+protected override void OnCalculate(int bar, decimal value)
+{
+    if (bar == 0)
     {
-		return GetCandle(bar - 1).Time.AddHours(InstrumentInfo.TimeZone);
+        // Initializes all variables to start fresh from the first bar.
+        ResetState();
+
+        // Sets the first bar to start calculations based on the 'Days' parameter.
+        InitializeTargetBar();
     }
+
+    // Ignores bars prior to the target point and retrieves the current local candle time.
+    if (bar < _targetBar)
+        return;
+
+    _initialized = true;
+
+    // Retrieves the current candle and its local time.
+    var candle = GetLocalCandle(bar, out var time, out var lastTime);
+
+    // Manages custom session logic, identifying when sessions start and end.
+    var candleDateTime = candle.Time.AddHours(InstrumentInfo.TimeZone);
+    UpdateCustomSession(candleDateTime, bar);
+
+    // Checks if a new calculation should start.
+    var isStart = ShouldStartNewCalculation(bar, time, lastTime, candleDateTime);
+
+    // Checks if the current calculation should end.
+    var isEnd = ShouldEndCurrentCalculation(bar, candleDateTime);
+
+    // Handles the appropriate logic depending on the session state.
+    if (isStart)
+    {
+        BeginCalculationWindow(bar, candleDateTime);
+    }
+    else if (isEnd)
+    {
+        EndCalculationWindow(bar);
+    }
+
+    if (_calculate)
+    {
+        // Updates the high and low for the Initial Balance.
+        UpdateIbHighLow(candle);
+
+        // Updates the Initial Balance rectangle coordinates.
+        UpdateRectangleDuringCalculation(bar);
+
+        // Updates visibility of the value lines.
+        UpdateSeriesVisibility();
+
+        // Redraws the Initial Balance area in real time if ShowDuringFormation is active.
+        if (ShowOpenRange && ShowDuringFormation)
+            RedrawChart();
+    }
+
+    // Updates the session high and low (not just the IB window).
+    UpdateSessionHighLow(candle);
+
+    if (!_highLowIsSet)
+        return;
+
+    // Calculates and stores the Initial Balance levels.
+    CalculateIbLevels(bar);
+
+    // Fills in the Value Areas between levels.
+    FillValueAreas(bar);
+}
+
+protected override void OnRender(RenderContext context, DrawingLayouts layout)
+{
+    if (_lastStartBar < 0 || !_initialized)
+        return;
+
+    // Do not render anything during formation if ShowDuringFormation is disabled.
+    if (_calculate && !ShowDuringFormation)
+        return;
+
+    // Define the initial point: either the last completed calculation or the most recent bar.
+    var startBar = _lastEndBar > 0 ? _lastEndBar : CurrentBar - 1;
+
+    // Define the endpoint: either the right edge of the chart or the latest candle.
+    var x1 = ChartInfo.GetXByBar(startBar, false);
+    var x2 = ExtendLastLineToRight && !_calculate
+        ? context.ClipBounds.Right
+        : ChartInfo.GetXByBar(CurrentBar - 1, false);
+
+    // If for any reason x2 is invalid (e.g., overlaps or precedes x1), abort rendering.
+    if (!_calculate && (x1 < 0 || x2 <= x1))
+        return;
+
+    // Draws Initial Balance horizontal level lines.
+    DrawIBLines(context, ChartInfo.GetXByBar(CurrentBar - 1, false), x2);
+
+    // Optionally draw level labels at the end of the lines.
+    if (DrawText)
+    {
+        DrawIBLabels(context, x2);
+    }
+
+    // Optionally draw the Initial Balance rectangle if it's enabled.
+    if (ShowOpenRange)
+    {
+        var barToDraw = _lastEndBar > 0 ? _lastEndBar : (_calculate && ShowDuringFormation ? CurrentBar : -1);
+
+        if (barToDraw >= 0)
+            DrawOpenRangeRectangle(barToDraw);
+    }
+}
+
+#endregion
+
+#region Private methods
+
+private DateTime GetPrevDateTime(int bar)
+{
+    return GetCandle(bar - 1).Time.AddHours(InstrumentInfo.TimeZone);
+}
 
 private System.Drawing.Drawing2D.DashStyle ConvertDashStyle(LineDashStyle style)
 {
-	return style switch
-	{
-		LineDashStyle.Solid => System.Drawing.Drawing2D.DashStyle.Solid,
-		LineDashStyle.Dash => System.Drawing.Drawing2D.DashStyle.Dash,
-		LineDashStyle.Dot => System.Drawing.Drawing2D.DashStyle.Dot,
-		LineDashStyle.DashDot => System.Drawing.Drawing2D.DashStyle.DashDot,
-		LineDashStyle.DashDotDot => System.Drawing.Drawing2D.DashStyle.DashDotDot,
-		_ => System.Drawing.Drawing2D.DashStyle.Solid
-	};
+    return style switch
+    {
+        LineDashStyle.Solid => DashStyle.Solid,
+        LineDashStyle.Dash => DashStyle.Dash,
+        LineDashStyle.Dot => DashStyle.Dot,
+        LineDashStyle.DashDot => DashStyle.DashDot,
+        LineDashStyle.DashDotDot => DashStyle.DashDotDot,
+        _ => DashStyle.Solid
+    };
 }
-    #endregion
 
-    #region Private methods
+private void DataSeriesPropertyChanged(object sender, PropertyChangedEventArgs e)
+{
+    if (!_initialized)
+        return;
 
-    private void DataSeriesPropertyChanged(object sender, PropertyChangedEventArgs e)
-	{
-		if (!_initialized)
-			return;
+    // If the user changes the color of a line from the UI, save it as the original color.
+    if (sender is ValueDataSeries series && e.PropertyName == nameof(ValueDataSeries.Color))
+    {
+        _originalColors[series] = series.Color;
+    }
 
-		RecalculateValues();
-	}
+    RecalculateValues();
+}
 
-	private System.Drawing.Color ConvertColor(CrossColor color)
-	{
-		return System.Drawing.Color.FromArgb(color.A, color.R, color.G, color.B);
-	}
+private System.Drawing.Color ConvertColor(CrossColor color)
+{
+    return System.Drawing.Color.FromArgb(color.A, color.R, color.G, color.B);
+}
+	
+/// <summary>
+/// Displays a message on the chart, typically used for debugging or information.
+/// </summary>
+private void DrawMessage(RenderContext context, string message)
+{
+    var font = new RenderFont("Arial", 12);
+    var textSize = context.MeasureString(message, font);
 
-	#endregion
+    // Fixed position at bottom left corner
+    var x = 10;
+    var y = (int)context.ClipBounds.Bottom - (int)textSize.Height - 10;
+
+    // Black background with margin
+    var backgroundRect = new Rectangle(x - 5, y - 2, (int)textSize.Width + 10, (int)textSize.Height + 4);
+    context.FillRectangle(System.Drawing.Color.Black, backgroundRect);
+
+    // Red text
+    context.DrawString(message, font, System.Drawing.Color.Red, x, y);
+}
+
+/// <summary>
+/// Creates and returns a new ValueDataSeries with default visual settings.
+/// </summary>
+private static ValueDataSeries CreateValueSeries(string name, CrossColor color, LineDashStyle dash = LineDashStyle.Dash)
+{
+    return new ValueDataSeries(name)
+    {
+        Color = color,
+        LineDashStyle = dash,
+        VisualType = VisualMode.Square,
+        Width = 1
+    };
+}
+
+/// <summary>
+/// Creates and returns a new RangeDataSeries with default settings.
+/// </summary>
+private static RangeDataSeries CreateRangeSeries(string name)
+{
+    return new RangeDataSeries(name)
+    {
+        IsHidden = true,
+        DrawAbovePrice = false,
+        RangeColor = System.Drawing.Color.Transparent.Convert()
+    };
+}
+
+/// <summary>
+/// Resets the high/low level tracking variables to their default values.
+/// </summary>
+private void ResetLevels()
+{
+    _maxValue = decimal.MinValue;
+    _minValue = decimal.MaxValue;
+    _ibMax = decimal.MinValue;
+    _ibMin = decimal.MaxValue;
+    _ibmValue = mid = ibhx1 = ibhx2 = ibhx3 = iblx1 = iblx2 = iblx3 = decimal.Zero;
+}
+
+/// <summary>
+/// Clears all internal state, data series, and session tracking variables.
+/// </summary>
+private void ResetState()
+{
+    _sessions.Clear();
+    _currentSession = null;
+    DataSeries.ForEach(x => x.Clear());
+    ResetLevels();
+    _highLowIsSet = false;
+    _calculate = false;
+    _isStarted = false;
+    _initialized = false;
+    _lastStartBar = -1;
+    _lastEndBar = -1;
+    _targetBar = 0;
+    _endTime = DateTime.MaxValue;
+}
+
+/// <summary>
+/// Identifies the oldest bar to be considered based on the 'Days' parameter.
+/// </summary>
+private void InitializeTargetBar()
+{
+    if (_days <= 0)
+        return;
+
+    int daysCounted = 0;
+
+    for (int i = CurrentBar - 1; i >= 0; i--)
+    {
+        _targetBar = i;
+
+        if (!IsNewSession(i))
+            continue;
+
+        daysCounted++;
+        if (daysCounted == _days)
+            break;
+    }
+}
+
+/// <summary>
+/// Tracks custom sessions by checking start/end time of each candle.
+/// </summary>
+private void UpdateCustomSession(DateTime dateTime, int bar)
+{
+    if (!CustomSessionStart)
+        return;
+
+    var sessionStart = dateTime.Date + StartDate;
+    var sessionEnd = dateTime.Date + EndDate;
+
+    if (EndDate < StartDate)
+        sessionEnd = sessionEnd.AddDays(1);
+
+    if (_currentSession == null || dateTime >= _currentSession.EndTime)
+    {
+        if (dateTime >= sessionStart && dateTime < sessionEnd)
+        {
+            _currentSession = new Session
+            {
+                StartBar = bar,
+                StartTime = sessionStart,
+                EndTime = sessionEnd,
+                EndBar = -1,
+                IsCalculationComplete = false
+            };
+
+            _sessions.Add(_currentSession);
+        }
+    }
+    else if (dateTime < _currentSession.StartTime)
+    {
+        _currentSession = null;
+    }
+
+    if (_currentSession != null && dateTime >= _currentSession.EndTime && _currentSession.EndBar == -1)
+    {
+        _currentSession.EndBar = bar;
+    }
+}
+
+/// <summary>
+/// Returns the candle at given bar with local timestamp information.
+/// </summary>
+private IndicatorCandle GetLocalCandle(int bar, out TimeSpan time, out TimeSpan lastTime)
+{
+    var candle = GetCandle(bar);
+    var localTime = candle.Time.AddHours(InstrumentInfo.TimeZone);
+    var localLastTime = candle.LastTime.AddHours(InstrumentInfo.TimeZone);
+    time = localTime.TimeOfDay;
+    lastTime = localLastTime.TimeOfDay;
+    return candle;
+}
+
+/// <summary>
+/// Determines if a new calculation window should be started.
+/// </summary>
+private bool ShouldStartNewCalculation(int bar, TimeSpan time, TimeSpan lastTime, DateTime currentDateTime)
+{
+    if (_isStarted)
+        return false;
+
+    if (CustomSessionStart)
+    {
+        var prevDateTime = GetPrevDateTime(bar);
+        return bar != 0
+            && (time >= StartDate || lastTime >= StartDate)
+            && (prevDateTime.TimeOfDay < StartDate || prevDateTime.Date < currentDateTime.Date);
+    }
+
+    return IsNewSession(bar);
+}
+
+/// <summary>
+/// Determines if the calculation window should be closed.
+/// </summary>
+private bool ShouldEndCurrentCalculation(int bar, DateTime currentDateTime)
+{
+    if (!_isStarted)
+        return false;
+
+    return (PeriodMode == PeriodType.Minutes && currentDateTime >= _endTime && GetPrevDateTime(bar) < _endTime)
+        || (PeriodMode == PeriodType.Bars && bar - _lastStartBar >= Period);
+}
+
+/// <summary>
+/// Initializes a new calculation window, resets high/low tracking and ends previous lines.
+/// </summary>
+private void BeginCalculationWindow(int bar, DateTime candleTime)
+{
+    _calculate = true;
+    _highLowIsSet = false;
+    _lastStartBar = bar;
+    _endTime = candleTime.AddMinutes(_period);
+    _isStarted = true;
+
+    ResetLevels();
+    EndPreviousValueLines(bar);
+
+    if (ShowOpenRange && ShowDuringFormation)
+        DrawOpenRangeRectangle(bar);
+}
+
+/// <summary>
+/// Finalizes the calculation window and forces chart redraw.
+/// </summary>
+private void EndCalculationWindow(int bar)
+{
+    _calculate = false;
+    _isStarted = false;
+    _lastEndBar = bar;
+    UpdateSeriesVisibility();
+    RedrawChart();
+}
+
+/// <summary>
+/// Ends all lines from the previous session visually at a specific bar.
+/// </summary>
+private void EndPreviousValueLines(int bar)
+{
+    foreach (var series in DataSeries.OfType<ValueDataSeries>())
+        series.SetPointOfEndLine(bar - 1);
+}
+
+/// <summary>
+/// Updates the highest and lowest values during the Initial Balance window.
+/// </summary>
+private void UpdateIbHighLow(IndicatorCandle candle)
+{
+    if (candle.High > _maxValue)
+    {
+        _highLowIsSet = true;
+        _ibMax = _maxValue = candle.High;
+    }
+
+    if (candle.Low < _minValue)
+    {
+        _highLowIsSet = true;
+        _ibMin = _minValue = candle.Low;
+    }
+}
+
+/// <summary>
+/// Dynamically adjusts the rectangle's coordinates based on the current candle.
+/// </summary>
+private void UpdateRectangleDuringCalculation(int bar)
+{
+    if (!_calculate)
+        return;
+
+    _rectangle.SecondBar = bar;
+    _rectangle.FirstPrice = _ibMax;
+    _rectangle.SecondPrice = _ibMin;
+}
+
+/// <summary>
+/// Updates the session's high and low values.
+/// </summary>
+private void UpdateSessionHighLow(IndicatorCandle candle)
+{
+    if (candle.High > _maxValue)
+        _maxValue = candle.High;
+
+    if (candle.Low < _minValue)
+        _minValue = candle.Low;
+}
+
+/// <summary>
+/// Dynamically updates the coordinates of the opening range rectangle during the calculation period.
+/// It runs whenever the calculation is active, regardless of whether the user has enabled its visualization.
+/// </summary>
+/// <param name="bar">Current calculation bar.</param>
+private void UpdateRectangleDuringCalculation(int bar)
+{
+    if (!_calculate)
+        return;
+
+    _rectangle.SecondBar = bar;
+    _rectangle.FirstPrice = _ibMax;
+    _rectangle.SecondPrice = _ibMin;
+}
+
+// Updates the session high and low
+private void UpdateSessionHighLow(IndicatorCandle candle)
+{
+    if (candle.High > _maxValue)
+        _maxValue = candle.High;
+
+    if (candle.Low < _minValue)
+        _minValue = candle.Low;
+}
+
+// Calculates the initial balance levels
+private void CalculateIbLevels(int bar)
+{
+    _mid[bar] = mid = (_minValue + _maxValue) / 2m;
+    _ibh[bar] = _ibMax;
+    _ibl[bar] = _ibMin;
+    _ibmValue = _ibm[bar] = (_ibMin + _ibMax) / 2m;
+
+    var diff = _ibMax - _ibMin;
+    ibhx1 = _ibhx1[bar] = _ibMax + diff * _x1;
+    ibhx2 = _ibhx2[bar] = _ibMax + diff * _x2;
+    ibhx3 = _ibhx3[bar] = _ibMax + diff * _x3;
+    iblx1 = _iblx1[bar] = _ibMin - diff * _x1;
+    iblx2 = _iblx2[bar] = _ibMin - diff * _x2;
+    iblx3 = _iblx3[bar] = _ibMin - diff * _x3;
+}
+
+// Fills the value areas
+private void FillValueAreas(int bar)
+{
+    _ibhx32[bar].Upper = ibhx3;
+    _ibhx32[bar].Lower = _ibhx21[bar].Upper = ibhx2;
+    _ibhx21[bar].Lower = _ibhx1h[bar].Upper = ibhx1;
+    _ibhx1h[bar].Lower = _ibHm[bar].Upper = _ibh[bar];
+    _ibHm[bar].Lower = _ibMl[bar].Upper = _ibm[bar];
+    _ibMl[bar].Lower = _ibl1[bar].Upper = _ibl[bar];
+    _ibl1[bar].Lower = _iblx12[bar].Upper = iblx1;
+    _iblx12[bar].Lower = _iblx23[bar].Upper = iblx2;
+    _iblx23[bar].Lower = iblx3;
+}
+
+// Draws the Initial Balance lines
+private void DrawIBLines(RenderContext context, int x1, int x2)
+{
+    var levels = new[]
+    {
+        ("IBH", _ibh.Color, _ibh.LineDashStyle, _ibh.Width, _ibMax),
+        ("IBL", _ibl.Color, _ibl.LineDashStyle, _ibl.Width, _ibMin),
+        ("IBM", _ibm.Color, _ibm.LineDashStyle, _ibm.Width, _ibmValue),
+        ("MID", _mid.Color, _mid.LineDashStyle, _mid.Width, mid),
+        ("IBHX1", _ibhx1.Color, _ibhx1.LineDashStyle, _ibhx1.Width, ibhx1),
+        ("IBHX2", _ibhx2.Color, _ibhx2.LineDashStyle, _ibhx2.Width, ibhx2),
+        ("IBHX3", _ibhx3.Color, _ibhx3.LineDashStyle, _ibhx3.Width, ibhx3),
+        ("IBLX1", _iblx1.Color, _iblx1.LineDashStyle, _iblx1.Width, iblx1),
+        ("IBLX2", _iblx2.Color, _iblx2.LineDashStyle, _iblx2.Width, iblx2),
+        ("IBLX3", _iblx3.Color, _iblx3.LineDashStyle, _iblx3.Width, iblx3)
+    };
+
+    const int offset = 2;
+
+    foreach (var (label, color, dash, width, price) in levels)
+    {
+        var y = (int)ChartInfo.GetYByPrice(price, false);
+        if (y < 0)
+            continue;
+
+        var pen = new RenderPen(ConvertColor(color), width, ConvertDashStyle(dash));
+        context.DrawLine(pen, x1, y, x2, y);
+    }
+}
+
+// Draws the labels for the Initial Balance lines
+private void DrawIBLabels(RenderContext context, int x2)
+{
+    const int offset = 2;
+
+    var labels = new[]
+    {
+        ("IBH", _ibh.Color, _ibMax),
+        ("IBL", _ibl.Color, _ibMin),
+        ("IBM", _ibm.Color, _ibmValue),
+        ("MID", _mid.Color, mid),
+        ("IBHX1", _ibhx1.Color, ibhx1),
+        ("IBHX2", _ibhx2.Color, ibhx2),
+        ("IBHX3", _ibhx3.Color, ibhx3),
+        ("IBLX1", _iblx1.Color, iblx1),
+        ("IBLX2", _iblx2.Color, iblx2),
+        ("IBLX3", _iblx3.Color, iblx3)
+    };
+
+    foreach (var (label, color, price) in labels)
+    {
+        var y = ChartInfo.GetYByPrice(price, false);
+        if (y < 0)
+            continue;
+
+        var size = context.MeasureString(label, _font);
+        context.DrawString(label, _font, ConvertColor(color),
+            x2 - size.Width - 2,
+            y - size.Height - offset);
+    }
+}
+
+// Draws the opening range rectangle
+private void DrawOpenRangeRectangle(int bar)
+{
+    if (!ShowOpenRange || _lastStartBar < 0)
+        return;
+
+    var pen = new Pen(ConvertColor(_borderColor)) { Width = _borderWidth };
+    var brush = new SolidBrush(ConvertColor(_fillColor));
+
+    var rect = new DrawingRectangle(
+        _lastStartBar, _ibMax,
+        bar, _ibMin,
+        pen, brush
+    );
+
+    // Remove any previous rectangle
+    Rectangles.Clear();
+
+    // Add the new rectangle
+    Rectangles.Add(rect);
+}
+
+private void UpdateSeriesVisibility()
+{
+    if (_lastStartBar < 0)
+        return;
+
+    for (var bar = _lastStartBar; bar <= CurrentBar; bar++)
+    {
+        foreach (var s in _originalColors.Keys)
+        {
+            s.Colors[bar] = ShowDuringFormation || !_calculate
+                ? ConvertColor(_originalColors[s])
+                : System.Drawing.Color.Transparent;
+        }
+    }
+}
+ 
+ #endregion
 }

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -392,6 +392,10 @@ public class InitialBalance : Indicator
 		GroupName = nameof(Strings.Drawing), Description = nameof(Strings.ExtendLastDescription), Order = 150)]
 	public bool ExtendLastLineToRight { get; set; } = true;
 
+ 	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.ShowDuringFormation),
+	GroupName = nameof(Strings.Show), Description = nameof(Strings.ShowDuringFormationDescription), Order = 160)]
+	public bool ShowDuringFormation { get; set; } = false;
+
 	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBHX32), 
 		GroupName = nameof(Strings.BackGround), Description = nameof(Strings.AreaColorDescription), Order = 200)]
 	public CrossColor Ibhx32
@@ -619,7 +623,7 @@ public class InitialBalance : Indicator
                 if (dataSeries is ValueDataSeries series)
                     series.SetPointOfEndLine(bar - 1);
 
-            if (ShowOpenRange)
+            if (ShowOpenRange && (!_calculate || ShowDuringFormation))
 			{
 				var pen = new Pen(ConvertColor(_borderColor))
 				{
@@ -671,68 +675,72 @@ public class InitialBalance : Indicator
 		if (!_highLowIsSet)
 			return;
 
-		_mid[bar] = mid = (_minValue + _maxValue) / 2m;
-		_ibh[bar] = _ibMax;
-		_ibl[bar] = _ibMin;
-		_ibmValue = _ibm[bar] = (_ibMin + _ibMax) / 2m;
-		var diff = _ibMax - _ibMin;
-
-		ibhx1 = _ibhx1[bar] = _ibMax + diff * _x1;
-		ibhx2 = _ibhx2[bar] = _ibMax + diff * _x2;
-		ibhx3 = _ibhx3[bar] = _ibMax + diff * _x3;
-		iblx1 = _iblx1[bar] = _ibMin - diff * _x1;
-		iblx2 = _iblx2[bar] = _ibMin - diff * _x2;
-		iblx3 = _iblx3[bar] = _ibMin - diff * _x3;
-
-		_ibhx32[bar].Upper = ibhx3;
-		_ibhx32[bar].Lower = _ibhx21[bar].Upper = ibhx2;
-		_ibhx21[bar].Lower = _ibhx1h[bar].Upper = ibhx1;
-		_ibhx1h[bar].Lower = _ibHm[bar].Upper = _ibh[bar];
-		_ibHm[bar].Lower = _ibMl[bar].Upper = _ibm[bar];
-		_ibMl[bar].Lower = _ibl1[bar].Upper = _ibl[bar];
-		_ibl1[bar].Lower = _iblx12[bar].Upper = iblx1;
-		_iblx12[bar].Lower = _iblx23[bar].Upper = iblx2;
-		_iblx23[bar].Lower = iblx3;
-
-        if (DrawText)
+   		if (!_calculate || ShowDuringFormation)
 		{
-			AddText(_lastStartBar + "Mid", "Mid", true, bar, mid, 0, 0, ConvertColor(_mid.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
 
-			AddText(_lastStartBar + "IBH", "IBH", true, bar, _ibMax, 0, 0, ConvertColor(_ibh.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
+			_mid[bar] = mid = (_minValue + _maxValue) / 2m;
+			_ibh[bar] = _ibMax;
+			_ibl[bar] = _ibMin;
+			_ibmValue = _ibm[bar] = (_ibMin + _ibMax) / 2m;
+			var diff = _ibMax - _ibMin;
 
-			AddText(_lastStartBar + "IBL", "IBL", true, bar, _ibMin, 0, 0, ConvertColor(_ibl.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
+			ibhx1 = _ibhx1[bar] = _ibMax + diff * _x1;
+			ibhx2 = _ibhx2[bar] = _ibMax + diff * _x2;
+			ibhx3 = _ibhx3[bar] = _ibMax + diff * _x3;
+			iblx1 = _iblx1[bar] = _ibMin - diff * _x1;
+			iblx2 = _iblx2[bar] = _ibMin - diff * _x2;
+			iblx3 = _iblx3[bar] = _ibMin - diff * _x3;
 
-			AddText(_lastStartBar + "IBM", "IBM", true, bar, _ibmValue, 0, 0, ConvertColor(_ibm.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
+			_ibhx32[bar].Upper = ibhx3;
+			_ibhx32[bar].Lower = _ibhx21[bar].Upper = ibhx2;
+			_ibhx21[bar].Lower = _ibhx1h[bar].Upper = ibhx1;
+			_ibhx1h[bar].Lower = _ibHm[bar].Upper = _ibh[bar];
+			_ibHm[bar].Lower = _ibMl[bar].Upper = _ibm[bar];
+			_ibMl[bar].Lower = _ibl1[bar].Upper = _ibl[bar];
+			_ibl1[bar].Lower = _iblx12[bar].Upper = iblx1;
+			_iblx12[bar].Lower = _iblx23[bar].Upper = iblx2;
+			_iblx23[bar].Lower = iblx3;
 
-			AddText(_lastStartBar + "IBHX1", "IBHX1", true, bar, ibhx1, 0, 0, ConvertColor(_ibhx1.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
+        		if (DrawText)
+			{
+				AddText(_lastStartBar + "Mid", "Mid", true, bar, mid, 0, 0, ConvertColor(_mid.Color), System.Drawing.Color.Transparent,
+					System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
 
-			AddText(_lastStartBar + "IBHX2", "IBHX2", true, bar, ibhx2, 0, 0, ConvertColor(_ibhx2.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
+				AddText(_lastStartBar + "IBH", "IBH", true, bar, _ibMax, 0, 0, ConvertColor(_ibh.Color), System.Drawing.Color.Transparent,
+					System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
 
-			AddText(_lastStartBar + "IBHX3", "IBHX3", true, bar, ibhx3, 0, 0, ConvertColor(_ibhx3.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
+				AddText(_lastStartBar + "IBL", "IBL", true, bar, _ibMin, 0, 0, ConvertColor(_ibl.Color), System.Drawing.Color.Transparent,
+					System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
 
-			AddText(_lastStartBar + "IBLX1", "IBLX1", true, bar, iblx1, 0, 0, ConvertColor(_iblx1.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
+				AddText(_lastStartBar + "IBM", "IBM", true, bar, _ibmValue, 0, 0, ConvertColor(_ibm.Color), System.Drawing.Color.Transparent,
+					System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
 
-			AddText(_lastStartBar + "IBLX2", "IBLX2", true, bar, iblx2, 0, 0, ConvertColor(_iblx2.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
+				AddText(_lastStartBar + "IBHX1", "IBHX1", true, bar, ibhx1, 0, 0, ConvertColor(_ibhx1.Color), System.Drawing.Color.Transparent,
+					System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
 
-			AddText(_lastStartBar + "IBLX3", "IBLX3", true, bar, iblx3, 0, 0, ConvertColor(_iblx3.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
-		}
+				AddText(_lastStartBar + "IBHX2", "IBHX2", true, bar, ibhx2, 0, 0, ConvertColor(_ibhx2.Color), System.Drawing.Color.Transparent,
+					System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
+
+				AddText(_lastStartBar + "IBHX3", "IBHX3", true, bar, ibhx3, 0, 0, ConvertColor(_ibhx3.Color), System.Drawing.Color.Transparent,
+					System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
+
+				AddText(_lastStartBar + "IBLX1", "IBLX1", true, bar, iblx1, 0, 0, ConvertColor(_iblx1.Color), System.Drawing.Color.Transparent,
+					System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
+
+				AddText(_lastStartBar + "IBLX2", "IBLX2", true, bar, iblx2, 0, 0, ConvertColor(_iblx2.Color), System.Drawing.Color.Transparent,
+					System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
+
+				AddText(_lastStartBar + "IBLX3", "IBLX3", true, bar, iblx3, 0, 0, ConvertColor(_iblx3.Color), System.Drawing.Color.Transparent,
+					System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
+			}
+  		}
 	}
 
     protected override void OnRender(GraphicsContext context, object[] parameters)
 	{
 	base.OnRender(context, parameters);
 
-	if (!ExtendLastLineToRight || !_isStarted)
+	if (!ExtendLastLineToRight || !_isStarted || _calculate)
 		return;
 
 	if (!ChartInfo.BarsCoordinates.TryGetValue(_lastStartBar, out var startCoord))

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -383,6 +383,15 @@ public class InitialBalance : Indicator
 		}
 	}
 
+ 	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.FontSize),
+		GroupName = nameof(Strings.Show), Description = nameof(Strings.TextSizeDescription), Order = 140)]
+		[Range(6, 48)]
+	public float FontSize { get; set; } = 12.0f;
+
+   	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.ExtendLast),
+		GroupName = nameof(Strings.Drawing), Description = nameof(Strings.ExtendLastDescription), Order = 150)]
+	public bool ExtendLastLineToRight { get; set; } = true;
+
 	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBHX32), 
 		GroupName = nameof(Strings.BackGround), Description = nameof(Strings.AreaColorDescription), Order = 200)]
 	public CrossColor Ibhx32
@@ -688,42 +697,127 @@ public class InitialBalance : Indicator
         if (DrawText)
 		{
 			AddText(_lastStartBar + "Mid", "Mid", true, bar, mid, 0, 0, ConvertColor(_mid.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
 
 			AddText(_lastStartBar + "IBH", "IBH", true, bar, _ibMax, 0, 0, ConvertColor(_ibh.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
 
 			AddText(_lastStartBar + "IBL", "IBL", true, bar, _ibMin, 0, 0, ConvertColor(_ibl.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
 
 			AddText(_lastStartBar + "IBM", "IBM", true, bar, _ibmValue, 0, 0, ConvertColor(_ibm.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
 
 			AddText(_lastStartBar + "IBHX1", "IBHX1", true, bar, ibhx1, 0, 0, ConvertColor(_ibhx1.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
 
 			AddText(_lastStartBar + "IBHX2", "IBHX2", true, bar, ibhx2, 0, 0, ConvertColor(_ibhx2.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
 
 			AddText(_lastStartBar + "IBHX3", "IBHX3", true, bar, ibhx3, 0, 0, ConvertColor(_ibhx3.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
 
 			AddText(_lastStartBar + "IBLX1", "IBLX1", true, bar, iblx1, 0, 0, ConvertColor(_iblx1.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
 
 			AddText(_lastStartBar + "IBLX2", "IBLX2", true, bar, iblx2, 0, 0, ConvertColor(_iblx2.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
 
 			AddText(_lastStartBar + "IBLX3", "IBLX3", true, bar, iblx3, 0, 0, ConvertColor(_iblx3.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent, FontSize, DrawingText.TextAlign.Right);
 		}
 	}
 
+    protected override void OnRender(GraphicsContext context, object[] parameters)
+	{
+	base.OnRender(context, parameters);
+
+	if (!ExtendLastLineToRight || !_isStarted)
+		return;
+
+	if (!ChartInfo.BarsCoordinates.TryGetValue(_lastStartBar, out var startCoord))
+		return;
+
+	var x1 = startCoord.X;
+	var x2 = (int)context.ClipBounds.Right;
+
+	// Lista de niveles a extender: (color, dashStyle, grosor, valorY)
+	var levels = new[]
+	{
+		(_ibh.Color, _ibh.LineDashStyle, _ibh.Width, _ibMax),
+		(_ibl.Color, _ibl.LineDashStyle, _ibl.Width, _ibMin),
+		(_ibm.Color, _ibm.LineDashStyle, _ibm.Width, _ibmValue),
+		(_mid.Color, _mid.LineDashStyle, _mid.Width, mid),
+		(_ibhx1.Color, _ibhx1.LineDashStyle, _ibhx1.Width, ibhx1),
+		(_ibhx2.Color, _ibhx2.LineDashStyle, _ibhx2.Width, ibhx2),
+		(_ibhx3.Color, _ibhx3.LineDashStyle, _ibhx3.Width, ibhx3),
+		(_iblx1.Color, _iblx1.LineDashStyle, _iblx1.Width, iblx1),
+		(_iblx2.Color, _iblx2.LineDashStyle, _iblx2.Width, iblx2),
+		(_iblx3.Color, _iblx3.LineDashStyle, _iblx3.Width, iblx3),
+	};
+
+	foreach (var (color, dash, width, price) in levels)
+	{
+		var y = context.BarsY(price);
+
+		var pen = new Pen(ConvertColor(color), width)
+		{
+			DashStyle = ConvertDashStyle(dash)
+		};
+
+		context.DrawLine(pen, x1, y, x2, y);
+	}
+
+	// Crear fuente con tamaño configurable
+	var _font = new Font("Arial", FontSize, FontStyle.Regular);
+
+	// Lista de textos y niveles
+	var labels = new[]
+	{
+	("IBH", _ibh.Color, _ibMax),
+	("IBL", _ibl.Color, _ibMin),
+	("IBM", _ibm.Color, _ibmValue),
+	("MID", _mid.Color, mid),
+	("IBHX1", _ibhx1.Color, ibhx1),
+	("IBHX2", _ibhx2.Color, ibhx2),
+	("IBHX3", _ibhx3.Color, ibhx3),
+	("IBLX1", _iblx1.Color, iblx1),
+	("IBLX2", _iblx2.Color, iblx2),
+	("IBLX3", _iblx3.Color, iblx3)
+	};
+
+	// Offset en píxeles para que el texto no se solape con la línea
+	const int offset = 2;
+
+	foreach (var (label, color, price) in labels)
+	{
+		var y = context.BarsY(price);
+		var brush = new SolidBrush(ConvertColor(color));
+
+		var stringSize = context.MeasureString(label, _font);
+		context.DrawString(label, _font, brush,
+			x2 - stringSize.Width - 2, // alineado a la derecha con pequeño margen
+			y - stringSize.Height - offset); // justo encima de la línea
+	}	
+	}
+    
     private DateTime GetPrevDateTime(int bar)
     {
 		return GetCandle(bar - 1).Time.AddHours(InstrumentInfo.TimeZone);
     }
 
+private System.Drawing.Drawing2D.DashStyle ConvertDashStyle(LineDashStyle style)
+{
+	return style switch
+	{
+		LineDashStyle.Solid => System.Drawing.Drawing2D.DashStyle.Solid,
+		LineDashStyle.Dash => System.Drawing.Drawing2D.DashStyle.Dash,
+		LineDashStyle.Dot => System.Drawing.Drawing2D.DashStyle.Dot,
+		LineDashStyle.DashDot => System.Drawing.Drawing2D.DashStyle.DashDot,
+		LineDashStyle.DashDotDot => System.Drawing.Drawing2D.DashStyle.DashDotDot,
+		_ => System.Drawing.Drawing2D.DashStyle.Solid
+	};
+}
     #endregion
 
     #region Private methods

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Drawing;
 using System.Linq;
+using System.Collections.Generic;
 
 using ATAS.Indicators.Drawing;
 
@@ -113,6 +114,22 @@ public class InitialBalance : Indicator
     private decimal iblx2;
     private decimal iblx3;
 
+     // ==========================
+     // IB levels structure per session
+     // ==========================
+ 
+     public class IBLevels
+ 	{
+     	public int StartBarLine;
+     	public int StartBarRectangle;
+     	public int EndBar;
+     	public decimal IBH, IBL, IBM, MID;
+     	public decimal IBHX1, IBHX2, IBHX3;
+     	public decimal IBLX1, IBLX2, IBLX3;
+ 	}
+  
+    private Dictionary<Session, IBLevels> _sessionIBValues = new();
+
     // ==========================
     // Range multipliers (IBHX / IBLX)
     // ==========================
@@ -143,6 +160,7 @@ public class InitialBalance : Indicator
 
     private readonly List<Session> _sessions = new();
     private Session _currentSession;
+    private bool _waitingForNextSession = false;
 
     #endregion
 
@@ -181,14 +199,32 @@ public bool ShowOpenRange
             // Clear rectangle from the chart
             Rectangles.Clear();
         }
-        else
-        {
-            // Redraw the rectangle if there are valid values
-            if (_lastEndBar > 0)
-                DrawOpenRangeRectangle(_lastEndBar);
-            else if (_calculate && ShowDuringFormation)
-                DrawOpenRangeRectangle(CurrentBar - 1);
-        }
+        else if (_currentSession != null)
+	{
+    		if (!_sessionIBValues.ContainsKey(_currentSession))
+    		{
+        		_sessionIBValues[_currentSession] = new IBLevels
+        		{
+            			StartBarRectangle = _lastStartBar,
+            			StartBarLine = CurrentBar - 1,
+            			IBH = _ibMax,
+            			IBL = _ibMin,
+            			IBM = _ibmValue,
+            			MID = mid,
+            			IBHX1 = ibhx1,
+            			IBHX2 = ibhx2,
+            			IBHX3 = ibhx3,
+            			IBLX1 = iblx1,
+            			IBLX2 = iblx2,
+            			IBLX3 = iblx3
+        		};
+    		}
+
+    		if (_currentSession.EndBar > 0)
+        		DrawOpenRangeRectangle(_currentSession.EndBar, _sessionIBValues[_currentSession]);
+    		else if (_calculate && ShowDuringFormation)
+        		DrawOpenRangeRectangle(CurrentBar - 1, _sessionIBValues[_currentSession]);
+	}
 
         RecalculateValues();
         RedrawChart();
@@ -406,6 +442,39 @@ public bool ShowDuringFormation
         // Update line background color
         UpdateSeriesVisibility();
         RecalculateValues();
+
+ 	if (!_showDuringFormation && _currentSession != null)
+	{
+    		foreach (var series in DataSeries.OfType<ValueDataSeries>())
+        		series.SetPointOfEndLine(_currentSession.StartBar - 1);
+
+    		// 🔥 Borra valores temporales si no ha terminado la sesión
+    		// 🔥 Deletes temporary values if the session hasn't ended
+    		if (_currentSession.EndBar <= 0)
+        		_sessionIBValues.Remove(_currentSession);
+	}
+
+	// ✅ NUEVO: guarda temporalmente niveles actuales en _sessionIBValues
+	// ✅ NEW: temporarily stores current levels in _sessionIBValues
+	if (_showDuringFormation && _currentSession != null && !_sessionIBValues.ContainsKey(_currentSession))
+	{
+    		_sessionIBValues[_currentSession] = new IBLevels
+    		{
+        		StartBarRectangle = _lastStartBar,
+        		StartBarLine = CurrentBar - 1,
+        		IBH = _ibMax,
+        		IBL = _ibMin,
+        		IBM = _ibmValue,
+        		MID = mid,
+        		IBHX1 = ibhx1,
+        		IBHX2 = ibhx2,
+        		IBHX3 = ibhx3,
+        		IBLX1 = iblx1,
+        		IBLX2 = iblx2,
+        		IBLX3 = iblx3
+    		};
+	}
+
         RedrawChart();
     }
 }
@@ -579,7 +648,27 @@ protected override void OnCalculate(int bar, decimal value)
 
     // Manages custom session logic, identifying when sessions start and end.
     var candleDateTime = candle.Time.AddHours(InstrumentInfo.TimeZone);
-    UpdateCustomSession(candleDateTime, bar);
+    if (!CustomSessionStart && _currentSession != null && _currentSession.EndBar == -1)
+	{
+    	if (candleDateTime >= _currentSession.EndTime)
+    		{
+        	_currentSession.EndBar = bar;
+        	PrepareForNextSession();
+    		}
+	}
+
+	if (CustomSessionStart)
+    		UpdateCustomSession(candleDateTime, bar);
+          
+    	// Checks if we're waiting for the next session to begin.
+    	if (_waitingForNextSession)
+    		{
+        	// Have we already entered the new session?
+        	if (_currentSession != null && bar >= _currentSession.StartBar)
+            		_waitingForNextSession = false;
+        	else
+            		return; // still waiting
+    		}
 
     // Checks if a new calculation should start.
     var isStart = ShouldStartNewCalculation(bar, time, lastTime, candleDateTime);
@@ -594,7 +683,7 @@ protected override void OnCalculate(int bar, decimal value)
     }
     else if (isEnd)
     {
-        EndCalculationWindow(bar);
+        EndCalculationWindow(_currentSession, bar);
     }
 
     if (_calculate)
@@ -628,67 +717,97 @@ protected override void OnCalculate(int bar, decimal value)
 
 protected override void OnRender(RenderContext context, DrawingLayouts layout)
 {
-    if (_lastStartBar < 0 || !_initialized)
-        return;
+        _messageLineIndex = 0; // 🔄 Reinicia el índice de línea de mensajes de depuración al inicio del renderizado
+                           // 🔄 Reset debug message line index at the start of rendering
 
-    // Do not render anything during formation if ShowDuringFormation is disabled.
-    if (_calculate && !ShowDuringFormation)
-        return;
+    	// 🚫 Si no se ha inicializado correctamente o no hay barra válida, se sale
+    	// 🚫 Exit if not properly initialized or no valid bar
+    	if (_lastStartBar < 0 || !_initialized)
+        	return;
 
-    // Define the initial point: either the last completed calculation or the most recent bar.
-    var startBar = _lastEndBar > 0 ? _lastEndBar : CurrentBar - 1;
+    	// 🔁 Recorre todas las sesiones guardadas
+    	// 🔁 Iterate through all saved sessions
+    	foreach (var session in _sessions)
+    	{
+        	// ❓ Si no hay valores de Initial Balance para esta sesión, se muestra un mensaje de error y se salta
+        	// ❓ If no Initial Balance data for this session, show error and skip
+        	if (!_sessionIBValues.TryGetValue(session, out var ib))
+        	{
+            	//DrawMessage(context, $"[X] Session sin datos: SB {session.StartBar} / EB {session.EndBar}");
+            	continue;
+        	}
 
-    // Define the endpoint: either the right edge of the chart or the latest candle.
-    var x1 = ChartInfo.GetXByBar(startBar, false);
-    var x2 = ExtendLastLineToRight && !_calculate
-        ? context.ClipBounds.Right
-        : ChartInfo.GetXByBar(CurrentBar - 1, false);
+        	// ✅ Muestra un mensaje de depuración con info de la sesión actual
+        	// ✅ Show debug message with current session info
+        	//DrawMessage(context, $"[OK] Session SB {session.StartBar} | EB {session.EndBar} | IBRect {ib.StartBarRectangle}-{ib.EndBar} | CB {CurrentBar}");
 
-    // If for any reason x2 is invalid (e.g., overlaps or precedes x1), abort rendering.
-    if (!_calculate && (x1 < 0 || x2 <= x1))
-        return;
+        	// ⚠️ Si los datos del rectángulo de apertura no son válidos, se informa con un mensaje de advertencia
+        	// ⚠️ Show warning if the Initial Balance rectangle data is invalid
+        	//if (ib.EndBar < ib.StartBarRectangle || ib.EndBar <= 0 || ib.StartBarRectangle < 0)
+            		//DrawMessage(context, $"⚠️ Rectángulo inválido: {ib.StartBarRectangle}-{ib.EndBar}");
 
-    // Draws Initial Balance horizontal level lines.
-    DrawIBLines(context, ChartInfo.GetXByBar(CurrentBar - 1, false), x2);
+        	// 📅 Calcula el rango visual de la sesión en coordenadas X de la pantalla
+        	// 📅 Compute the visible X range of the session on screen
+        	var startsession = _lastEndBar > 0 ? _lastEndBar : CurrentBar - 1;
+        	int endsession = session.EndBar > 0 ? session.EndBar : CurrentBar - 1;
+        	int xStart = ChartInfo.GetXByBar(startsession, false);
+        	int xEnd = ChartInfo.GetXByBar(endsession, false);
+        	bool sessionVisible = xEnd >= context.ClipBounds.Left && xStart <= context.ClipBounds.Right;
 
-    // Optionally draw level labels at the end of the lines.
-    if (DrawText)
-    {
-        DrawIBLabels(context, x2);
-    }
+        	// 🧩 Dibuja la sesión si no es la sesión actual
+        	// 🧩 Draw the session if it's not the current one
+        	if (session != _currentSession)
+        	{
+            		DrawIBVisuals(context, session, drawLabels: DrawText, drawLines: true);
+        	}
+        
+        	// ⏳ Si es la sesión actual, la dibuja solo si no está en cálculo o si está activada la opción de mostrar durante formación
+        	// ⏳ If it's the current session, draw only if not in calculation or if ShowDuringFormation is enabled
+        	else if ((!_calculate || ShowDuringFormation) && sessionVisible)
+        	{
+            		DrawIBVisuals(context, session, drawLabels: DrawText, drawLines: true);
+        	}
 
-    // Optionally draw the Initial Balance rectangle if it's enabled.
-    if (ShowOpenRange)
-    {
-        var barToDraw = _lastEndBar > 0 ? _lastEndBar : (_calculate && ShowDuringFormation ? CurrentBar : -1);
+        	// 🟦 Dibuja el rectángulo del rango de apertura si los valores son válidos y la opción está activada
+        	// 🟦 Draw the Open Range rectangle if values are valid and option is enabled
+        	if (ShowOpenRange && ib.EndBar > ib.StartBarRectangle && ib.EndBar <= CurrentBar)
+            		DrawOpenRangeRectangle(ib.EndBar, ib);
+    	}
 
-        if (barToDraw >= 0)
-            DrawOpenRangeRectangle(barToDraw);
-    }
+    	// ❌ Si estamos en formación y no se debe mostrar nada, se detiene aquí el renderizado
+    	// ❌ If in formation and ShowDuringFormation is disabled, skip rendering
+    	bool sessionInFormation = _calculate && _currentSession?.EndBar <= 0;
+
+    	if (sessionInFormation && !ShowDuringFormation)
+        	return;
+
 }
 
 #endregion
 
 #region Private methods
 
+// Returns the datetime of the previous candle adjusted by the instrument's time zone
 private DateTime GetPrevDateTime(int bar)
 {
     return GetCandle(bar - 1).Time.AddHours(InstrumentInfo.TimeZone);
 }
 
+// Converts platform's LineDashStyle to system drawing DashStyle
 private System.Drawing.Drawing2D.DashStyle ConvertDashStyle(LineDashStyle style)
 {
     return style switch
     {
-        LineDashStyle.Solid => DashStyle.Solid,
-        LineDashStyle.Dash => DashStyle.Dash,
-        LineDashStyle.Dot => DashStyle.Dot,
-        LineDashStyle.DashDot => DashStyle.DashDot,
-        LineDashStyle.DashDotDot => DashStyle.DashDotDot,
-        _ => DashStyle.Solid
+        LineDashStyle.Solid => System.Drawing.Drawing2D.DashStyle.Solid,
+	LineDashStyle.Dash => System.Drawing.Drawing2D.DashStyle.Dash,
+	LineDashStyle.Dot => System.Drawing.Drawing2D.DashStyle.Dot,
+	LineDashStyle.DashDot => System.Drawing.Drawing2D.DashStyle.DashDot,
+	LineDashStyle.DashDotDot => System.Drawing.Drawing2D.DashStyle.DashDotDot,
+	_ => System.Drawing.Drawing2D.DashStyle.Solid
     };
 }
 
+// Handles property changes in visual data series
 private void DataSeriesPropertyChanged(object sender, PropertyChangedEventArgs e)
 {
     if (!_initialized)
@@ -698,11 +817,22 @@ private void DataSeriesPropertyChanged(object sender, PropertyChangedEventArgs e
     if (sender is ValueDataSeries series && e.PropertyName == nameof(ValueDataSeries.Color))
     {
         _originalColors[series] = series.Color;
+
+ 	for (int bar = _lastStartBar; bar <= CurrentBar; bar++)
+	{
+       		// If in formation and ShowDuringFormation is active, apply the color
+    		if (_calculate && ShowDuringFormation)
+        		series.Colors[bar] = ConvertColor(series.Color);
+    		else
+        		series.Colors[bar] = System.Drawing.Color.Transparent;
+	}
+ 	RedrawChart();
     }
 
     RecalculateValues();
 }
 
+// Converts a custom CrossColor to a system Color
 private System.Drawing.Color ConvertColor(CrossColor color)
 {
     return System.Drawing.Color.FromArgb(color.A, color.R, color.G, color.B);
@@ -711,21 +841,28 @@ private System.Drawing.Color ConvertColor(CrossColor color)
 /// <summary>
 /// Displays a message on the chart, typically used for debugging or information.
 /// </summary>
+private int _messageLineIndex = 0;
 private void DrawMessage(RenderContext context, string message)
 {
     var font = new RenderFont("Arial", 12);
     var textSize = context.MeasureString(message, font);
 
+    // Posición fija en la esquina inferior izquierda
     // Fixed position at bottom left corner
     var x = 10;
-    var y = (int)context.ClipBounds.Bottom - (int)textSize.Height - 10;
+    var lineHeight = (int)textSize.Height + 4;
+    var y = (int)context.ClipBounds.Bottom - ((_messageLineIndex + 1) * lineHeight) - 10;
 
+    // Fondo negro con borde (por si hay confusión con el gráfico)
     // Black background with margin
-    var backgroundRect = new Rectangle(x - 5, y - 2, (int)textSize.Width + 10, (int)textSize.Height + 4);
+    var backgroundRect = new Rectangle(x - 5, y - 2, (int)textSize.Width + 10, lineHeight);
     context.FillRectangle(System.Drawing.Color.Black, backgroundRect);
 
-    // Red text
+    // Dibuja el texto en rojo
+    // Draw the message text in red
     context.DrawString(message, font, System.Drawing.Color.Red, x, y);
+
+    _messageLineIndex++;
 }
 
 /// <summary>
@@ -751,6 +888,7 @@ private static RangeDataSeries CreateRangeSeries(string name)
     {
         IsHidden = true,
         DrawAbovePrice = false,
+	// Initialized with a transparent background
         RangeColor = System.Drawing.Color.Transparent.Convert()
     };
 }
@@ -772,17 +910,23 @@ private void ResetLevels()
 /// </summary>
 private void ResetState()
 {
+    // Clear previous sessions
     _sessions.Clear();
     _currentSession = null;
+    // Clear all data series
     DataSeries.ForEach(x => x.Clear());
+    // Reset calculated levels
     ResetLevels();
+    // Reset calculation flags and state
     _highLowIsSet = false;
     _calculate = false;
     _isStarted = false;
     _initialized = false;
+    // Reset bar tracking variables
     _lastStartBar = -1;
     _lastEndBar = -1;
     _targetBar = 0;
+    // Reset calculation window end time
     _endTime = DateTime.MaxValue;
 }
 
@@ -800,6 +944,7 @@ private void InitializeTargetBar()
     {
         _targetBar = i;
 
+	// Only count a new day if there’s a session change
         if (!IsNewSession(i))
             continue;
 
@@ -820,9 +965,11 @@ private void UpdateCustomSession(DateTime dateTime, int bar)
     var sessionStart = dateTime.Date + StartDate;
     var sessionEnd = dateTime.Date + EndDate;
 
+    // If session crosses midnight, adjust EndDate to next day
     if (EndDate < StartDate)
         sessionEnd = sessionEnd.AddDays(1);
 
+    // If no active session or the previous one has ended, attempt to start a new one
     if (_currentSession == null || dateTime >= _currentSession.EndTime)
     {
         if (dateTime >= sessionStart && dateTime < sessionEnd)
@@ -839,14 +986,18 @@ private void UpdateCustomSession(DateTime dateTime, int bar)
             _sessions.Add(_currentSession);
         }
     }
+    
+    // If candle is before the session start (possible in cross-midnight sessions), cancel the session
     else if (dateTime < _currentSession.StartTime)
     {
         _currentSession = null;
     }
-
+    
+    // If session end is reached, store EndBar and trigger completion logic
     if (_currentSession != null && dateTime >= _currentSession.EndTime && _currentSession.EndBar == -1)
     {
         _currentSession.EndBar = bar;
+	PrepareForNextSession();
     }
 }
 
@@ -905,23 +1056,59 @@ private void BeginCalculationWindow(int bar, DateTime candleTime)
     _endTime = candleTime.AddMinutes(_period);
     _isStarted = true;
 
-    ResetLevels();
-    EndPreviousValueLines(bar);
+    // Reset max, min and derived levels
+    ResetLevels(); 
+               
+    // Ends previously drawn lines from last session
+    EndPreviousValueLines(bar);                             
 
-    if (ShowOpenRange && ShowDuringFormation)
-        DrawOpenRangeRectangle(bar);
+	if (!CustomSessionStart)
+	{
+    		var sessionStart = GetCandle(bar).Time.Date;
+		var sessionEnd = sessionStart.AddHours(23).AddMinutes(59).AddSeconds(59);
+
+    		_currentSession = new Session
+    		{
+        		StartBar = bar,
+        		EndBar = -1,
+       		 	StartTime = sessionStart,
+        		EndTime = sessionEnd
+    		};
+
+    	_sessions.Add(_currentSession);
+	}
 }
 
 /// <summary>
 /// Finalizes the calculation window and forces chart redraw.
 /// </summary>
-private void EndCalculationWindow(int bar)
+private void EndCalculationWindow(Session session, int bar)
 {
     _calculate = false;
     _isStarted = false;
     _lastEndBar = bar;
-    UpdateSeriesVisibility();
-    RedrawChart();
+    UpdateSeriesVisibility(); 
+    RedrawChart(); 
+
+    // Save calculated levels in session dictionary
+    _sessionIBValues[session] = new IBLevels
+	{
+    		StartBarLine = bar,              // for the lines (from the end of the IB)
+    		StartBarRectangle = _lastStartBar, // for the rectangle (from the start of the IB)
+    		EndBar = bar,
+    		IBH = _ibMax,
+    		IBL = _ibMin,
+    		IBM = _ibmValue,
+    		MID = mid,
+    		IBHX1 = ibhx1,
+   		IBHX2 = ibhx2,
+    		IBHX3 = ibhx3,
+    		IBLX1 = iblx1,
+    		IBLX2 = iblx2,
+    		IBLX3 = iblx3
+	};
+
+	EndPreviousValueLines(bar);
 }
 
 /// <summary>
@@ -952,31 +1139,6 @@ private void UpdateIbHighLow(IndicatorCandle candle)
 }
 
 /// <summary>
-/// Dynamically adjusts the rectangle's coordinates based on the current candle.
-/// </summary>
-private void UpdateRectangleDuringCalculation(int bar)
-{
-    if (!_calculate)
-        return;
-
-    _rectangle.SecondBar = bar;
-    _rectangle.FirstPrice = _ibMax;
-    _rectangle.SecondPrice = _ibMin;
-}
-
-/// <summary>
-/// Updates the session's high and low values.
-/// </summary>
-private void UpdateSessionHighLow(IndicatorCandle candle)
-{
-    if (candle.High > _maxValue)
-        _maxValue = candle.High;
-
-    if (candle.Low < _minValue)
-        _minValue = candle.Low;
-}
-
-/// <summary>
 /// Dynamically updates the coordinates of the opening range rectangle during the calculation period.
 /// It runs whenever the calculation is active, regardless of whether the user has enabled its visualization.
 /// </summary>
@@ -1004,6 +1166,9 @@ private void UpdateSessionHighLow(IndicatorCandle candle)
 // Calculates the initial balance levels
 private void CalculateIbLevels(int bar)
 {
+    if (!_calculate)
+    	return;
+     
     _mid[bar] = mid = (_minValue + _maxValue) / 2m;
     _ibh[bar] = _ibMax;
     _ibl[bar] = _ibMin;
@@ -1016,6 +1181,27 @@ private void CalculateIbLevels(int bar)
     iblx1 = _iblx1[bar] = _ibMin - diff * _x1;
     iblx2 = _iblx2[bar] = _ibMin - diff * _x2;
     iblx3 = _iblx3[bar] = _ibMin - diff * _x3;
+
+    // Save temporary IB levels during formation if ShowDuringFormation is active
+    if (_calculate && ShowDuringFormation && _currentSession != null)
+    {
+    	_sessionIBValues[_currentSession] = new IBLevels
+    	{
+        	StartBarRectangle = _lastStartBar,
+        	StartBarLine = bar,
+        	EndBar = bar, // No finalizado aún // Not finished yet
+        	IBH = _ibMax,
+        	IBL = _ibMin,
+        	IBM = _ibmValue,
+        	MID = mid,
+        	IBHX1 = ibhx1,
+        	IBHX2 = ibhx2,
+        	IBHX3 = ibhx3,
+        	IBLX1 = iblx1,
+        	IBLX2 = iblx2,
+        	IBLX3 = iblx3
+    	};
+     }
 }
 
 // Fills the value areas
@@ -1032,81 +1218,16 @@ private void FillValueAreas(int bar)
     _iblx23[bar].Lower = iblx3;
 }
 
-// Draws the Initial Balance lines
-private void DrawIBLines(RenderContext context, int x1, int x2)
-{
-    var levels = new[]
-    {
-        ("IBH", _ibh.Color, _ibh.LineDashStyle, _ibh.Width, _ibMax),
-        ("IBL", _ibl.Color, _ibl.LineDashStyle, _ibl.Width, _ibMin),
-        ("IBM", _ibm.Color, _ibm.LineDashStyle, _ibm.Width, _ibmValue),
-        ("MID", _mid.Color, _mid.LineDashStyle, _mid.Width, mid),
-        ("IBHX1", _ibhx1.Color, _ibhx1.LineDashStyle, _ibhx1.Width, ibhx1),
-        ("IBHX2", _ibhx2.Color, _ibhx2.LineDashStyle, _ibhx2.Width, ibhx2),
-        ("IBHX3", _ibhx3.Color, _ibhx3.LineDashStyle, _ibhx3.Width, ibhx3),
-        ("IBLX1", _iblx1.Color, _iblx1.LineDashStyle, _iblx1.Width, iblx1),
-        ("IBLX2", _iblx2.Color, _iblx2.LineDashStyle, _iblx2.Width, iblx2),
-        ("IBLX3", _iblx3.Color, _iblx3.LineDashStyle, _iblx3.Width, iblx3)
-    };
-
-    const int offset = 2;
-
-    foreach (var (label, color, dash, width, price) in levels)
-    {
-        var y = (int)ChartInfo.GetYByPrice(price, false);
-        if (y < 0)
-            continue;
-
-        var pen = new RenderPen(ConvertColor(color), width, ConvertDashStyle(dash));
-        context.DrawLine(pen, x1, y, x2, y);
-    }
-}
-
-// Draws the labels for the Initial Balance lines
-private void DrawIBLabels(RenderContext context, int x2)
-{
-    const int offset = 2;
-
-    var labels = new[]
-    {
-        ("IBH", _ibh.Color, _ibMax),
-        ("IBL", _ibl.Color, _ibMin),
-        ("IBM", _ibm.Color, _ibmValue),
-        ("MID", _mid.Color, mid),
-        ("IBHX1", _ibhx1.Color, ibhx1),
-        ("IBHX2", _ibhx2.Color, ibhx2),
-        ("IBHX3", _ibhx3.Color, ibhx3),
-        ("IBLX1", _iblx1.Color, iblx1),
-        ("IBLX2", _iblx2.Color, iblx2),
-        ("IBLX3", _iblx3.Color, iblx3)
-    };
-
-    foreach (var (label, color, price) in labels)
-    {
-        var y = ChartInfo.GetYByPrice(price, false);
-        if (y < 0)
-            continue;
-
-        var size = context.MeasureString(label, _font);
-        context.DrawString(label, _font, ConvertColor(color),
-            x2 - size.Width - 2,
-            y - size.Height - offset);
-    }
-}
-
 // Draws the opening range rectangle
-private void DrawOpenRangeRectangle(int bar)
+private void DrawOpenRangeRectangle(int bar, IBLevels ib)
 {
-    if (!ShowOpenRange || _lastStartBar < 0)
-        return;
-
     var pen = new Pen(ConvertColor(_borderColor)) { Width = _borderWidth };
     var brush = new SolidBrush(ConvertColor(_fillColor));
 
     var rect = new DrawingRectangle(
-        _lastStartBar, _ibMax,
-        bar, _ibMin,
-        pen, brush
+            ib.StartBarRectangle, ib.IBH,
+            bar, ib.IBL,
+            pen, brush
     );
 
     // Remove any previous rectangle
@@ -1116,6 +1237,7 @@ private void DrawOpenRangeRectangle(int bar)
     Rectangles.Add(rect);
 }
 
+// Updates series visibility depending on current state
 private void UpdateSeriesVisibility()
 {
     if (_lastStartBar < 0)
@@ -1131,6 +1253,102 @@ private void UpdateSeriesVisibility()
         }
     }
 }
- 
- #endregion
+    // Prepares the indicator state for the next session
+    private void PrepareForNextSession()
+    {
+        _calculate = false;
+        _isStarted = false;
+        _highLowIsSet = false;
+        _waitingForNextSession = true;
+
+
+        //Ends all active lines visually
+        foreach (var series in DataSeries.OfType<ValueDataSeries>())
+        {            
+            series.SetPointOfEndLine(CurrentBar);
+        }
+        
+        UpdateSeriesVisibility();
+
+        RedrawChart();
+    }
+
+    // Returns X2 (final) coordinate for a session based on its status
+    private int GetSessionX2(RenderContext context, Session session)
+    {
+        if (session == _currentSession)
+        {
+            if (_currentSession.EndBar > 0)
+            {
+                //Case 3: Session already ended → line to the end of the session
+                return ChartInfo.GetXByBar(_currentSession.EndBar, false);
+            }
+            else if (!_calculate)
+            {
+                //Case 1 and 2: calculation already ended but session is still active
+                if (ExtendLastLineToRight)
+                    return context.ClipBounds.Right;
+                else
+                    return ChartInfo.GetXByBar(CurrentBar - 1, false);
+            }
+            else
+            {
+                //Still in formation → to the current visible candle
+                return ChartInfo.GetXByBar(CurrentBar - 1, false);
+            }
+        }
+        else
+        {
+            // Previous sessions → use their EndBar
+            return ChartInfo.GetXByBar(session.EndBar, false);
+        }
+    }
+
+    // Draws the Initial Balance lines and their labels
+    private void DrawIBVisuals(RenderContext context, Session session, bool drawLabels = true, bool drawLines = true)
+    {
+        const int offset = 2;
+
+        if (!_sessionIBValues.TryGetValue(session, out var ib))
+            return;
+
+        int sessionX2 = GetSessionX2(context, session);
+        int sessionX1 = ChartInfo.GetXByBar(ib.StartBarLine, false);
+
+        var items = new[]
+        {
+        ("IBH", _ibh, ib.IBH),
+        ("IBL", _ibl, ib.IBL),
+        ("IBM", _ibm, ib.IBM),
+        ("MID", _mid, ib.MID),
+        ("IBHX1", _ibhx1, ib.IBHX1),
+        ("IBHX2", _ibhx2, ib.IBHX2),
+        ("IBHX3", _ibhx3, ib.IBHX3),
+        ("IBLX1", _iblx1, ib.IBLX1),
+        ("IBLX2", _iblx2, ib.IBLX2),
+        ("IBLX3", _iblx3, ib.IBLX3)
+    };
+
+        foreach (var (label, series, price) in items)
+        {
+            var y = ChartInfo.GetYByPrice(price, false);
+            if (y < 0)
+                continue;
+
+            if (drawLines)
+            {
+                var pen = new RenderPen(ConvertColor(series.Color), series.Width, ConvertDashStyle(series.LineDashStyle));
+                context.DrawLine(pen, sessionX1, y, sessionX2, y);
+            }
+
+            if (drawLabels)
+            {
+                var size = context.MeasureString(label, _font);
+                context.DrawString(label, _font, ConvertColor(series.Color),
+                    sessionX2 - size.Width - 2,
+                    y - size.Height - offset);
+            }
+        }
+    }
+#endregion
 }


### PR DESCRIPTION
feat: extend Initial Balance lines and labels to right edge of chart

- Added user setting 'ExtendLastLineToRight' to control line/label extension
- Implemented OnRender to draw all major IB lines (IBH, IBL, IBM, MID, IBHX/IBLX) to the right chart margin
- Replaced AddText() with precise context.DrawString() to align labels visually with extended lines
- Added configurable 'FontSize' for label rendering
- Cleaned up and refactored rendering logic for maintainability