### PR TITLE
feat(clustersearch): support per-cluster PriceSelectionColor override (stacked on top of #83)

### DIFF
--- a/Technical/ClusterSearch.Models.cs
+++ b/Technical/ClusterSearch.Models.cs
@@ -51,7 +51,7 @@ public partial class ClusterSearch
 
 				for (var iPrice = price; iPrice <= price + (priceRowsMerge - 1) * tickSize; iPrice += tickSize)
 				{
-					if (!TryGetValue(price, out var iLevel))
+					if (!TryGetValue(iPrice, out var iLevel))
 						continue;
 
 					sum += iLevel.Volume;

--- a/Technical/ClusterSearch.Models.cs
+++ b/Technical/ClusterSearch.Models.cs
@@ -97,12 +97,14 @@ public partial class ClusterSearch
 		public decimal AvgTrade => Ticks is 0 ? 0 : Volume / Ticks;
 
 		public decimal Delta => Ask - Bid;
-
-		#endregion
-
-		#region ctor
 		
-		public CustomVolumeInfo(decimal price)
+		public CrossColor? PriceSelectionColor { get; set; }
+
+        #endregion
+
+        #region ctor
+
+        public CustomVolumeInfo(decimal price)
 		{
 			Price = price;
 		}

--- a/Technical/ClusterSearch.SeriesHandling.cs
+++ b/Technical/ClusterSearch.SeriesHandling.cs
@@ -303,8 +303,8 @@ public partial class ClusterSearch
 			SelectionSide = selectionSide,
 			ObjectColor = _clusterTransColor,
 			ObjectsTransparency = _visualObjectsTransparency,
-			PriceSelectionColor = ShowPriceSelection ? _clusterPriceColor : CrossColors.Transparent,
-			Tooltip = CreateToolTip(value),
+            PriceSelectionColor = cluster.PriceSelectionColor ?? (ShowPriceSelection ? _clusterPriceColor : CrossColors.Transparent),
+            Tooltip = CreateToolTip(value),
 			Context = absValue,
 			MinimumPrice = cluster.Price,
 			MaximumPrice = cluster.Price + InstrumentInfo.TickSize * (PriceRange - 1)

--- a/Technical/ClusterSearch.cs
+++ b/Technical/ClusterSearch.cs
@@ -780,26 +780,30 @@ public partial class ClusterSearch : Indicator
 			_mergedLevels[trade.Price] = level;
 		}
 
-		_mergedLevels.RemoveVolume(level);
+        // --- IMPORTANT: do NOT mutate 'level' in-place (it's the object stored in the dictionary).
+        // Build a NEW instance, apply the incoming trade, then assign via the indexer so
+        // TotalVolume and PocPrice are updated consistently.
+        var updated = new CustomVolumeInfo(level);
 
-		switch (trade.Direction)
+        switch (trade.Direction)
 		{
 			case TradeDirection.Buy:
-				level.Ask += trade.Volume;
+                updated.Ask += trade.Volume;
 				break;
 			case TradeDirection.Sell:
-				level.Bid += trade.Volume;
+                updated.Bid += trade.Volume;
 				break;
 			case TradeDirection.Between:
 			default:
-				level.Between += trade.Volume;
+                updated.Between += trade.Volume;
 				break;
 		}
-		
-		level.Volume += trade.Volume;
-		level.Ticks++;
 
-        _mergedLevels[trade.Price] = level;
+        updated.Volume += trade.Volume;
+        updated.Ticks +=1;
+
+        // Recompute totals and POC through the indexer
+        _mergedLevels[trade.Price] = updated;
     }
 
 	//Update data series values size on properties change


### PR DESCRIPTION
**Body:**

- Adds an optional PriceSelectionColor on CustomVolumeInfo.

- CreatePriceSelectionValue now prefers the cluster-specific color when present; otherwise falls back to the existing ShowPriceSelection behavior.

- Presentation-only, backward compatible. No calculation changes.

**Notes / Testing:**

- Verified that when a cluster provides PriceSelectionColor, the rendered selection uses it; otherwise it uses the default color or transparent when ShowPriceSelection is off.

- No impact on sizing, filters, or alerts.