### PR TITLE
Fix ActiveVolume.cs

### DIFF
--- a/Technical/ActiveVolume.cs
+++ b/Technical/ActiveVolume.cs
@@ -15,10 +15,11 @@ using OFT.Rendering.Tools;
 
 using Utils.Common.Collections;
 
+[Category(IndicatorCategories.VolumeOrderFlow)]
 [DisplayName("Active Volume")]
 [Display(ResourceType = typeof(Strings), Description = nameof(Strings.ActiveVolumeDescription))]
 [HelpLink("https://help.atas.net/ru-RU/support/solutions/articles/72000608343-active-volume")]
-[FeatureId("070459C1-1655-4824-BB31-8B2BE78EEB4D")]
+
 public class ActiveVolume : Indicator
 {
 	#region Nested types


### PR DESCRIPTION
## Summary of changes

- 🔧 Removed the `[FeatureId]` attribute, which was preventing the indicator from appearing in the list after compilation.
- 🗂️ Added `[Category(IndicatorCategories.VolumeOrderFlow)]` to explicitly classify the indicator.

## Justification

The `Active Volume` indicator is primarily designed to visualize aggressive volume accumulation (bid and ask) at each price level. Therefore, it naturally fits within the `VolumeOrderFlow` category.

Although ATAS currently has few active indicator categories, adding this one improves usability and organization within the platform. If a more specific classification is introduced in the future (e.g. `AggressionProfile`, `CumulativeFlow`, etc.), it can be updated without impacting functionality.

## Additional notes

The `[FeatureId]` attribute may still be reintroduced later if needed, but should be regenerated with a unique GUID to avoid conflicts across custom indicators.