### PR TITLE
Set category to TechnicalIndicators (would use "Momentum" if available)

### DIFF
--- a/Technical/ACBW.cs
+++ b/Technical/ACBW.cs
@@ -9,6 +9,7 @@ using ATAS.Indicators.Drawing;
 using OFT.Attributes;
 using OFT.Localization;
 
+[Category(IndicatorCategories.TechnicalIndicators)]
 [DisplayName("Bill Williams AC")]
 [Display(ResourceType = typeof(Strings), Description = nameof(Strings.ACDescription))]
 [HelpLink("https://help.atas.net/support/solutions/articles/72000602333")]


### PR DESCRIPTION
The indicator has been assigned to [Category(IndicatorCategories.TechnicalIndicators)] to ensure proper registration within ATAS. However, the ideal classification would be "Momentum" to reflect the indicator's function more accurately. If a custom category system is ever supported or extended, consider adding IndicatorCategories.Momentum = "Momentum".