### PR TITLE
fix(clustersearch): correct merged POC computation and real-time cache update

### DIFF
--- a/Technical/ClusterSearch.Models.cs
+++ b/Technical/ClusterSearch.Models.cs
@@ -51,7 +51,7 @@ public partial class ClusterSearch
 
 				for (var iPrice = price; iPrice <= price + (priceRowsMerge - 1) * tickSize; iPrice += tickSize)
 				{
-					if (!TryGetValue(price, out var iLevel))
+					if (!TryGetValue(iPrice, out var iLevel))
 						continue;
 
 					sum += iLevel.Volume;

--- a/Technical/ClusterSearch.cs
+++ b/Technical/ClusterSearch.cs
@@ -780,26 +780,30 @@ public partial class ClusterSearch : Indicator
 			_mergedLevels[trade.Price] = level;
 		}
 
-		_mergedLevels.RemoveVolume(level);
+        // --- IMPORTANT: do NOT mutate 'level' in-place (it's the object stored in the dictionary).
+        // Build a NEW instance, apply the incoming trade, then assign via the indexer so
+        // TotalVolume and PocPrice are updated consistently.
+        var updated = new CustomVolumeInfo(level);
 
-		switch (trade.Direction)
+        switch (trade.Direction)
 		{
 			case TradeDirection.Buy:
-				level.Ask += trade.Volume;
+                updated.Ask += trade.Volume;
 				break;
 			case TradeDirection.Sell:
-				level.Bid += trade.Volume;
+                updated.Bid += trade.Volume;
 				break;
 			case TradeDirection.Between:
 			default:
-				level.Between += trade.Volume;
+                updated.Between += trade.Volume;
 				break;
 		}
-		
-		level.Volume += trade.Volume;
-		level.Ticks++;
 
-        _mergedLevels[trade.Price] = level;
+        updated.Volume += trade.Volume;
+        updated.Ticks +=1;
+
+        // Recompute totals and POC through the indexer
+        _mergedLevels[trade.Price] = updated;
     }
 
 	//Update data series values size on properties change


### PR DESCRIPTION
**Scope**: calculation-only fixes. No UI/visual changes.
This PR addresses two correctness issues in the merged-level logic.

**1) Correct merged-window POC computation**

**File**: `ClusterSearchModels.cs`

**Change**: In `MergedClusterDictionary` indexer, sum the window using
`TryGetValue(iPrice, out var iLevel)` (not `price`).

**Why**: The current code always queries the base key (`price`) inside the loop, so the “N-level merge” sums the same level N times and ignores neighbors. Using `iPrice `produces the intended sliding-window sum and a correct `PocPrice `when `PriceRange > 1`.

**2) Keep `TotalVolume `and `PocPrice `consistent in real time**

**File**: `ClusterSearch.cs`

**Change**: In `UpdateLevelCache`, stop mutating the object stored in `_mergedLevels`, and do not call `RemoveVolume(level)`. Instead:

1. Create a **new** `CustomVolumeInfo `from the existing `level`.

2. Apply the incoming trade to the **new** instance.

3. Assign via indexer: `_mergedLevels[trade.Price] = updated;`.

**Why**: Mutating the same object that the dictionary already holds means the indexer later subtracts the **mutated** volume (not the old one). Combined with `RemoveVolume(level)`, this double-subtracts and corrupts `TotalVolume`; `PocPrice `also becomes stale. Replacing with a fresh instance lets the indexer subtract the old snapshot and add the updated one, recomputing `PocPrice` correctly.

**Files changed**

- `ClusterSearchModels.cs` — indexer uses `iPrice `when summing the window.

- `ClusterSearch.cs` — `UpdateLevelCache `builds a new instance and assigns via the indexer; no `RemoveVolume `call; no in-place mutation of the stored object.

**Backward compatibility**

Fully backward compatible. Only fixes calculation correctness; no API or UI changes.

**Test plan**

- **Merged-window POC**: With `PriceRange > 1`, verify that `PocPrice `matches the maximum of the true N-level sliding sum (base level + neighbors).

- **Live updates**: During ticks, confirm that `TotalVolume `remains consistent (no drift) and `PocPrice `updates as trades arrive at different prices.

- **Regression check**: Visual output and alerts remain unchanged aside from the corrected POC behavior.