### PR TITLE
Set category to TechnicalIndicators (would use "Momentum" if available)

### DIFF
--- a/Technical/ACDC.cs
+++ b/Technical/ACDC.cs
@@ -7,6 +7,7 @@ using System.Drawing;
 using OFT.Attributes;
 using OFT.Localization;
 
+[Category(IndicatorCategories.TechnicalIndicators)]
 [DisplayName("AC DC Histogram")]
 [Display(ResourceType = typeof(Strings), Description = nameof(Strings.ACDCDescription))]
 [HelpLink("https://help.atas.net/support/solutions/articles/72000602293")]


### PR DESCRIPTION
The indicator has been assigned to [Category(IndicatorCategories.TechnicalIndicators)] to ensure proper registration within ATAS. However, the ideal classification would be "Momentum" to reflect the indicator's function more accurately. If a custom category system is ever supported or extended, consider adding IndicatorCategories.Momentum = "Momentum".