### PR TITLE
feat(ACR): set indicator category to 'Other'

### DIFF
--- a/Technical/ACR.cs
+++ b/Technical/ACR.cs
@@ -7,6 +7,7 @@ namespace ATAS.Indicators.Technical
 	using OFT.Attributes;
     using OFT.Localization;
 
+    [Category(IndicatorCategories.Other)]
     [DisplayName("Average Candle Range")]
     [Display(ResourceType = typeof(Strings), Description = nameof(Strings.ACRDescription))]
     [HelpLink("https://help.atas.net/support/solutions/articles/72000602323")]


### PR DESCRIPTION
Added [Category(IndicatorCategories.Other)] to ACR indicator.

💡 Suggestion: consider creating a new category 'PriceStatistics' to better group indicators that compute price-based metrics like candle ranges or average ranges.