### PR TITLE
Fix mojibake in pivot formula display: replace '�' with '-' (UI text …

### DIFF
--- a/Technical/Pivots.cs
+++ b/Technical/Pivots.cs
@@ -66,7 +66,7 @@ namespace ATAS.Indicators.Technical
 
         public enum Formula
         {
-            [Display(Name = "PP +/- 2(High � Low)")]
+            [Display(Name = "PP +/- 2(High - Low)")]
             HighLow,
             [Display(Name = "High/Low + 2(PP - Low/High)")]
             PpHighLow


### PR DESCRIPTION
**Summary**  
Replace the mojibake character `�` with a regular hyphen `-` in the `Display` name of `Formula.HighLow` in `pivot.cs`.

**Problem**  
In the Pivot formula label, the “High − Low” part shows a replacement character `�`, likely due to an encoding mismatch. This is visible in the UI and looks incorrect.

**Change**  
`diff`
- [Display(Name = "PP +/- 2(High � Low)")]
+ [Display(Name = "PP +/- 2(High - Low)")]

**Scope / Impact**

- UI text only. No behavioral or API changes.

- No resource keys or localization files affected.

- Safe for backport if needed.

**Why now**
This fixes a user-facing typo and improves consistency/legibility of the indicator list.

**Target branch**
develop

**Supersedes**
This replaces previous PR #62 which was based on a temporary branch. Closing that one in favor of this clean, single-change PR.