### PR TITLE
Feat/clustersearch/diagonal imbalance with grouped windows compatibility (stacked on top of #82 and #83)

### DIFF
--- a/Technical/ClusterSearch.Models.cs
+++ b/Technical/ClusterSearch.Models.cs
@@ -140,27 +140,30 @@ public partial class ClusterSearch
 	public enum CalcMode
 	{
 		[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Bid))]
-		Bid,
+		Bid = 0,
 
 		[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Ask))]
-		Ask,
+		Ask = 1,
 
 		[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Delta))]
-		Delta,
+		Delta = 2,
 
 		[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Volume))]
-		Volume,
+		Volume = 3,
 
 		[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Ticks))]
-		Tick,
+		Tick = 4,
 
 		[Display(ResourceType = typeof(Strings), Name = nameof(Strings.PocLevel))]
-		MaxVolume,
+		MaxVolume = 5,
 
-		[Browsable(false)]
+        [Display(Name = "Diagonal Imbalance")]
+        DiagonalImbalance = 6,
+
+        [Browsable(false)]
 		[Obsolete]
 		[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Time))]
-		Time
+		Time = 7
 	}
 
 	public enum CandleDirection

--- a/Technical/ClusterSearch.Models.cs
+++ b/Technical/ClusterSearch.Models.cs
@@ -51,7 +51,7 @@ public partial class ClusterSearch
 
 				for (var iPrice = price; iPrice <= price + (priceRowsMerge - 1) * tickSize; iPrice += tickSize)
 				{
-					if (!TryGetValue(price, out var iLevel))
+					if (!TryGetValue(iPrice, out var iLevel))
 						continue;
 
 					sum += iLevel.Volume;

--- a/Technical/ClusterSearch.Models.cs
+++ b/Technical/ClusterSearch.Models.cs
@@ -97,12 +97,14 @@ public partial class ClusterSearch
 		public decimal AvgTrade => Ticks is 0 ? 0 : Volume / Ticks;
 
 		public decimal Delta => Ask - Bid;
-
-		#endregion
-
-		#region ctor
 		
-		public CustomVolumeInfo(decimal price)
+		public CrossColor? PriceSelectionColor { get; set; }
+
+        #endregion
+
+        #region ctor
+
+        public CustomVolumeInfo(decimal price)
 		{
 			Price = price;
 		}

--- a/Technical/ClusterSearch.SeriesHandling.cs
+++ b/Technical/ClusterSearch.SeriesHandling.cs
@@ -303,8 +303,8 @@ public partial class ClusterSearch
 			SelectionSide = selectionSide,
 			ObjectColor = _clusterTransColor,
 			ObjectsTransparency = _visualObjectsTransparency,
-			PriceSelectionColor = ShowPriceSelection ? _clusterPriceColor : CrossColors.Transparent,
-			Tooltip = CreateToolTip(value),
+            PriceSelectionColor = cluster.PriceSelectionColor ?? (ShowPriceSelection ? _clusterPriceColor : CrossColors.Transparent),
+            Tooltip = CreateToolTip(value),
 			Context = absValue,
 			MinimumPrice = cluster.Price,
 			MaximumPrice = cluster.Price + InstrumentInfo.TickSize * (PriceRange - 1)

--- a/Technical/ClusterSearch.SeriesHandling.cs
+++ b/Technical/ClusterSearch.SeriesHandling.cs
@@ -207,7 +207,8 @@ public partial class ClusterSearch
 			CalcMode.Delta => cluster.Delta,
 			CalcMode.Volume or CalcMode.MaxVolume => cluster.Volume,
 			CalcMode.Tick => cluster.Ticks,
-			_ => 0
+            CalcMode.DiagonalImbalance => Math.Max(cluster.Ask, cluster.Bid), // size by dominant side
+            _ => 0
 		};
 
 		var level = CreatePriceSelectionValue(cluster);
@@ -272,7 +273,8 @@ public partial class ClusterSearch
 			CalcMode.Delta => cluster.Delta,
 			CalcMode.Volume or CalcMode.MaxVolume => cluster.Volume,
 			CalcMode.Tick => cluster.Ticks,
-			_ => 0
+            CalcMode.DiagonalImbalance => Math.Max(cluster.Ask, cluster.Bid), // size by dominant side
+            _ => 0
 		};
 
 		var absValue = CalcType is CalcMode.Delta 
@@ -326,7 +328,8 @@ public partial class ClusterSearch
 			CalcMode.Volume => Strings.Volume,
 			CalcMode.Tick => Strings.Ticks,
 			CalcMode.MaxVolume => Strings.PocLevel,
-			_ => ""
+            CalcMode.DiagonalImbalance => "Diagonal imbalance",
+            _ => ""
 		};
 
 		return tip;

--- a/Technical/ClusterSearch.cs
+++ b/Technical/ClusterSearch.cs
@@ -595,6 +595,9 @@ public partial class ClusterSearch : Indicator
     //Compare clusters values with volume filters
     private bool CheckCluster(int bar, decimal price)
     {
+        // Optional color override for Diagonal Imbalance
+        CrossColor? diColor = null;
+
         var endPrice = price + (PriceRange - 1) * InstrumentInfo.TickSize;
 
         var ask = 0m;
@@ -602,56 +605,6 @@ public partial class ClusterSearch : Indicator
         var between = 0m;
         var volume = 0m;
         var ticks = 0;
-
-        // -----------------------------------------------------------------------
-        // (A) Diagonal Imbalance tick-by-tick (N = 1), stacked by 1 tick
-        // Run this BEFORE aggregating ask/bid/... when price grouping is OFF.
-        // If it fails, exit early; if it passes, continue with the normal flow
-        // (aggregation, common filters) and finish at the usual SaveLevel().
-        // -----------------------------------------------------------------------
-        if (CalcType == CalcMode.DiagonalImbalance && !GroupDiagonalImbalances)
-        {
-            var step = InstrumentInfo.TickSize;
-
-            int stacked = 0;
-            bool? firstIsBuy = null;
-            var p = price;
-
-            while (stacked < ImbalanceStackedRange)
-            {
-                if (!_mergedLevels.TryGetValue(p, out var up) ||
-                    !_mergedLevels.TryGetValue(p - step, out var low))
-                    break;
-
-                bool buy =
-                    low.Bid > 0 &&
-                    (up.Ask / low.Bid) >= ImbalanceRatio &&
-                    (up.Ask - low.Bid) >= MinVolumeDifference &&
-                    up.Ask >= MinDominantVolume;
-
-                bool sell =
-                    up.Ask > 0 &&
-                    (low.Bid / up.Ask) >= ImbalanceRatio &&
-                    (low.Bid - up.Ask) >= MinVolumeDifference &&
-                    low.Bid >= MinDominantVolume;
-
-                if (!(buy || sell))
-                    break;
-
-                // Lock direction on first valid pair and keep it consistent across the stack
-                if (firstIsBuy is null) firstIsBuy = buy;
-                else if (firstIsBuy.Value != buy) break;
-
-                stacked++;
-                p += step; // advance by one price row
-            }
-
-            if (stacked < ImbalanceStackedRange)
-                return false;
-
-            // Passed tick-level DI → continue to aggregate [price..endPrice],
-            // apply common filters, and SaveLevel() at the end as usual.
-        }
 
         for (var iPrice = price; iPrice <= endPrice; iPrice += InstrumentInfo.TickSize)
         {
@@ -663,113 +616,6 @@ public partial class ClusterSearch : Indicator
             between += level.Between;
             volume += level.Volume;
             ticks += level.Ticks;
-        }
-
-        // -----------------------------------------------------------------------
-        // (B) Diagonal Imbalance over GROUPED windows (N = PriceRange), stacked by groups
-        // Run this AFTER aggregating ask/bid/... when price grouping is ON.
-        // If it fails, exit early; if it passes, return SaveLevel() immediately
-        // (exclusive pipeline), preserving the behavior of your original function.
-        // -----------------------------------------------------------------------
-        if (CalcType == CalcMode.DiagonalImbalance && GroupDiagonalImbalances)
-        {
-            var step = InstrumentInfo.TickSize;
-            var nTicks = PriceRange; // window size (number of price rows)
-
-            // Lower window aligned to the START of the upper and shifted down by 1 tick:
-            // [price - N*step .. price - step]
-            var lowerStart = price - nTicks * step; // inclusive
-            var lowerEnd = price - step;          // inclusive
-
-            decimal lowerBid = 0m;
-            for (var p = lowerStart; p <= lowerEnd; p += step)
-            {
-                if (_mergedLevels.TryGetValue(p, out var lv))
-                    lowerBid += lv.Bid;
-            }
-
-            // Base window DI decision
-            bool buy =
-                lowerBid > 0 &&
-                (ask / lowerBid) >= ImbalanceRatio &&
-                (ask - lowerBid) >= MinVolumeDifference &&
-                ask >= MinDominantVolume;
-
-            bool sell =
-                ask > 0 &&
-                (lowerBid / ask) >= ImbalanceRatio &&
-                (lowerBid - ask) >= MinVolumeDifference &&
-                lowerBid >= MinDominantVolume;
-
-            if (!(buy || sell))
-                return false;
-
-            // Stacking by GROUPS of N ticks: slide both windows by exactly N rows per step
-            int stacked = 1;
-            for (int g = 1; g < ImbalanceStackedRange; g++)
-            {
-                // Upper window for group g
-                var upStart_g = price + g * nTicks * step;
-                var upEnd_g = endPrice + g * nTicks * step;
-
-                // Lower window aligned to the START of the upper g, shifted down 1 tick:
-                // [upStart_g - N*step .. upStart_g - step]
-                var lowStart_g = upStart_g - nTicks * step;
-                var lowEnd_g = upStart_g - step;
-
-                // Re-aggregate ASK on the upper window g
-                decimal upAsk_g = 0m;
-                for (var p = upStart_g; p <= upEnd_g; p += step)
-                {
-                    if (_mergedLevels.TryGetValue(p, out var lvUp))
-                        upAsk_g += lvUp.Ask;
-                }
-
-                // Re-aggregate BID on the lower window g
-                decimal lowBid_g = 0m;
-                for (var p = lowStart_g; p <= lowEnd_g; p += step)
-                {
-                    if (_mergedLevels.TryGetValue(p, out var lvLo))
-                        lowBid_g += lvLo.Bid;
-                }
-
-                bool nextBuy =
-                    lowBid_g > 0 &&
-                    (upAsk_g / lowBid_g) >= ImbalanceRatio &&
-                    (upAsk_g - lowBid_g) >= MinVolumeDifference &&
-                    upAsk_g >= MinDominantVolume;
-
-                bool nextSell =
-                    upAsk_g > 0 &&
-                    (lowBid_g / upAsk_g) >= ImbalanceRatio &&
-                    (lowBid_g - upAsk_g) >= MinVolumeDifference &&
-                    lowBid_g >= MinDominantVolume;
-
-                if ((buy && nextBuy) || (sell && nextSell))
-                    stacked++;
-                else
-                    break;
-            }
-
-            if (stacked < ImbalanceStackedRange)
-                return false;
-
-            // Ensure marker size reflects the dominant side used by the diagonal test.
-            // - BUY: dominant = upper window 'ask' (already in `ask`), zero-out 'bid' to avoid accidental Max()
-            // - SELL: dominant = lower window 'lowerBid' (computed earlier), zero-out 'ask'
-            if (buy)
-            {
-                bid = 0m;                  // keep `ask` as the dominant value
-            }
-            else // sell
-            {
-                ask = 0m;                  // force dominant into Bid
-                bid = lowerBid;            // use lower window Bid for sizing
-            }
-
-            // Keep current aggregated values for the current upper window and mark it as valid.
-            // Maintain original behavior: exit the function here for grouped DI.
-            return SaveLevel();
         }
 
         if (CalcType is CalcMode.MaxVolume && price != _mergedLevels.PocPrice)
@@ -786,6 +632,88 @@ public partial class ClusterSearch : Indicator
             CalcMode.Tick => ticks,
             _ => 0
         };
+
+        // -----------------------------------------------------------------------
+        // Diagonal Imbalance over a window of N rows (N = PriceRange).
+        // For N=1 this degenerates to the classic tick-by-tick pairing.
+        // - Upper window: [price .. endPrice] (we already aggregated 'ask')
+        // - Lower window: [price - N*tick .. price - 1*tick] (same size, aligned to upper START)
+        // - Stacking: advance by GROUPS of N ticks (non-overlapping) to avoid duplicates.
+        // - On success: save ONE level (the current upper window) and exit.
+        // -----------------------------------------------------------------------
+        if (CalcType == CalcMode.DiagonalImbalance)
+        {
+            var step = InstrumentInfo.TickSize;
+            var nTicks = Math.Max(1, PriceRange);
+
+            // Sum Bid on the lower window aligned to the START of the upper and shifted down by 1 tick
+            var lowerStart = price - nTicks * step;
+            var lowerEnd = price - step;
+
+            decimal lowerBid = 0m;
+            for (var p = lowerStart; p <= lowerEnd; p += step)
+                if (_mergedLevels.TryGetValue(p, out var lvLo)) lowerBid += lvLo.Bid;
+
+            // Base DI decision using window sums
+            bool buy = lowerBid > 0 &&
+                         (ask / lowerBid) >= ImbalanceRatio &&
+                         (ask - lowerBid) >= MinVolumeDifference &&
+                         ask >= MinDominantVolume;
+
+            bool sell = ask > 0 &&
+                         (lowerBid / ask) >= ImbalanceRatio &&
+                         (lowerBid - ask) >= MinVolumeDifference &&
+                         lowerBid >= MinDominantVolume;
+
+            if (!(buy || sell))
+                return false;
+
+            // Stacked windows: slide by GROUPS of N ticks (non-overlapping)
+            int stacked = 1;
+            for (int g = 1; g < ImbalanceStackedRange; g++)
+            {
+                var upStart_g = price + g * nTicks * step;
+                var upEnd_g = endPrice + g * nTicks * step;
+
+                // Sum ASK on the upper window g
+                decimal upAsk_g = 0m;
+                for (var p = upStart_g; p <= upEnd_g; p += step)
+                    if (_mergedLevels.TryGetValue(p, out var lvUp)) upAsk_g += lvUp.Ask;
+
+                // Sum BID on the lower window g: [upStart_g - N*step .. upStart_g - step]
+                var lowStart_g = upStart_g - nTicks * step;
+                var lowEnd_g = upStart_g - step;
+
+                decimal lowBid_g = 0m;
+                for (var p = lowStart_g; p <= lowEnd_g; p += step)
+                    if (_mergedLevels.TryGetValue(p, out var lvL)) lowBid_g += lvL.Bid;
+
+                bool nextBuy = lowBid_g > 0 &&
+                                 (upAsk_g / lowBid_g) >= ImbalanceRatio &&
+                                 (upAsk_g - lowBid_g) >= MinVolumeDifference &&
+                                 upAsk_g >= MinDominantVolume;
+
+                bool nextSell = upAsk_g > 0 &&
+                                 (lowBid_g / upAsk_g) >= ImbalanceRatio &&
+                                 (lowBid_g - upAsk_g) >= MinVolumeDifference &&
+                                 lowBid_g >= MinDominantVolume;
+
+                if ((buy && nextBuy) || (sell && nextSell))
+                    stacked++;
+                else
+                    break;
+            }
+
+            if (stacked < ImbalanceStackedRange)
+                return false;
+
+            // Color override (optional)
+            if (UseSeparateColors)
+                diColor = buy ? BuyImbalanceColor : SellImbalanceColor;
+
+            // Save ONE level (the current upper window) and exit — same behavior for N=1 and N>1
+            return SaveLevel();
+        }
 
         if (AutoFilter)
         {
@@ -819,13 +747,8 @@ public partial class ClusterSearch : Indicator
         if (DeltaImbalance != 0)
         {
             var vol = volume;
-            var askImbalance = vol is not 0
-                ? ask * 100.0m / vol
-                : 0;
-
-            var bidImbalance = vol is not 0
-                ? bid * 100.0m / vol
-                : 0;
+            var askImbalance = vol is not 0 ? ask * 100.0m / vol : 0;
+            var bidImbalance = vol is not 0 ? bid * 100.0m / vol : 0;
 
             switch (DeltaImbalance)
             {
@@ -872,6 +795,10 @@ public partial class ClusterSearch : Indicator
             info.Between = between;
             info.Volume = volume;
             info.Ticks = ticks;
+
+            // Apply DI color override (if any)
+            if (diColor.HasValue)
+                info.PriceSelectionColor = diColor.Value;
 
             return true;
         }
@@ -1236,22 +1163,6 @@ public partial class ClusterSearch : Indicator
         set
         {
             _minDominantVolume = value;
-            OnChangeProperty();
-
-            RecalculateValues();
-        }
-    }
-
-    private bool _groupDiagonalImbalances = true; // default ON, to mirror grouped logic elsewhere
-    [Display(
-    Name = "Group Diagonal Imbalances", GroupName = "Diagonal Imbalances Filters", Order = 345,
-    Description = "When enabled, diagonal imbalances use the same grouping length (PriceRange) as the rest of the indicator; stacking also advances by groups instead of single ticks.")]
-    public bool GroupDiagonalImbalances
-    {
-        get => _groupDiagonalImbalances;
-        set
-        {
-            _groupDiagonalImbalances = value;
             OnChangeProperty();
 
             RecalculateValues();

--- a/Technical/ClusterSearch.cs
+++ b/Technical/ClusterSearch.cs
@@ -630,7 +630,96 @@ public partial class ClusterSearch : Indicator
 			_ => 0
 		};
 
-		if (AutoFilter)
+        // =======================================================================
+        // Diagonal Imbalance over GROUPED windows (exclusive pipeline)
+        // Upper window (ASK): [price .. endPrice]  -> already aggregated as 'ask'
+        // Lower window (BID): [price - N*step .. price - step] (same size, aligned to upper START, shifted down 1 tick)
+        // Stacking: advance by GROUPS of N ticks (block-wise), not by single ticks.
+        // =======================================================================
+        if (CalcType == CalcMode.DiagonalImbalance)
+        {
+            var step = InstrumentInfo.TickSize;
+            var nTicks = PriceRange; // group size (rows in merged window)
+
+            // 1) First group's LOWER window uses START alignment: [price - N*step .. price - step]
+            var lowerStart = price - nTicks * step; // inclusive
+            var lowerEnd = price - step;          // inclusive
+
+            decimal lowerBid = 0m;
+            for (var p = lowerStart; p <= lowerEnd; p += step)
+            {
+                if (_mergedLevels.TryGetValue(p, out var lv))
+                    lowerBid += lv.Bid;
+            }
+
+            // 2) Decide BUY/SELL diagonal imbalance with grouped windows
+            bool buy = lowerBid > 0
+                        && (ask / lowerBid) >= ImbalanceRatio
+                        && (ask - lowerBid) >= MinVolumeDifference
+                        && ask >= MinDominantVolume;
+
+            bool sell = ask > 0
+                        && (lowerBid / ask) >= ImbalanceRatio
+                        && (lowerBid - ask) >= MinVolumeDifference
+                        && lowerBid >= MinDominantVolume;
+
+            if (!(buy || sell))
+                return false;
+
+            // 3) Stacking by GROUPS: slide both windows UP by exactly N ticks per step
+            var stacked = 1;
+            for (int g = 1; g < ImbalanceStackedRange; g++)
+            {
+                // Upper group g
+                var upStart_g = price + g * nTicks * step;
+                var upEnd_g = endPrice + g * nTicks * step;
+
+                // Lower group g aligned to the START of the upper g, shifted down 1 tick, same size N:
+                // [upStart_g - N*step .. upStart_g - step]
+                var lowStart_g = upStart_g - nTicks * step;
+                var lowEnd_g = upStart_g - step;
+
+                // Re-aggregate ASK on the upper window g
+                decimal upAsk_g = 0m;
+                for (var p = upStart_g; p <= upEnd_g; p += step)
+                {
+                    if (_mergedLevels.TryGetValue(p, out var lvUp))
+                        upAsk_g += lvUp.Ask;
+                }
+
+                // Re-aggregate BID on the lower window g
+                decimal lowBid_g = 0m;
+                for (var p = lowStart_g; p <= lowEnd_g; p += step)
+                {
+                    if (_mergedLevels.TryGetValue(p, out var lvLo))
+                        lowBid_g += lvLo.Bid;
+                }
+
+                bool nextBuy = lowBid_g > 0
+                                 && (upAsk_g / lowBid_g) >= ImbalanceRatio
+                                 && (upAsk_g - lowBid_g) >= MinVolumeDifference
+                                 && upAsk_g >= MinDominantVolume;
+
+                bool nextSell = upAsk_g > 0
+                                 && (lowBid_g / upAsk_g) >= ImbalanceRatio
+                                 && (lowBid_g - upAsk_g) >= MinVolumeDifference
+                                 && lowBid_g >= MinDominantVolume;
+
+                if ((buy && nextBuy) || (sell && nextSell))
+                    stacked++;
+                else
+                    break;
+            }
+
+            if (stacked < ImbalanceStackedRange)
+                return false;
+
+            // Keep current aggregated values for the upper window and mark it as valid.
+            return SaveLevel();
+        }
+
+
+        if (AutoFilter)
 		{
 			if (_autoFilterValue is 0)
 				return SaveLevel();
@@ -648,7 +737,7 @@ public partial class ClusterSearch : Indicator
 		if (MinAverageTrade != 0 && avgTrade < MinAverageTrade)
 			return false;
 
-		if (MaxAverageTrade != 0 && avgTrade > MinAverageTrade)
+		if (MaxAverageTrade != 0 && avgTrade > MaxAverageTrade)
 			return false;
 
 		if (MinPercent != 0 || MaxPercent != 0)
@@ -901,7 +990,13 @@ public partial class ClusterSearch : Indicator
 		set
 		{
 			_type = value;
-			RecalculateValues();
+            if (_type == CalcMode.DiagonalImbalance)
+            {
+                AutoFilter = false;
+                MinimumFilter.Enabled = false;
+                MaximumFilter.Enabled = false;
+            }
+            RecalculateValues();
 		}
 	}
 
@@ -1028,6 +1123,104 @@ public partial class ClusterSearch : Indicator
 			RecalculateValues();
 		}
 	}
+
+    #endregion
+
+    #region Imbalance filters
+	
+	[Display(Name = "Minimum Ask/Bid Ratio", GroupName = "Diagonal Imbalances Filters", Order = 320, Description = "Minimum Ask-to-Bid or Bid-to-Ask ratio to consider an imbalance.")]
+    [Range(1, 100)]
+    public decimal ImbalanceRatio
+    {
+        get => _imbalanceRatio;
+        set 
+		{
+			_imbalanceRatio = value; 
+			OnDiagonalImbalancePropertyChanged();
+		}
+    }
+    private decimal _imbalanceRatio = 3m;
+
+    [Display(Name = "Minimum Volume Difference", GroupName = "Diagonal Imbalances Filters", Order = 330, Description = "Minimum absolute volume difference between dominant and weaker sides.")]
+    [Range(0, 1000000)]
+    public decimal MinVolumeDifference
+    {
+        get => _minVolumeDifference;
+        set 
+		{
+			_minVolumeDifference = value;
+			OnDiagonalImbalancePropertyChanged();
+		}
+    }
+    private decimal _minVolumeDifference = 30m;
+
+    [Display(Name = "Minimum Dominant Side Volume", GroupName = "Diagonal Imbalances Filters", Order = 340, Description = "Minimum volume on the dominant side (Ask or Bid).")]
+    [Range(0, 1000000)]
+    public decimal MinDominantVolume
+    {
+        get => _minDominantVolume;
+        set 
+		{
+			_minDominantVolume = value;
+			OnDiagonalImbalancePropertyChanged();
+		}
+    }
+    private decimal _minDominantVolume = 100m;
+
+    [Display(Name = "Minimum Stacked Imbalances", GroupName = "Diagonal Imbalances Filters", Order = 350, Description = "Minimum number of consecutive diagonal imbalances required.")]
+    [Range(1, 10)]
+    public int ImbalanceStackedRange
+    {
+        get => _imbalanceStackedRange;
+        set
+		{
+			_imbalanceStackedRange = value;
+			OnDiagonalImbalancePropertyChanged();
+		}
+    }
+    private int _imbalanceStackedRange = 1;
+
+    #endregion
+
+    #region Imbalances visualization
+
+    [Display(Name = "Use Separate Colors for Imbalances", GroupName = "Imbalances Visualization", Order = 680, Description = "Use different colors for Buy and Sell imbalances.")]
+    public bool UseSeparateColors
+    {
+        get => _useSeparateColors;
+        set
+		{
+			_useSeparateColors = value;
+			OnDiagonalImbalancePropertyChanged();
+		}
+    }
+    private bool _useSeparateColors = true;
+
+    [Display(Name = "Buy Imbalance Color", GroupName = "Imbalances Visualization", Order = 690, Description = "Color for Buy (Ask > Bid) diagonal imbalances.")]
+    public CrossColor BuyImbalanceColor
+    {
+        get => _buyImbalanceColor;
+        set
+		{
+			_buyImbalanceColor = value;
+			OnDiagonalImbalancePropertyChanged();
+		}
+    }
+    private CrossColor _buyImbalanceColor = CrossColors.Green;
+
+    [Display(Name = "Sell Imbalance Color", GroupName = "Imbalances Visualization", Order = 695, Description = "Color for Sell (Bid > Ask) diagonal imbalances.")]
+    public CrossColor SellImbalanceColor
+    {
+        get => _sellImbalanceColor;
+        set
+		{
+			_sellImbalanceColor = value;
+			OnDiagonalImbalancePropertyChanged();
+		}
+    }
+    private CrossColor _sellImbalanceColor = CrossColors.Red;
+
+    #endregion
 
 	#endregion
 

--- a/Technical/ClusterSearch.cs
+++ b/Technical/ClusterSearch.cs
@@ -780,26 +780,30 @@ public partial class ClusterSearch : Indicator
 			_mergedLevels[trade.Price] = level;
 		}
 
-		_mergedLevels.RemoveVolume(level);
+        // --- IMPORTANT: do NOT mutate 'level' in-place (it's the object stored in the dictionary).
+        // Build a NEW instance, apply the incoming trade, then assign via the indexer so
+        // TotalVolume and PocPrice are updated consistently.
+        var updated = new CustomVolumeInfo(level);
 
-		switch (trade.Direction)
+        switch (trade.Direction)
 		{
 			case TradeDirection.Buy:
-				level.Ask += trade.Volume;
+                updated.Ask += trade.Volume;
 				break;
 			case TradeDirection.Sell:
-				level.Bid += trade.Volume;
+                updated.Bid += trade.Volume;
 				break;
 			case TradeDirection.Between:
 			default:
-				level.Between += trade.Volume;
+                updated.Between += trade.Volume;
 				break;
 		}
-		
-		level.Volume += trade.Volume;
-		level.Ticks++;
 
-        _mergedLevels[trade.Price] = level;
+        updated.Volume += trade.Volume;
+        updated.Ticks +=1;
+
+        // Recompute totals and POC through the indexer
+        _mergedLevels[trade.Price] = updated;
     }
 
 	//Update data series values size on properties change

--- a/Technical/ClusterSearch.cs
+++ b/Technical/ClusterSearch.cs
@@ -1,4 +1,4 @@
-namespace ATAS.Indicators.Technical;
+﻿namespace ATAS.Indicators.Technical;
 
 using System;
 using System.Collections.Generic;
@@ -21,235 +21,235 @@ using static DynamicLevels;
 [HelpLink("https://help.atas.net/support/solutions/articles/72000602240")]
 public partial class ClusterSearch : Indicator
 {
-	#region Fields
+    #region Fields
 
-	private readonly PriceSelectionDataSeries _renderDataSeries = new("RenderDataSeries", "Price");
-	private bool _autoFilter;
-	private decimal _autoFilterValue;
+    private readonly PriceSelectionDataSeries _renderDataSeries = new("RenderDataSeries", "Price");
+    private bool _autoFilter;
+    private decimal _autoFilterValue;
 
-	private HashSet<decimal> _alertPrices = [];
+    private HashSet<decimal> _alertPrices = [];
 
-	private int _barsRange = 1;
-	private CandleDirection _candleDirection = CandleDirection.Any;
-	private CrossColor _clusterPriceColor;
+    private int _barsRange = 1;
+    private CandleDirection _candleDirection = CandleDirection.Any;
+    private CrossColor _clusterPriceColor;
 
-	private Dictionary<(int Bar, decimal Price), PriceVolumeInfo> _clustersCache = new();
+    private Dictionary<(int Bar, decimal Price), PriceVolumeInfo> _clustersCache = new();
 
-	private CrossColor _clusterTransColor;
-	private int _days = 20;
-	private decimal _deltaFilter;
-	private decimal _deltaImbalance;
-	private bool _fixedSizes;
-	private bool _isFinishRecalculate;
-	private int _lastBar = -1;
+    private CrossColor _clusterTransColor;
+    private int _days = 20;
+    private decimal _deltaFilter;
+    private decimal _deltaImbalance;
+    private bool _fixedSizes;
+    private bool _isFinishRecalculate;
+    private int _lastBar = -1;
 
-	private decimal _lastPrice;
+    private decimal _lastPrice;
 
-	private SyncList<PriceSelectionValue> _lastSeriesBar = [];
-	private decimal _maxAverageTrade;
-	private Filter _maxFilter = new() { Enabled = true, Value = 99999 };
-	private decimal _maxPercent;
-	private int _maxSize = 50;
+    private SyncList<PriceSelectionValue> _lastSeriesBar = [];
+    private decimal _maxAverageTrade;
+    private Filter _maxFilter = new() { Enabled = true, Value = 99999 };
+    private decimal _maxPercent;
+    private int _maxSize = 50;
 
-	private MergedClusterDictionary _mergedLevels;
-	private decimal _minAverageTrade;
-	private Filter _minFilter = new() { Enabled = true, Value = 1000 };
-	private decimal _minFilterValue;
-	private decimal _minPercent;
-	private int _minSize = 5;
-	private bool _onlyOneSelectionPerBar;
-	private Filter _pipsFromHigh = new() { Value = 100000000 };
-	private Filter _pipsFromLow = new() { Value = 100000000 };
-	private PriceLocation _priceLocation = PriceLocation.Any;
-	private int _priceRange = 1;
-	private bool _showPriceSelection = true;
-	private int _size = 10;
-	private int _targetBar;
-	private TimeSpan _timeFrom = TimeSpan.Zero;
-	private TimeSpan _timeTo = TimeSpan.Zero;
-	private CalcMode _type = CalcMode.Volume;
-	private bool _usePrevClose;
-	private bool _useTimeFilter;
+    private MergedClusterDictionary _mergedLevels;
+    private decimal _minAverageTrade;
+    private Filter _minFilter = new() { Enabled = true, Value = 1000 };
+    private decimal _minFilterValue;
+    private decimal _minPercent;
+    private int _minSize = 5;
+    private bool _onlyOneSelectionPerBar;
+    private Filter _pipsFromHigh = new() { Value = 100000000 };
+    private Filter _pipsFromLow = new() { Value = 100000000 };
+    private PriceLocation _priceLocation = PriceLocation.Any;
+    private int _priceRange = 1;
+    private bool _showPriceSelection = true;
+    private int _size = 10;
+    private int _targetBar;
+    private TimeSpan _timeFrom = TimeSpan.Zero;
+    private TimeSpan _timeTo = TimeSpan.Zero;
+    private CalcMode _type = CalcMode.Volume;
+    private bool _usePrevClose;
+    private bool _useTimeFilter;
 
-	private Dictionary<decimal, CustomVolumeInfo> _validVolumeLevels = new();
-	private int _visualObjectsTransparency;
-	private ObjectType _visualType = ObjectType.Rectangle;
+    private Dictionary<decimal, CustomVolumeInfo> _validVolumeLevels = new();
+    private int _visualObjectsTransparency;
+    private ObjectType _visualType = ObjectType.Rectangle;
 
-	#endregion
+    #endregion
 
-	#region ctor
+    #region ctor
 
-	public ClusterSearch()
-		: base(true)
-	{
-		VisualObjectsTransparency = 70;
-		PriceSelectionColor = ClusterColor = CrossColor.FromArgb(100, 255, 0, 255);
+    public ClusterSearch()
+        : base(true)
+    {
+        VisualObjectsTransparency = 70;
+        PriceSelectionColor = ClusterColor = CrossColor.FromArgb(100, 255, 0, 255);
 
-		VisualType = ObjectType.Rectangle;
+        VisualType = ObjectType.Rectangle;
 
-		DenyToChangePanel = true;
-		_renderDataSeries.IsHidden = true;
-		DataSeries[0] = _renderDataSeries;
-	}
-
-	#endregion
-
-	#region Protected methods
-
-	protected override void OnInitialize()
-	{
-		_maxFilter.PropertyChanged += MaxMinFilter_PropertyChanged;
-		_minFilter.PropertyChanged += MaxMinFilter_PropertyChanged;
-		PipsFromHigh.PropertyChanged += Filter_PropertyChanged;
-		PipsFromLow.PropertyChanged += Filter_PropertyChanged;
-
-		MinCandleHeight.PropertyChanged += Filter_PropertyChanged;
-		MaxCandleHeight.PropertyChanged += Filter_PropertyChanged;
-		MinCandleBodyHeight.PropertyChanged += Filter_PropertyChanged;
-		MaxCandleBodyHeight.PropertyChanged += Filter_PropertyChanged;
-	}
-
-	protected override void OnNewTrade(MarketDataArg trade)
-	{
-		if (!_isFinishRecalculate || UsePrevClose)
-			return;
-
-		var curBar = CurrentBar - 1;
-
-		var i = 0;
-
-		while (i < curBar)
-		{
-			if (trade.Time < GetCandle(curBar - i).Time)
-			{
-				i++;
-				continue;
-			}
-
-			break;
-		}
-
-		if (_lastBar != curBar - i)
-		{
-			OnNewBar(curBar - i);
-			_lastBar = curBar - i;
-		}
-
-		CalculateTick(curBar - i, trade);
-		_lastPrice = trade.Price;
-	}
-
-	protected override void OnCalculate(int bar, decimal value)
-	{
-		if (bar is 0 && UsePrevClose)
-			return;
-
-		if (!UsePrevClose)
-		{
-			if (_isFinishRecalculate)
-				return;
-		}
-		else
-			bar--;
-
-		var newBar = _lastBar != bar;
-		_lastBar = bar;
-
-		if (bar < _targetBar || !newBar)
-			return;
-
-		if (bar is 0)
-			_renderDataSeries[bar] = _lastSeriesBar;
-		else
-			OnNewBar(bar);
-
-		CalculateBar(bar);
-	}
-
-	protected override void OnRecalculate()
-	{
-		if (InstrumentInfo is null)
-			return;
-
-		_lastBar = -1;
-        _isFinishRecalculate = false;
-		_mergedLevels = new MergedClusterDictionary(PriceRange, InstrumentInfo.TickSize);
-		
-		_autoFilterValue = 0;
-		_targetBar = 0;
-
-		if (Days is 0)
-			return;
-
-		var days = 0;
-
-		for (var i = CurrentBar - 1; i >= 0; i--)
-		{
-			_targetBar = i;
-
-			if (!IsNewSession(i))
-				continue;
-
-			days++;
-
-			if (days == Days)
-				break;
-		}
-
-		_lastSeriesBar.Clear();
-		_renderDataSeries.Clear();
-
-		if (!AutoFilter)
-			_minFilterValue = MinimalFilter();
+        DenyToChangePanel = true;
+        _renderDataSeries.IsHidden = true;
+        DataSeries[0] = _renderDataSeries;
     }
 
-	//Apply autofilter
-	protected override void OnFinishRecalculate()
-	{
-		try
-		{
-			if (!AutoFilter)
-				return;
+    #endregion
 
-			var valuesList = new List<PriceSelectionValue>();
+    #region Protected methods
 
-			for (var i = 0; i < _renderDataSeries.Count; i++)
-			{
-				if (_renderDataSeries[i].Count is 0)
-					continue;
+    protected override void OnInitialize()
+    {
+        _maxFilter.PropertyChanged += MaxMinFilter_PropertyChanged;
+        _minFilter.PropertyChanged += MaxMinFilter_PropertyChanged;
+        PipsFromHigh.PropertyChanged += Filter_PropertyChanged;
+        PipsFromLow.PropertyChanged += Filter_PropertyChanged;
 
-				valuesList.AddRange(_renderDataSeries[i]);
-			}
+        MinCandleHeight.PropertyChanged += Filter_PropertyChanged;
+        MaxCandleHeight.PropertyChanged += Filter_PropertyChanged;
+        MinCandleBodyHeight.PropertyChanged += Filter_PropertyChanged;
+        MaxCandleBodyHeight.PropertyChanged += Filter_PropertyChanged;
+    }
 
-			if (valuesList.Count is 0)
-				return;
+    protected override void OnNewTrade(MarketDataArg trade)
+    {
+        if (!_isFinishRecalculate || UsePrevClose)
+            return;
 
-			valuesList = valuesList.OrderByDescending(x => (decimal)x.Context).ToList();
+        var curBar = CurrentBar - 1;
 
-			_autoFilterValue = valuesList.Count <= 10
-				? (decimal)valuesList.Last().Context
-				: (decimal)valuesList.Skip(10).First().Context;
+        var i = 0;
 
-			//Set autofilter value to see it in minimal filter value
-			MinimumFilter.Value = _autoFilterValue;
-			_minFilterValue     = MinimalFilter();
+        while (i < curBar)
+        {
+            if (trade.Time < GetCandle(curBar - i).Time)
+            {
+                i++;
+                continue;
+            }
 
-			for (var i = 0; i < _renderDataSeries.Count; i++)
-			{
-				if (_renderDataSeries[i].Count is 0)
-					continue;
+            break;
+        }
 
-				_renderDataSeries[i].RemoveAll(x => (decimal)x.Context < _autoFilterValue);
+        if (_lastBar != curBar - i)
+        {
+            OnNewBar(curBar - i);
+            _lastBar = curBar - i;
+        }
 
-				_renderDataSeries[i].ForEach(l =>
-				{
-					var clusterSize = FixedSizes ? _size : (int)((decimal)l.Context * _size / _minFilterValue);
+        CalculateTick(curBar - i, trade);
+        _lastPrice = trade.Price;
+    }
 
-					if (!FixedSizes)
-					{
-						clusterSize = Math.Min(clusterSize, MaxSize);
-						clusterSize = Math.Max(clusterSize, MinSize);
-					}
+    protected override void OnCalculate(int bar, decimal value)
+    {
+        if (bar is 0 && UsePrevClose)
+            return;
+
+        if (!UsePrevClose)
+        {
+            if (_isFinishRecalculate)
+                return;
+        }
+        else
+            bar--;
+
+        var newBar = _lastBar != bar;
+        _lastBar = bar;
+
+        if (bar < _targetBar || !newBar)
+            return;
+
+        if (bar is 0)
+            _renderDataSeries[bar] = _lastSeriesBar;
+        else
+            OnNewBar(bar);
+
+        CalculateBar(bar);
+    }
+
+    protected override void OnRecalculate()
+    {
+        if (InstrumentInfo is null)
+            return;
+
+        _lastBar = -1;
+        _isFinishRecalculate = false;
+        _mergedLevels = new MergedClusterDictionary(PriceRange, InstrumentInfo.TickSize);
+
+        _autoFilterValue = 0;
+        _targetBar = 0;
+
+        if (Days is 0)
+            return;
+
+        var days = 0;
+
+        for (var i = CurrentBar - 1; i >= 0; i--)
+        {
+            _targetBar = i;
+
+            if (!IsNewSession(i))
+                continue;
+
+            days++;
+
+            if (days == Days)
+                break;
+        }
+
+        _lastSeriesBar.Clear();
+        _renderDataSeries.Clear();
+
+        if (!AutoFilter)
+            _minFilterValue = MinimalFilter();
+    }
+
+    //Apply autofilter
+    protected override void OnFinishRecalculate()
+    {
+        try
+        {
+            if (!AutoFilter)
+                return;
+
+            var valuesList = new List<PriceSelectionValue>();
+
+            for (var i = 0; i < _renderDataSeries.Count; i++)
+            {
+                if (_renderDataSeries[i].Count is 0)
+                    continue;
+
+                valuesList.AddRange(_renderDataSeries[i]);
+            }
+
+            if (valuesList.Count is 0)
+                return;
+
+            valuesList = valuesList.OrderByDescending(x => (decimal)x.Context).ToList();
+
+            _autoFilterValue = valuesList.Count <= 10
+                ? (decimal)valuesList.Last().Context
+                : (decimal)valuesList.Skip(10).First().Context;
+
+            //Set autofilter value to see it in minimal filter value
+            MinimumFilter.Value = _autoFilterValue;
+            _minFilterValue = MinimalFilter();
+
+            for (var i = 0; i < _renderDataSeries.Count; i++)
+            {
+                if (_renderDataSeries[i].Count is 0)
+                    continue;
+
+                _renderDataSeries[i].RemoveAll(x => (decimal)x.Context < _autoFilterValue);
+
+                _renderDataSeries[i].ForEach(l =>
+                {
+                    var clusterSize = FixedSizes ? _size : (int)((decimal)l.Context * _size / _minFilterValue);
+
+                    if (!FixedSizes)
+                    {
+                        clusterSize = Math.Min(clusterSize, MaxSize);
+                        clusterSize = Math.Max(clusterSize, MinSize);
+                    }
 
 					l.Size = clusterSize;
 				});
@@ -270,378 +270,414 @@ public partial class ClusterSearch : Indicator
 		{
 			OnChangeProperty(nameof(MinimumFilter));
 
-			_isFinishRecalculate = true;
-		}
-	}
-
-	#endregion
-
-	#region Private methods
-
-	private void CalculateTick(int bar, MarketDataArg trade)
-	{
-		var priceLevel = _clustersCache.GetOrAdd((bar, trade.Price), () => new CustomVolumeInfo(trade.Price));
-
-		switch (trade.Direction)
-		{
-			case TradeDirection.Buy:
-				priceLevel.Ask += trade.Volume;
-				break;
-			case TradeDirection.Sell:
-				priceLevel.Bid += trade.Volume;
-				break;
-			case TradeDirection.Between:
-			default:
-				priceLevel.Between += trade.Volume;
-				break;
-		}
-
-		priceLevel.Volume += trade.Volume;
-		priceLevel.Ticks++;
-		UpdateLevelCache(bar, trade);
-
-		var candle = GetCandle(bar);
-
-		var startPrice = Math.Min(_lastPrice, trade.Price);
-		startPrice = Math.Max(candle.Low, startPrice - (PriceRange - 1) * InstrumentInfo.TickSize);
-
-		var endPrice = Math.Max(_lastPrice, trade.Price);
-		endPrice = Math.Min(candle.High - (PriceRange - 1) * InstrumentInfo.TickSize, endPrice);
-
-		for (var price = startPrice; price <= endPrice; price += InstrumentInfo.TickSize)
-		{
-			if (CheckCluster(bar, price))
-				continue;
-
-			_validVolumeLevels.Remove(price);
-			RemoveOldSelection(bar, trade.Price);
-		}
-
-
-		if (!CheckBarFormation(candle))
-		{
-			_renderDataSeries[bar] = new SyncList<PriceSelectionValue>();
-			return;
-		}
-
-		_renderDataSeries[bar] = _lastSeriesBar;
-
-		var ranges = GetPriceRanges(bar, endPrice);
-
-		var changedDirection = false;
-
-		if (_lastPrice != trade.Price)
-		{
-			changedDirection = _lastPrice >= candle.Open && trade.Price < candle.Open
-				||
-				_lastPrice <= candle.Open && trade.Price > candle.Open
-				||
-				_lastPrice == candle.Open;
-		}
-
-		foreach (var range in ranges)
-		{
-			if ((trade.Price < range.From || trade.Price > range.To) && !changedDirection)
-				continue;
-
-			RemoveOldSelection(bar, trade.Price);
-			CheckPriceRange(bar, range.From, range.To);
-			break;
-		}
-
-		if (_lastPrice == trade.Price)
-			return;
-
-		if (PriceLoc is not PriceLocation.Any)
-			UpdatePriceLocationValues(bar, trade);
-
-		if (PipsFromHigh.Enabled)
-		{
-			var lowValue = candle.High - InstrumentInfo.TickSize * PipsFromHigh.Value;
-
-			if (lowValue > candle.Low)
-			{
-				for (var i = _lastSeriesBar.Count - 1; i >= 0; i--)
-				{
-					var item = _lastSeriesBar[i];
-
-					if (item.MinimumPrice >= lowValue)
-						break;
-
-					_lastSeriesBar.RemoveAt(i);
-				}
-			}
-		}
-
-		if (PipsFromLow.Enabled)
-		{
-			var highValue = candle.Low + InstrumentInfo.TickSize * PipsFromLow.Value;
-
-			if (highValue < candle.High)
-			{
-				for (var i = _lastSeriesBar.Count - 1; i >= 0; i--)
-				{
-					var item = _lastSeriesBar[i];
-
-					if (item.MinimumPrice <= highValue)
-						break;
-
-					_lastSeriesBar.RemoveAt(i);
-				}
-			}
-		}
-	}
-
-	private void OnNewBar(int bar)
-	{
-		_mergedLevels.Clear();
-		_validVolumeLevels.Clear();
-
-		if (CheckBarFormation(GetCandle(bar - 1)))
-		{
-			var lastBar = _lastSeriesBar.Select(p => p.MemberwiseClone()).ToArray();
-			_renderDataSeries[bar - 1] = new SyncList<PriceSelectionValue>(lastBar);
-		}
-		else
-			_renderDataSeries[bar - 1] = [];
-
-		_lastSeriesBar.Clear();
-		_renderDataSeries[bar] = _lastSeriesBar;
-
-		_lastPrice = GetCandle(bar).Close;
-		_alertPrices.Clear();
-	}
-
-	private void MaxMinFilter_PropertyChanged(object sender, PropertyChangedEventArgs e)
-	{
-		Filter_PropertyChanged(sender, e);
-	}
-
-	//Calculate all clusters on current bar
-	private void CalculateBar(int bar)
-	{
-		UpdateCumulativeCachePerBar(bar);
-
-		var candle = GetCandle(bar);
-
-		var endPrice = Math.Max(candle.Low, candle.High - (PriceRange - 1) * InstrumentInfo.TickSize);
-
-		for (var price = candle.Low; price <= endPrice; price += InstrumentInfo.TickSize)
-		{
-			if (!CheckCluster(bar, price))
-				_validVolumeLevels.Remove(price);
-		}
-
-		if (_validVolumeLevels.Count is 0)
-			return;
-
-		if (!CheckBarFormation(candle))
-			return;
-
-		var ranges = GetPriceRanges(bar, endPrice);
-
-		foreach (var range in ranges)
-			CheckPriceRange(bar, range.From, range.To);
-	}
-
-	/// <summary>
-	///     Get price ranges on bar that are passed candle filters
-	/// </summary>
-	/// <param name="bar">Bar number</param>
-	/// <param name="endPrice">High price minus price range value</param>
-	/// <returns></returns>
-	private List<(decimal From, decimal To)> GetPriceRanges(int bar, decimal endPrice)
-	{
-		var ranges = new List<(decimal From, decimal To)>();
-		var candle = GetCandle(bar);
-
-		var maxPrice = PipsFromLow.Enabled
-			? candle.Low + PipsFromLow.Value * InstrumentInfo.TickSize
-			: candle.High;
-
-		var minPrice = PipsFromHigh.Enabled
-			? candle.High - PipsFromHigh.Value * InstrumentInfo.TickSize
-			: candle.Low;
-
-		if (minPrice > maxPrice)
-			return ranges;
-
-		maxPrice = Math.Min(candle.High, maxPrice);
-		minPrice = Math.Max(candle.Low, minPrice);
-
-		switch (PriceLoc)
-		{
-			case PriceLocation.AtHigh when maxPrice != candle.High:
-			case PriceLocation.AtLow when minPrice != candle.Low:
-			case PriceLocation.AtHighOrLow when maxPrice != candle.High && minPrice != candle.Low:
-				return ranges;
-
-			case PriceLocation.Any:
-				return [(minPrice, maxPrice)];
-
-			case PriceLocation.AtHighOrLow:
-			case PriceLocation.AtHigh:
-			case PriceLocation.AtLow:
-			{
-				if (PriceLoc is PriceLocation.AtHighOrLow or PriceLocation.AtHigh)
-				{
-					if (maxPrice >= endPrice)
-						ranges.Add((endPrice, endPrice));
-				}
-
-				if (PriceLoc is PriceLocation.AtHighOrLow or PriceLocation.AtLow)
-				{
-					if (minPrice <= candle.Low)
-						ranges.Add((candle.Low, candle.Low));
-				}
-
-				return ranges;
-			}
-			case PriceLocation.AtUpperLowerWick or PriceLocation.UpperWick or PriceLocation.LowerWick or PriceLocation.Body:
-			{
-				var maxBody = Math.Max(candle.Close, candle.Open);
-				var minBody = Math.Min(candle.Close, candle.Open);
-
-				if (PriceLoc is PriceLocation.Body)
-				{
-					maxBody = Math.Min(maxBody, maxPrice);
-					minBody = Math.Max(minBody, minPrice);
-					return [(minBody, maxBody)];
-				}
-
-				if (PriceLoc is PriceLocation.UpperWick or PriceLocation.AtUpperLowerWick)
-					ranges.Add((maxBody + InstrumentInfo.TickSize, maxPrice));
-
-				if (PriceLoc is PriceLocation.LowerWick or PriceLocation.AtUpperLowerWick)
-					ranges.Add((minPrice, minBody - InstrumentInfo.TickSize));
-
-				return ranges;
-			}
-		}
-
-		return ranges;
-	}
-
-	//Check valid clusters on filtered price range and draw it
-	private void CheckPriceRange(int bar, decimal from, decimal to)
-	{
-		for (var price = from; price <= to; price += InstrumentInfo.TickSize)
-			CheckPriceRange(bar, price);
-	}
-
-	private void CheckPriceRange(int bar, decimal price)
-	{
-		if (_validVolumeLevels.TryGetValue(price, out var info))
-			PlaceToDataSeries(bar, info);
-		else
-			RemoveOldSelection(bar, price);
-	}
-
-	//Compare current candle with current candles filters
-	private bool CheckBarFormation(IndicatorCandle candle)
-	{
-		if ((CandleDir is CandleDirection.Bearish && candle.Close >= candle.Open)
-		    ||
-		    (CandleDir is CandleDirection.Bullish && candle.Close <= candle.Open)
-		    ||
-		    (CandleDir is CandleDirection.Neutral && candle.Close != candle.Open))
-			return false;
-
-		if (UseTimeFilter)
-		{
-			var time = candle.Time.AddHours(InstrumentInfo.TimeZone);
-
-			if (TimeFrom < TimeTo)
-			{
-				if (time < time.Date + TimeFrom)
-					return false;
-
-				if (time > time.Date + TimeTo)
-					return false;
-			}
-			else
-			{
-				if (time < time.Date + TimeFrom && time > time.Date + TimeTo)
-					return false;
-			}
-		}
-
-		if (MinCandleHeight.Enabled || MaxCandleHeight.Enabled)
-		{
-			var height = (candle.High - candle.Low) / InstrumentInfo.TickSize + 1;
-
-			if (MinCandleHeight.Enabled && height < MinCandleHeight.Value)
-				return false;
-
-			if (MaxCandleHeight.Enabled && height > MaxCandleHeight.Value)
-				return false;
-		}
-
-		if (MinCandleBodyHeight.Enabled || MaxCandleBodyHeight.Enabled)
-		{
-			var bHeight = Math.Abs(candle.Close - candle.Open) / InstrumentInfo.TickSize + 1;
-
-			if (MinCandleBodyHeight.Enabled && bHeight < MinCandleBodyHeight.Value)
-				return false;
-
-			if (MaxCandleBodyHeight.Enabled && bHeight > MaxCandleBodyHeight.Value)
-				return false;
-		}
-
-		return true;
-	}
-
-	//Merge wide clusters if price levels is more then 1
-	//Compare clusters values with volume filters
-	private bool CheckCluster(int bar, decimal price)
-	{
-		var endPrice = price + (PriceRange - 1) * InstrumentInfo.TickSize;
-
-		var ask = 0m;
-		var bid = 0m;
-		var between = 0m;
-		var volume = 0m;
-		var ticks = 0;
-
-		for (var iPrice = price; iPrice <= endPrice; iPrice += InstrumentInfo.TickSize)
-		{
-			if (!_mergedLevels.TryGetValue(iPrice, out var level))
-				continue;
-
-			ask += level.Ask;
-			bid += level.Bid;
-			between += level.Between;
-			volume += level.Volume;
-			ticks += level.Ticks;
-		}
-
-		if (CalcType is CalcMode.MaxVolume && price != _mergedLevels.PocPrice)
-			return false;
-
-		var delta = ask - bid;
-		var avgTrade = ticks is 0 ? 0 : volume / ticks;
-		var value = CalcType switch
-		{
-			CalcMode.Bid => bid,
-			CalcMode.Ask => ask,
-			CalcMode.Delta => delta,
-			CalcMode.Volume or CalcMode.MaxVolume => volume,
-			CalcMode.Tick => ticks,
-			_ => 0
-		};
-
-        // =======================================================================
-        // Diagonal Imbalance over GROUPED windows (exclusive pipeline)
-        // Upper window (ASK): [price .. endPrice]  -> already aggregated as 'ask'
-        // Lower window (BID): [price - N*step .. price - step] (same size, aligned to upper START, shifted down 1 tick)
-        // Stacking: advance by GROUPS of N ticks (block-wise), not by single ticks.
-        // =======================================================================
-        if (CalcType == CalcMode.DiagonalImbalance)
+            _isFinishRecalculate = true;
+        }
+    }
+
+    #endregion
+
+    #region Private methods
+
+    private void CalculateTick(int bar, MarketDataArg trade)
+    {
+        var priceLevel = _clustersCache.GetOrAdd((bar, trade.Price), () => new CustomVolumeInfo(trade.Price));
+
+        switch (trade.Direction)
+        {
+            case TradeDirection.Buy:
+                priceLevel.Ask += trade.Volume;
+                break;
+            case TradeDirection.Sell:
+                priceLevel.Bid += trade.Volume;
+                break;
+            case TradeDirection.Between:
+            default:
+                priceLevel.Between += trade.Volume;
+                break;
+        }
+
+        priceLevel.Volume += trade.Volume;
+        priceLevel.Ticks++;
+        UpdateLevelCache(bar, trade);
+
+        var candle = GetCandle(bar);
+
+        var startPrice = Math.Min(_lastPrice, trade.Price);
+        startPrice = Math.Max(candle.Low, startPrice - (PriceRange - 1) * InstrumentInfo.TickSize);
+
+        var endPrice = Math.Max(_lastPrice, trade.Price);
+        endPrice = Math.Min(candle.High - (PriceRange - 1) * InstrumentInfo.TickSize, endPrice);
+
+        for (var price = startPrice; price <= endPrice; price += InstrumentInfo.TickSize)
+        {
+            if (CheckCluster(bar, price))
+                continue;
+
+            _validVolumeLevels.Remove(price);
+            RemoveOldSelection(bar, trade.Price);
+        }
+
+
+        if (!CheckBarFormation(candle))
+        {
+            _renderDataSeries[bar] = new SyncList<PriceSelectionValue>();
+            return;
+        }
+
+        _renderDataSeries[bar] = _lastSeriesBar;
+
+        var ranges = GetPriceRanges(bar, endPrice);
+
+        var changedDirection = false;
+
+        if (_lastPrice != trade.Price)
+        {
+            changedDirection = _lastPrice >= candle.Open && trade.Price < candle.Open
+                ||
+                _lastPrice <= candle.Open && trade.Price > candle.Open
+                ||
+                _lastPrice == candle.Open;
+        }
+
+        foreach (var range in ranges)
+        {
+            if ((trade.Price < range.From || trade.Price > range.To) && !changedDirection)
+                continue;
+
+            RemoveOldSelection(bar, trade.Price);
+            CheckPriceRange(bar, range.From, range.To);
+            break;
+        }
+
+        if (_lastPrice == trade.Price)
+            return;
+
+        if (PriceLoc is not PriceLocation.Any)
+            UpdatePriceLocationValues(bar, trade);
+
+        if (PipsFromHigh.Enabled)
+        {
+            var lowValue = candle.High - InstrumentInfo.TickSize * PipsFromHigh.Value;
+
+            if (lowValue > candle.Low)
+            {
+                for (var i = _lastSeriesBar.Count - 1; i >= 0; i--)
+                {
+                    var item = _lastSeriesBar[i];
+
+                    if (item.MinimumPrice >= lowValue)
+                        break;
+
+                    _lastSeriesBar.RemoveAt(i);
+                }
+            }
+        }
+
+        if (PipsFromLow.Enabled)
+        {
+            var highValue = candle.Low + InstrumentInfo.TickSize * PipsFromLow.Value;
+
+            if (highValue < candle.High)
+            {
+                for (var i = _lastSeriesBar.Count - 1; i >= 0; i--)
+                {
+                    var item = _lastSeriesBar[i];
+
+                    if (item.MinimumPrice <= highValue)
+                        break;
+
+                    _lastSeriesBar.RemoveAt(i);
+                }
+            }
+        }
+    }
+
+    private void OnNewBar(int bar)
+    {
+        _mergedLevels.Clear();
+        _validVolumeLevels.Clear();
+
+        if (CheckBarFormation(GetCandle(bar - 1)))
+        {
+            var lastBar = _lastSeriesBar.Select(p => p.MemberwiseClone()).ToArray();
+            _renderDataSeries[bar - 1] = new SyncList<PriceSelectionValue>(lastBar);
+        }
+        else
+            _renderDataSeries[bar - 1] = [];
+
+        _lastSeriesBar.Clear();
+        _renderDataSeries[bar] = _lastSeriesBar;
+
+        _lastPrice = GetCandle(bar).Close;
+        _alertPrices.Clear();
+    }
+
+    private void MaxMinFilter_PropertyChanged(object sender, PropertyChangedEventArgs e)
+    {
+        Filter_PropertyChanged(sender, e);
+    }
+
+    //Calculate all clusters on current bar
+    private void CalculateBar(int bar)
+    {
+        UpdateCumulativeCachePerBar(bar);
+
+        var candle = GetCandle(bar);
+
+        var endPrice = Math.Max(candle.Low, candle.High - (PriceRange - 1) * InstrumentInfo.TickSize);
+
+        for (var price = candle.Low; price <= endPrice; price += InstrumentInfo.TickSize)
+        {
+            if (!CheckCluster(bar, price))
+                _validVolumeLevels.Remove(price);
+        }
+
+        if (_validVolumeLevels.Count is 0)
+            return;
+
+        if (!CheckBarFormation(candle))
+            return;
+
+        var ranges = GetPriceRanges(bar, endPrice);
+
+        foreach (var range in ranges)
+            CheckPriceRange(bar, range.From, range.To);
+    }
+
+    /// <summary>
+    ///     Get price ranges on bar that are passed candle filters
+    /// </summary>
+    /// <param name="bar">Bar number</param>
+    /// <param name="endPrice">High price minus price range value</param>
+    /// <returns></returns>
+    private List<(decimal From, decimal To)> GetPriceRanges(int bar, decimal endPrice)
+    {
+        var ranges = new List<(decimal From, decimal To)>();
+        var candle = GetCandle(bar);
+
+        var maxPrice = PipsFromLow.Enabled
+            ? candle.Low + PipsFromLow.Value * InstrumentInfo.TickSize
+            : candle.High;
+
+        var minPrice = PipsFromHigh.Enabled
+            ? candle.High - PipsFromHigh.Value * InstrumentInfo.TickSize
+            : candle.Low;
+
+        if (minPrice > maxPrice)
+            return ranges;
+
+        maxPrice = Math.Min(candle.High, maxPrice);
+        minPrice = Math.Max(candle.Low, minPrice);
+
+        switch (PriceLoc)
+        {
+            case PriceLocation.AtHigh when maxPrice != candle.High:
+            case PriceLocation.AtLow when minPrice != candle.Low:
+            case PriceLocation.AtHighOrLow when maxPrice != candle.High && minPrice != candle.Low:
+                return ranges;
+
+            case PriceLocation.Any:
+                return [(minPrice, maxPrice)];
+
+            case PriceLocation.AtHighOrLow:
+            case PriceLocation.AtHigh:
+            case PriceLocation.AtLow:
+                {
+                    if (PriceLoc is PriceLocation.AtHighOrLow or PriceLocation.AtHigh)
+                    {
+                        if (maxPrice >= endPrice)
+                            ranges.Add((endPrice, endPrice));
+                    }
+
+                    if (PriceLoc is PriceLocation.AtHighOrLow or PriceLocation.AtLow)
+                    {
+                        if (minPrice <= candle.Low)
+                            ranges.Add((candle.Low, candle.Low));
+                    }
+
+                    return ranges;
+                }
+            case PriceLocation.AtUpperLowerWick or PriceLocation.UpperWick or PriceLocation.LowerWick or PriceLocation.Body:
+                {
+                    var maxBody = Math.Max(candle.Close, candle.Open);
+                    var minBody = Math.Min(candle.Close, candle.Open);
+
+                    if (PriceLoc is PriceLocation.Body)
+                    {
+                        maxBody = Math.Min(maxBody, maxPrice);
+                        minBody = Math.Max(minBody, minPrice);
+                        return [(minBody, maxBody)];
+                    }
+
+                    if (PriceLoc is PriceLocation.UpperWick or PriceLocation.AtUpperLowerWick)
+                        ranges.Add((maxBody + InstrumentInfo.TickSize, maxPrice));
+
+                    if (PriceLoc is PriceLocation.LowerWick or PriceLocation.AtUpperLowerWick)
+                        ranges.Add((minPrice, minBody - InstrumentInfo.TickSize));
+
+                    return ranges;
+                }
+        }
+
+        return ranges;
+    }
+
+    //Check valid clusters on filtered price range and draw it
+    private void CheckPriceRange(int bar, decimal from, decimal to)
+    {
+        for (var price = from; price <= to; price += InstrumentInfo.TickSize)
+            CheckPriceRange(bar, price);
+    }
+
+    private void CheckPriceRange(int bar, decimal price)
+    {
+        if (_validVolumeLevels.TryGetValue(price, out var info))
+            PlaceToDataSeries(bar, info);
+        else
+            RemoveOldSelection(bar, price);
+    }
+
+    //Compare current candle with current candles filters
+    private bool CheckBarFormation(IndicatorCandle candle)
+    {
+        if ((CandleDir is CandleDirection.Bearish && candle.Close >= candle.Open)
+            ||
+            (CandleDir is CandleDirection.Bullish && candle.Close <= candle.Open)
+            ||
+            (CandleDir is CandleDirection.Neutral && candle.Close != candle.Open))
+            return false;
+
+        if (UseTimeFilter)
+        {
+            var time = candle.Time.AddHours(InstrumentInfo.TimeZone);
+
+            if (TimeFrom < TimeTo)
+            {
+                if (time < time.Date + TimeFrom)
+                    return false;
+
+                if (time > time.Date + TimeTo)
+                    return false;
+            }
+            else
+            {
+                if (time < time.Date + TimeFrom && time > time.Date + TimeTo)
+                    return false;
+            }
+        }
+
+        if (MinCandleHeight.Enabled || MaxCandleHeight.Enabled)
+        {
+            var height = (candle.High - candle.Low) / InstrumentInfo.TickSize + 1;
+
+            if (MinCandleHeight.Enabled && height < MinCandleHeight.Value)
+                return false;
+
+            if (MaxCandleHeight.Enabled && height > MaxCandleHeight.Value)
+                return false;
+        }
+
+        if (MinCandleBodyHeight.Enabled || MaxCandleBodyHeight.Enabled)
+        {
+            var bHeight = Math.Abs(candle.Close - candle.Open) / InstrumentInfo.TickSize + 1;
+
+            if (MinCandleBodyHeight.Enabled && bHeight < MinCandleBodyHeight.Value)
+                return false;
+
+            if (MaxCandleBodyHeight.Enabled && bHeight > MaxCandleBodyHeight.Value)
+                return false;
+        }
+
+        return true;
+    }
+
+    //Merge wide clusters if price levels is more then 1
+    //Compare clusters values with volume filters
+    private bool CheckCluster(int bar, decimal price)
+    {
+        var endPrice = price + (PriceRange - 1) * InstrumentInfo.TickSize;
+
+        var ask = 0m;
+        var bid = 0m;
+        var between = 0m;
+        var volume = 0m;
+        var ticks = 0;
+
+        // -----------------------------------------------------------------------
+        // (A) Diagonal Imbalance tick-by-tick (N = 1), stacked by 1 tick
+        // Run this BEFORE aggregating ask/bid/... when price grouping is OFF.
+        // If it fails, exit early; if it passes, continue with the normal flow
+        // (aggregation, common filters) and finish at the usual SaveLevel().
+        // -----------------------------------------------------------------------
+        if (CalcType == CalcMode.DiagonalImbalance && !GroupDiagonalImbalances)
         {
             var step = InstrumentInfo.TickSize;
-            var nTicks = PriceRange; // group size (rows in merged window)
 
-            // 1) First group's LOWER window uses START alignment: [price - N*step .. price - step]
+            int stacked = 0;
+            bool? firstIsBuy = null;
+            var p = price;
+
+            while (stacked < ImbalanceStackedRange)
+            {
+                if (!_mergedLevels.TryGetValue(p, out var up) ||
+                    !_mergedLevels.TryGetValue(p - step, out var low))
+                    break;
+
+                bool buy =
+                    low.Bid > 0 &&
+                    (up.Ask / low.Bid) >= ImbalanceRatio &&
+                    (up.Ask - low.Bid) >= MinVolumeDifference &&
+                    up.Ask >= MinDominantVolume;
+
+                bool sell =
+                    up.Ask > 0 &&
+                    (low.Bid / up.Ask) >= ImbalanceRatio &&
+                    (low.Bid - up.Ask) >= MinVolumeDifference &&
+                    low.Bid >= MinDominantVolume;
+
+                if (!(buy || sell))
+                    break;
+
+                // Lock direction on first valid pair and keep it consistent across the stack
+                if (firstIsBuy is null) firstIsBuy = buy;
+                else if (firstIsBuy.Value != buy) break;
+
+                stacked++;
+                p += step; // advance by one price row
+            }
+
+            if (stacked < ImbalanceStackedRange)
+                return false;
+
+            // Passed tick-level DI → continue to aggregate [price..endPrice],
+            // apply common filters, and SaveLevel() at the end as usual.
+        }
+
+        for (var iPrice = price; iPrice <= endPrice; iPrice += InstrumentInfo.TickSize)
+        {
+            if (!_mergedLevels.TryGetValue(iPrice, out var level))
+                continue;
+
+            ask += level.Ask;
+            bid += level.Bid;
+            between += level.Between;
+            volume += level.Volume;
+            ticks += level.Ticks;
+        }
+
+        // -----------------------------------------------------------------------
+        // (B) Diagonal Imbalance over GROUPED windows (N = PriceRange), stacked by groups
+        // Run this AFTER aggregating ask/bid/... when price grouping is ON.
+        // If it fails, exit early; if it passes, return SaveLevel() immediately
+        // (exclusive pipeline), preserving the behavior of your original function.
+        // -----------------------------------------------------------------------
+        if (CalcType == CalcMode.DiagonalImbalance && GroupDiagonalImbalances)
+        {
+            var step = InstrumentInfo.TickSize;
+            var nTicks = PriceRange; // window size (number of price rows)
+
+            // Lower window aligned to the START of the upper and shifted down by 1 tick:
+            // [price - N*step .. price - step]
             var lowerStart = price - nTicks * step; // inclusive
             var lowerEnd = price - step;          // inclusive
 
@@ -652,29 +688,31 @@ public partial class ClusterSearch : Indicator
                     lowerBid += lv.Bid;
             }
 
-            // 2) Decide BUY/SELL diagonal imbalance with grouped windows
-            bool buy = lowerBid > 0
-                        && (ask / lowerBid) >= ImbalanceRatio
-                        && (ask - lowerBid) >= MinVolumeDifference
-                        && ask >= MinDominantVolume;
+            // Base window DI decision
+            bool buy =
+                lowerBid > 0 &&
+                (ask / lowerBid) >= ImbalanceRatio &&
+                (ask - lowerBid) >= MinVolumeDifference &&
+                ask >= MinDominantVolume;
 
-            bool sell = ask > 0
-                        && (lowerBid / ask) >= ImbalanceRatio
-                        && (lowerBid - ask) >= MinVolumeDifference
-                        && lowerBid >= MinDominantVolume;
+            bool sell =
+                ask > 0 &&
+                (lowerBid / ask) >= ImbalanceRatio &&
+                (lowerBid - ask) >= MinVolumeDifference &&
+                lowerBid >= MinDominantVolume;
 
             if (!(buy || sell))
                 return false;
 
-            // 3) Stacking by GROUPS: slide both windows UP by exactly N ticks per step
-            var stacked = 1;
+            // Stacking by GROUPS of N ticks: slide both windows by exactly N rows per step
+            int stacked = 1;
             for (int g = 1; g < ImbalanceStackedRange; g++)
             {
-                // Upper group g
+                // Upper window for group g
                 var upStart_g = price + g * nTicks * step;
                 var upEnd_g = endPrice + g * nTicks * step;
 
-                // Lower group g aligned to the START of the upper g, shifted down 1 tick, same size N:
+                // Lower window aligned to the START of the upper g, shifted down 1 tick:
                 // [upStart_g - N*step .. upStart_g - step]
                 var lowStart_g = upStart_g - nTicks * step;
                 var lowEnd_g = upStart_g - step;
@@ -695,15 +733,17 @@ public partial class ClusterSearch : Indicator
                         lowBid_g += lvLo.Bid;
                 }
 
-                bool nextBuy = lowBid_g > 0
-                                 && (upAsk_g / lowBid_g) >= ImbalanceRatio
-                                 && (upAsk_g - lowBid_g) >= MinVolumeDifference
-                                 && upAsk_g >= MinDominantVolume;
+                bool nextBuy =
+                    lowBid_g > 0 &&
+                    (upAsk_g / lowBid_g) >= ImbalanceRatio &&
+                    (upAsk_g - lowBid_g) >= MinVolumeDifference &&
+                    upAsk_g >= MinDominantVolume;
 
-                bool nextSell = upAsk_g > 0
-                                 && (lowBid_g / upAsk_g) >= ImbalanceRatio
-                                 && (lowBid_g - upAsk_g) >= MinVolumeDifference
-                                 && lowBid_g >= MinDominantVolume;
+                bool nextSell =
+                    upAsk_g > 0 &&
+                    (lowBid_g / upAsk_g) >= ImbalanceRatio &&
+                    (lowBid_g - upAsk_g) >= MinVolumeDifference &&
+                    lowBid_g >= MinDominantVolume;
 
                 if ((buy && nextBuy) || (sell && nextSell))
                     stacked++;
@@ -714,68 +754,96 @@ public partial class ClusterSearch : Indicator
             if (stacked < ImbalanceStackedRange)
                 return false;
 
-            // Keep current aggregated values for the upper window and mark it as valid.
+            // Ensure marker size reflects the dominant side used by the diagonal test.
+            // - BUY: dominant = upper window 'ask' (already in `ask`), zero-out 'bid' to avoid accidental Max()
+            // - SELL: dominant = lower window 'lowerBid' (computed earlier), zero-out 'ask'
+            if (buy)
+            {
+                bid = 0m;                  // keep `ask` as the dominant value
+            }
+            else // sell
+            {
+                ask = 0m;                  // force dominant into Bid
+                bid = lowerBid;            // use lower window Bid for sizing
+            }
+
+            // Keep current aggregated values for the current upper window and mark it as valid.
+            // Maintain original behavior: exit the function here for grouped DI.
             return SaveLevel();
         }
 
+        if (CalcType is CalcMode.MaxVolume && price != _mergedLevels.PocPrice)
+            return false;
+
+        var delta = ask - bid;
+        var avgTrade = ticks is 0 ? 0 : volume / ticks;
+        var value = CalcType switch
+        {
+            CalcMode.Bid => bid,
+            CalcMode.Ask => ask,
+            CalcMode.Delta => delta,
+            CalcMode.Volume or CalcMode.MaxVolume => volume,
+            CalcMode.Tick => ticks,
+            _ => 0
+        };
 
         if (AutoFilter)
-		{
-			if (_autoFilterValue is 0)
-				return SaveLevel();
+        {
+            if (_autoFilterValue is 0)
+                return SaveLevel();
 
-			if (value < _autoFilterValue)
-				return false;
-		}
+            if (value < _autoFilterValue)
+                return false;
+        }
 
-		if (MinimumFilter.Enabled && value < MinimumFilter.Value)
-			return false;
+        if (MinimumFilter.Enabled && value < MinimumFilter.Value)
+            return false;
 
-		if (MaximumFilter.Enabled && value > MaximumFilter.Value)
-			return false;
+        if (MaximumFilter.Enabled && value > MaximumFilter.Value)
+            return false;
 
-		if (MinAverageTrade != 0 && avgTrade < MinAverageTrade)
-			return false;
+        if (MinAverageTrade != 0 && avgTrade < MinAverageTrade)
+            return false;
 
-		if (MaxAverageTrade != 0 && avgTrade > MaxAverageTrade)
-			return false;
+        if (MaxAverageTrade != 0 && avgTrade > MaxAverageTrade)
+            return false;
 
-		if (MinPercent != 0 || MaxPercent != 0)
-		{
-			var curPerc = 100 * volume / _mergedLevels.TotalVolume;
+        if (MinPercent != 0 || MaxPercent != 0)
+        {
+            var curPerc = 100 * volume / _mergedLevels.TotalVolume;
 
-			if (curPerc < MinPercent || MaxPercent is not 0 && curPerc > MaxPercent)
-				return false;
-		}
+            if (curPerc < MinPercent || MaxPercent is not 0 && curPerc > MaxPercent)
+                return false;
+        }
 
-		if (DeltaImbalance != 0)
-		{
-			var vol = volume;
-			var askImbalance = vol is not 0
-				? ask * 100.0m / vol
-				: 0;
+        if (DeltaImbalance != 0)
+        {
+            var vol = volume;
+            var askImbalance = vol is not 0
+                ? ask * 100.0m / vol
+                : 0;
 
-			var bidImbalance = vol is not 0
-				? bid * 100.0m / vol
-				: 0;
+            var bidImbalance = vol is not 0
+                ? bid * 100.0m / vol
+                : 0;
 
-			switch (DeltaImbalance)
-			{
-				case > 0 when askImbalance < DeltaImbalance:
-				case < 0 when bidImbalance < Math.Abs(DeltaImbalance):
-					return false;
-			}
-		}
+            switch (DeltaImbalance)
+            {
+                case > 0 when askImbalance < DeltaImbalance:
+                case < 0 when bidImbalance < Math.Abs(DeltaImbalance):
+                    return false;
+            }
+        }
 
-		if (DeltaFilter != 0)
-		{
-			switch (DeltaFilter)
-			{
-				case > 0 when delta < DeltaFilter:
-				case < 0 when delta > DeltaFilter:
-					return false;
-			}
-		}
+        if (DeltaFilter != 0)
+        {
+            switch (DeltaFilter)
+            {
+                case > 0 when delta < DeltaFilter:
+                case < 0 when delta > DeltaFilter:
+                    return false;
+            }
+        }
 
 		if (CalcType is CalcMode.MaxVolume)
 		{
@@ -794,80 +862,80 @@ public partial class ClusterSearch : Indicator
 
 		return SaveLevel();
 
-		bool SaveLevel()
-		{
-			if (!_validVolumeLevels.TryGetValue(price, out var info))
-				_validVolumeLevels.Add(price, info = new CustomVolumeInfo(price));
+        bool SaveLevel()
+        {
+            if (!_validVolumeLevels.TryGetValue(price, out var info))
+                _validVolumeLevels.Add(price, info = new CustomVolumeInfo(price));
 
-			info.Ask = ask;
-			info.Bid = bid;
-			info.Between = between;
-			info.Volume = volume;
-			info.Ticks = ticks;
+            info.Ask = ask;
+            info.Bid = bid;
+            info.Between = between;
+            info.Volume = volume;
+            info.Ticks = ticks;
 
-			return true;
-		}
-	}
+            return true;
+        }
+    }
 
-	//Create horizontal merged clusters on all current bar prices
-	private void UpdateCumulativeCachePerBar(int bar)
-	{
-		var candle = GetCandle(bar);
-		
-		for (var iPrice = candle.Low; iPrice <= candle.High; iPrice += InstrumentInfo.TickSize)
-			CreateLevelCache(bar, iPrice);
-	}
+    //Create horizontal merged clusters on all current bar prices
+    private void UpdateCumulativeCachePerBar(int bar)
+    {
+        var candle = GetCandle(bar);
 
-	//Create horizontal merged clusters
-	private void CreateLevelCache(int bar, decimal price)
-	{
-		var level = new CustomVolumeInfo(price);
-		var endBar = Math.Max(0, bar - (BarsRange - 1));
+        for (var iPrice = candle.Low; iPrice <= candle.High; iPrice += InstrumentInfo.TickSize)
+            CreateLevelCache(bar, iPrice);
+    }
 
-		for (var i = bar; i >= endBar; i--)
-		{
-			var iCandle = GetCandle(i);
-			var cluster = _clustersCache.GetOrAdd((i, price), () => iCandle.GetPriceVolumeInfo(price), true);
+    //Create horizontal merged clusters
+    private void CreateLevelCache(int bar, decimal price)
+    {
+        var level = new CustomVolumeInfo(price);
+        var endBar = Math.Max(0, bar - (BarsRange - 1));
 
-			if (cluster is null)
-				continue;
+        for (var i = bar; i >= endBar; i--)
+        {
+            var iCandle = GetCandle(i);
+            var cluster = _clustersCache.GetOrAdd((i, price), () => iCandle.GetPriceVolumeInfo(price), true);
 
-			level.Ask += cluster.Ask;
-			level.Between += cluster.Between;
-			level.Bid += cluster.Bid;
-			level.Ticks += cluster.Ticks;
-			level.Volume += cluster.Volume;
-		}
+            if (cluster is null)
+                continue;
 
-		_mergedLevels[price] = level;
-	}
+            level.Ask += cluster.Ask;
+            level.Between += cluster.Between;
+            level.Bid += cluster.Bid;
+            level.Ticks += cluster.Ticks;
+            level.Volume += cluster.Volume;
+        }
 
-	//Increment trade data to existing cluster
-	private void UpdateLevelCache(int bar, MarketDataArg trade)
-	{
-		if (!_mergedLevels.TryGetValue(trade.Price, out var level))
-		{
-			level = new CustomVolumeInfo(trade.Price);
-			var startBar = Math.Max(0, bar - 1);
-			var endBar = Math.Max(0, bar - (BarsRange - 1));
+        _mergedLevels[price] = level;
+    }
 
-			for (var i = startBar; i >= endBar; i--)
-			{
-				var iCandle = GetCandle(i);
-				var cluster = _clustersCache.GetOrAdd((i, trade.Price), () => iCandle.GetPriceVolumeInfo(trade.Price), true);
+    //Increment trade data to existing cluster
+    private void UpdateLevelCache(int bar, MarketDataArg trade)
+    {
+        if (!_mergedLevels.TryGetValue(trade.Price, out var level))
+        {
+            level = new CustomVolumeInfo(trade.Price);
+            var startBar = Math.Max(0, bar - 1);
+            var endBar = Math.Max(0, bar - (BarsRange - 1));
 
-				if (cluster is null)
-					continue;
+            for (var i = startBar; i >= endBar; i--)
+            {
+                var iCandle = GetCandle(i);
+                var cluster = _clustersCache.GetOrAdd((i, trade.Price), () => iCandle.GetPriceVolumeInfo(trade.Price), true);
 
-				level.Ask += cluster.Ask;
-				level.Between += cluster.Between;
-				level.Bid += cluster.Bid;
-				level.Ticks += cluster.Ticks;
-				level.Volume += cluster.Volume;
-			}
+                if (cluster is null)
+                    continue;
 
-			_mergedLevels[trade.Price] = level;
-		}
+                level.Ask += cluster.Ask;
+                level.Between += cluster.Between;
+                level.Bid += cluster.Bid;
+                level.Ticks += cluster.Ticks;
+                level.Volume += cluster.Volume;
+            }
+
+            _mergedLevels[trade.Price] = level;
+        }
 
         // --- IMPORTANT: do NOT mutate 'level' in-place (it's the object stored in the dictionary).
         // Build a NEW instance, apply the incoming trade, then assign via the indexer so
@@ -875,121 +943,121 @@ public partial class ClusterSearch : Indicator
         var updated = new CustomVolumeInfo(level);
 
         switch (trade.Direction)
-		{
-			case TradeDirection.Buy:
+        {
+            case TradeDirection.Buy:
                 updated.Ask += trade.Volume;
-				break;
-			case TradeDirection.Sell:
+                break;
+            case TradeDirection.Sell:
                 updated.Bid += trade.Volume;
-				break;
-			case TradeDirection.Between:
-			default:
+                break;
+            case TradeDirection.Between:
+            default:
                 updated.Between += trade.Volume;
-				break;
-		}
+                break;
+        }
 
         updated.Volume += trade.Volume;
-        updated.Ticks +=1;
+        updated.Ticks += 1;
 
         // Recompute totals and POC through the indexer
         _mergedLevels[trade.Price] = updated;
     }
 
-	//Update data series values size on properties change
-	private void SetSize()
-	{
-		if (_fixedSizes)
-		{
-			for (var i = 0; i < _renderDataSeries.Count; i++)
-				_renderDataSeries[i].ForEach(x => x.Size = _size);
-		}
-		else
-		{
-			var filterValue = MinimalFilter();
+    //Update data series values size on properties change
+    private void SetSize()
+    {
+        if (_fixedSizes)
+        {
+            for (var i = 0; i < _renderDataSeries.Count; i++)
+                _renderDataSeries[i].ForEach(x => x.Size = _size);
+        }
+        else
+        {
+            var filterValue = MinimalFilter();
 
-			for (var i = 0; i < _renderDataSeries.Count; i++)
-			{
-				_renderDataSeries[i].ForEach(x =>
-				{
-					x.Size = (int)((decimal)x.Context * _size / Math.Max(filterValue, 1));
+            for (var i = 0; i < _renderDataSeries.Count; i++)
+            {
+                _renderDataSeries[i].ForEach(x =>
+                {
+                    x.Size = (int)((decimal)x.Context * _size / Math.Max(filterValue, 1));
 
-					if (x.Size > MaxSize)
-						x.Size = MaxSize;
+                    if (x.Size > MaxSize)
+                        x.Size = MaxSize;
 
-					if (x.Size < MinSize)
-						x.Size = MinSize;
-				});
-			}
-		}
-	}
+                    if (x.Size < MinSize)
+                        x.Size = MinSize;
+                });
+            }
+        }
+    }
 
-	private void Filter_PropertyChanged(object sender, PropertyChangedEventArgs e)
-	{
-		RecalculateValues();
-		RedrawChart();
-	}
+    private void Filter_PropertyChanged(object sender, PropertyChangedEventArgs e)
+    {
+        RecalculateValues();
+        RedrawChart();
+    }
 
-	private void AddClusterAlert(string msg)
-	{
-		if (!UseAlerts)
-			return;
+    private void AddClusterAlert(string msg)
+    {
+        if (!UseAlerts)
+            return;
 
-		AddAlert(AlertFile, InstrumentInfo.Instrument, msg, AlertColor, ClusterColor);
-	}
+        AddAlert(AlertFile, InstrumentInfo.Instrument, msg, AlertColor, ClusterColor);
+    }
 
-	private decimal MinimalFilter()
-	{
-		if (AutoFilter)
-			return Math.Max(_autoFilterValue, 1);
+    private decimal MinimalFilter()
+    {
+        if (AutoFilter)
+            return Math.Max(_autoFilterValue, 1);
 
         var minFilter = MinimumFilter.Enabled ? MinimumFilter.Value : 0;
-		var maxFilter = MaximumFilter.Enabled ? MaximumFilter.Value : 0;
+        var maxFilter = MaximumFilter.Enabled ? MaximumFilter.Value : 0;
 
-		if (MinimumFilter.Value >= 0 && MaximumFilter.Value >= 0)
-			return minFilter;
+        if (MinimumFilter.Value >= 0 && MaximumFilter.Value >= 0)
+            return minFilter;
 
-		if (MinimumFilter.Value < 0 && MaximumFilter.Value >= 0)
-			return Math.Min(Math.Abs(minFilter), maxFilter);
+        if (MinimumFilter.Value < 0 && MaximumFilter.Value >= 0)
+            return Math.Min(Math.Abs(minFilter), maxFilter);
 
-		return Math.Abs(maxFilter);
-	}
+        return Math.Abs(maxFilter);
+    }
 
-	#endregion
+    #endregion
 
-	#region Filters
+    #region Filters
 
-	[Browsable(false)]
-	[Obsolete]
-	public MiddleClusterType Type
-	{
-		get => CalcType switch
-		{
-			CalcMode.Bid => MiddleClusterType.Bid,
-			CalcMode.Ask => MiddleClusterType.Ask,
-			CalcMode.Delta => MiddleClusterType.Delta,
-			CalcMode.Volume => MiddleClusterType.Volume,
-			CalcMode.Tick => MiddleClusterType.Tick,
-			_ => MiddleClusterType.Volume
-		};
-		set => CalcType = value switch
-		{
-			MiddleClusterType.Bid => CalcMode.Bid,
-			MiddleClusterType.Ask => CalcMode.Ask,
-			MiddleClusterType.Delta => CalcMode.Delta,
-			MiddleClusterType.Volume or MiddleClusterType.Time => CalcMode.Volume,
-			MiddleClusterType.Tick => CalcMode.Tick,
-			_ => throw new ArgumentOutOfRangeException(nameof(value), value, null)
-		};
-	}
+    [Browsable(false)]
+    [Obsolete]
+    public MiddleClusterType Type
+    {
+        get => CalcType switch
+        {
+            CalcMode.Bid => MiddleClusterType.Bid,
+            CalcMode.Ask => MiddleClusterType.Ask,
+            CalcMode.Delta => MiddleClusterType.Delta,
+            CalcMode.Volume => MiddleClusterType.Volume,
+            CalcMode.Tick => MiddleClusterType.Tick,
+            _ => MiddleClusterType.Volume
+        };
+        set => CalcType = value switch
+        {
+            MiddleClusterType.Bid => CalcMode.Bid,
+            MiddleClusterType.Ask => CalcMode.Ask,
+            MiddleClusterType.Delta => CalcMode.Delta,
+            MiddleClusterType.Volume or MiddleClusterType.Time => CalcMode.Volume,
+            MiddleClusterType.Tick => CalcMode.Tick,
+            _ => throw new ArgumentOutOfRangeException(nameof(value), value, null)
+        };
+    }
 
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Filters), Name = nameof(Strings.CalculationMode),
-		Description = nameof(Strings.CalculationModeDescription), Order = 200)]
-	public CalcMode CalcType
-	{
-		get => _type;
-		set
-		{
-			_type = value;
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Filters), Name = nameof(Strings.CalculationMode),
+        Description = nameof(Strings.CalculationModeDescription), Order = 200)]
+    public CalcMode CalcType
+    {
+        get => _type;
+        set
+        {
+            _type = value;
             if (_type == CalcMode.DiagonalImbalance)
             {
                 AutoFilter = false;
@@ -997,188 +1065,213 @@ public partial class ClusterSearch : Indicator
                 MaximumFilter.Enabled = false;
             }
             RecalculateValues();
-		}
-	}
+        }
+    }
 
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Filters), Name = nameof(Strings.AutoFilter),
-		Description = nameof(Strings.ClusterSearchAutofilterDescription), Order = 215)]
-	public bool AutoFilter
-	{
-		get => _autoFilter;
-		set
-		{
-			_autoFilter = value;
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Filters), Name = nameof(Strings.AutoFilter),
+        Description = nameof(Strings.ClusterSearchAutofilterDescription), Order = 215)]
+    public bool AutoFilter
+    {
+        get => _autoFilter;
+        set
+        {
+            _autoFilter = value;
 
-			if (value)
-			{
-				MinimumFilter.Enabled = true;
-				MaximumFilter.Enabled = false;
-			}
+            if (value)
+            {
+                MinimumFilter.Enabled = true;
+                MaximumFilter.Enabled = false;
+            }
 
-			RecalculateValues();
-		}
-	}
+            RecalculateValues();
+        }
+    }
 
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Filters), Description = nameof(Strings.MinimumFilterDescription),
-		Name = nameof(Strings.MinValue), Order = 220)]
-	public Filter MinimumFilter
-	{
-		get => _minFilter;
-		set => SetTrackedProperty(ref _minFilter, value, _ => RecalculateValues());
-	}
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Filters), Description = nameof(Strings.MinimumFilterDescription),
+        Name = nameof(Strings.MinValue), Order = 220)]
+    public Filter MinimumFilter
+    {
+        get => _minFilter;
+        set => SetTrackedProperty(ref _minFilter, value, _ => RecalculateValues());
+    }
 
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Filters), Description = nameof(Strings.MaximumFilterDescription),
-		Name = nameof(Strings.MaxValue), Order = 230)]
-	public Filter MaximumFilter
-	{
-		get => _maxFilter;
-		set => SetTrackedProperty(ref _maxFilter, value, _ => RecalculateValues());
-	}
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Filters), Description = nameof(Strings.MaximumFilterDescription),
+        Name = nameof(Strings.MaxValue), Order = 230)]
+    public Filter MaximumFilter
+    {
+        get => _maxFilter;
+        set => SetTrackedProperty(ref _maxFilter, value, _ => RecalculateValues());
+    }
 
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Filters), Name = nameof(Strings.MinimumAverageTrade), Order = 470,
-		Description = nameof(Strings.MinAvgTradeDescription))]
-	[Range(0, 10000000)]
-	public decimal MinAverageTrade
-	{
-		get => _minAverageTrade;
-		set
-		{
-			_minAverageTrade = value;
-			OnChangeProperty();
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Filters), Name = nameof(Strings.MinimumAverageTrade), Order = 470,
+        Description = nameof(Strings.MinAvgTradeDescription))]
+    [Range(0, 10000000)]
+    public decimal MinAverageTrade
+    {
+        get => _minAverageTrade;
+        set
+        {
+            _minAverageTrade = value;
+            OnChangeProperty();
 
-			RecalculateValues();
-		}
-	}
+            RecalculateValues();
+        }
+    }
 
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Filters), Name = nameof(Strings.MaximumAverageTrade), Order = 480,
-		Description = nameof(Strings.MaxAvgTradeDescription))]
-	[Range(0, 10000000)]
-	public decimal MaxAverageTrade
-	{
-		get => _maxAverageTrade;
-		set
-		{
-			_maxAverageTrade = value;
-			OnChangeProperty();
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Filters), Name = nameof(Strings.MaximumAverageTrade), Order = 480,
+        Description = nameof(Strings.MaxAvgTradeDescription))]
+    [Range(0, 10000000)]
+    public decimal MaxAverageTrade
+    {
+        get => _maxAverageTrade;
+        set
+        {
+            _maxAverageTrade = value;
+            OnChangeProperty();
 
-			RecalculateValues();
-		}
-	}
+            RecalculateValues();
+        }
+    }
 
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Filters), Name = nameof(Strings.MinVolumePercent), Order = 490,
-		Description = nameof(Strings.MinPercentDescription))]
-	[Range(0, 100)]
-	public decimal MinPercent
-	{
-		get => _minPercent;
-		set
-		{
-			_minPercent = value;
-			OnChangeProperty();
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Filters), Name = nameof(Strings.MinVolumePercent), Order = 490,
+        Description = nameof(Strings.MinPercentDescription))]
+    [Range(0, 100)]
+    public decimal MinPercent
+    {
+        get => _minPercent;
+        set
+        {
+            _minPercent = value;
+            OnChangeProperty();
 
-			RecalculateValues();
-		}
-	}
+            RecalculateValues();
+        }
+    }
 
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Filters), Name = nameof(Strings.MaxVolumePercent), Order = 492,
-		Description = nameof(Strings.MaxPercentDescription))]
-	[Range(0, 100)]
-	public decimal MaxPercent
-	{
-		get => _maxPercent;
-		set
-		{
-			_maxPercent = value;
-			OnChangeProperty();
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Filters), Name = nameof(Strings.MaxVolumePercent), Order = 492,
+        Description = nameof(Strings.MaxPercentDescription))]
+    [Range(0, 100)]
+    public decimal MaxPercent
+    {
+        get => _maxPercent;
+        set
+        {
+            _maxPercent = value;
+            OnChangeProperty();
 
-			RecalculateValues();
-		}
-	}
+            RecalculateValues();
+        }
+    }
 
-	#endregion
+    #endregion
 
-	#region DeltaFilters
+    #region DeltaFilters
 
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.DeltaFilters), Name = nameof(Strings.DeltaImbalance), Order = 300,
-		Description = nameof(Strings.DeltaImbalanceDescription))]
-	[Range(-100, 100)]
-	public decimal DeltaImbalance
-	{
-		get => _deltaImbalance;
-		set
-		{
-			_deltaImbalance = value;
-			RecalculateValues();
-		}
-	}
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.DeltaFilters), Name = nameof(Strings.DeltaImbalance), Order = 300,
+        Description = nameof(Strings.DeltaImbalanceDescription))]
+    [Range(-100, 100)]
+    public decimal DeltaImbalance
+    {
+        get => _deltaImbalance;
+        set
+        {
+            _deltaImbalance = value;
+            RecalculateValues();
+        }
+    }
 
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.DeltaFilters), Name = nameof(Strings.DeltaFilter), Order = 310,
-		Description = nameof(Strings.DeltaFilterDescription))]
-	public decimal DeltaFilter
-	{
-		get => _deltaFilter;
-		set
-		{
-			_deltaFilter = value;
-			RecalculateValues();
-		}
-	}
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.DeltaFilters), Name = nameof(Strings.DeltaFilter), Order = 310,
+        Description = nameof(Strings.DeltaFilterDescription))]
+    public decimal DeltaFilter
+    {
+        get => _deltaFilter;
+        set
+        {
+            _deltaFilter = value;
+            RecalculateValues();
+        }
+    }
 
     #endregion
 
     #region Imbalance filters
-	
-	[Display(Name = "Minimum Ask/Bid Ratio", GroupName = "Diagonal Imbalances Filters", Order = 320, Description = "Minimum Ask-to-Bid or Bid-to-Ask ratio to consider an imbalance.")]
+
+    private decimal _imbalanceRatio = 3m;
+    [Display(Name = "Minimum Ask/Bid Ratio", GroupName = "Diagonal Imbalances Filters", Order = 320, Description = "Minimum Ask-to-Bid or Bid-to-Ask ratio to consider an imbalance.")]
     [Range(1, 100)]
     public decimal ImbalanceRatio
     {
         get => _imbalanceRatio;
-        set 
-		{
-			_imbalanceRatio = value; 
-			OnDiagonalImbalancePropertyChanged();
-		}
-    }
-    private decimal _imbalanceRatio = 3m;
+        set
+        {
+            _imbalanceRatio = value;
+            OnChangeProperty();
 
+            RecalculateValues();
+        }
+    }
+
+    private decimal _minVolumeDifference = 30m;
     [Display(Name = "Minimum Volume Difference", GroupName = "Diagonal Imbalances Filters", Order = 330, Description = "Minimum absolute volume difference between dominant and weaker sides.")]
     [Range(0, 1000000)]
     public decimal MinVolumeDifference
     {
         get => _minVolumeDifference;
-        set 
-		{
-			_minVolumeDifference = value;
-			OnDiagonalImbalancePropertyChanged();
-		}
-    }
-    private decimal _minVolumeDifference = 30m;
+        set
+        {
+            _minVolumeDifference = value;
+            OnChangeProperty();
 
+            RecalculateValues();
+        }
+    }
+
+
+    private decimal _minDominantVolume = 100m;
     [Display(Name = "Minimum Dominant Side Volume", GroupName = "Diagonal Imbalances Filters", Order = 340, Description = "Minimum volume on the dominant side (Ask or Bid).")]
     [Range(0, 1000000)]
     public decimal MinDominantVolume
     {
         get => _minDominantVolume;
-        set 
-		{
-			_minDominantVolume = value;
-			OnDiagonalImbalancePropertyChanged();
-		}
-    }
-    private decimal _minDominantVolume = 100m;
+        set
+        {
+            _minDominantVolume = value;
+            OnChangeProperty();
 
+            RecalculateValues();
+        }
+    }
+
+    private bool _groupDiagonalImbalances = true; // default ON, to mirror grouped logic elsewhere
+    [Display(
+    Name = "Group Diagonal Imbalances", GroupName = "Diagonal Imbalances Filters", Order = 345,
+    Description = "When enabled, diagonal imbalances use the same grouping length (PriceRange) as the rest of the indicator; stacking also advances by groups instead of single ticks.")]
+    public bool GroupDiagonalImbalances
+    {
+        get => _groupDiagonalImbalances;
+        set
+        {
+            _groupDiagonalImbalances = value;
+            OnChangeProperty();
+
+            RecalculateValues();
+        }
+    }
+
+    private int _imbalanceStackedRange = 1;
     [Display(Name = "Minimum Stacked Imbalances", GroupName = "Diagonal Imbalances Filters", Order = 350, Description = "Minimum number of consecutive diagonal imbalances required.")]
     [Range(1, 10)]
     public int ImbalanceStackedRange
     {
         get => _imbalanceStackedRange;
         set
-		{
-			_imbalanceStackedRange = value;
-			OnDiagonalImbalancePropertyChanged();
-		}
+        {
+            _imbalanceStackedRange = value;
+            OnChangeProperty();
+
+            RecalculateValues();
+        }
     }
-    private int _imbalanceStackedRange = 1;
 
     #endregion
 
@@ -1189,10 +1282,12 @@ public partial class ClusterSearch : Indicator
     {
         get => _useSeparateColors;
         set
-		{
-			_useSeparateColors = value;
-			OnDiagonalImbalancePropertyChanged();
-		}
+        {
+            _useSeparateColors = value;
+            OnChangeProperty();
+
+            RecalculateValues();
+        }
     }
     private bool _useSeparateColors = true;
 
@@ -1201,10 +1296,12 @@ public partial class ClusterSearch : Indicator
     {
         get => _buyImbalanceColor;
         set
-		{
-			_buyImbalanceColor = value;
-			OnDiagonalImbalancePropertyChanged();
-		}
+        {
+            _buyImbalanceColor = value;
+            OnChangeProperty();
+
+            RecalculateValues();
+        }
     }
     private CrossColor _buyImbalanceColor = CrossColors.Green;
 
@@ -1213,393 +1310,393 @@ public partial class ClusterSearch : Indicator
     {
         get => _sellImbalanceColor;
         set
-		{
-			_sellImbalanceColor = value;
-			OnDiagonalImbalancePropertyChanged();
-		}
+        {
+            _sellImbalanceColor = value;
+            OnChangeProperty();
+
+            RecalculateValues();
+        }
     }
     private CrossColor _sellImbalanceColor = CrossColors.Red;
 
     #endregion
 
-	#endregion
+    #region Location filters
 
-	#region Location filters
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.LocationFilters), Name = nameof(Strings.CandleDirection),
+        Description = nameof(Strings.CandleDirectionDescription), Order = 400)]
+    public CandleDirection CandleDir
+    {
+        get => _candleDirection;
+        set
+        {
+            _candleDirection = value;
+            RecalculateValues();
+        }
+    }
 
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.LocationFilters), Name = nameof(Strings.CandleDirection),
-		Description = nameof(Strings.CandleDirectionDescription), Order = 400)]
-	public CandleDirection CandleDir
-	{
-		get => _candleDirection;
-		set
-		{
-			_candleDirection = value;
-			RecalculateValues();
-		}
-	}
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.LocationFilters), Name = nameof(Strings.BarsRange), Order = 410,
+        Description = nameof(Strings.BarsRangeDescription))]
+    [Range(1, 10000)]
+    public int BarsRange
+    {
+        get => _barsRange;
+        set
+        {
+            _barsRange = value;
+            RecalculateValues();
+        }
+    }
 
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.LocationFilters), Name = nameof(Strings.BarsRange), Order = 410,
-		Description = nameof(Strings.BarsRangeDescription))]
-	[Range(1, 10000)]
-	public int BarsRange
-	{
-		get => _barsRange;
-		set
-		{
-			_barsRange = value;
-			RecalculateValues();
-		}
-	}
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.LocationFilters), Name = nameof(Strings.PriceRange), Order = 420,
+        Description = nameof(Strings.PriceRangeDescription))]
+    [Range(1, 100000)]
+    public int PriceRange
+    {
+        get => _priceRange;
+        set
+        {
+            _priceRange = value;
+            RecalculateValues();
+        }
+    }
 
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.LocationFilters), Name = nameof(Strings.PriceRange), Order = 420,
-		Description = nameof(Strings.PriceRangeDescription))]
-	[Range(1, 100000)]
-	public int PriceRange
-	{
-		get => _priceRange;
-		set
-		{
-			_priceRange = value;
-			RecalculateValues();
-		}
-	}
+    [Range(1, int.MaxValue)]
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.LocationFilters), Name = nameof(Strings.PipsFromHigh), Order = 430,
+        Description = nameof(Strings.PipsFromHighDescription))]
+    public Filter PipsFromHigh
+    {
+        get => _pipsFromHigh;
+        set
+        {
+            _pipsFromHigh = value;
+            RecalculateValues();
+        }
+    }
 
-	[Range(1, int.MaxValue)]
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.LocationFilters), Name = nameof(Strings.PipsFromHigh), Order = 430,
-		Description = nameof(Strings.PipsFromHighDescription))]
-	public Filter PipsFromHigh
-	{
-		get => _pipsFromHigh;
-		set
-		{
-			_pipsFromHigh = value;
-			RecalculateValues();
-		}
-	}
+    [Range(1, int.MaxValue)]
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.LocationFilters), Name = nameof(Strings.PipsFromLow), Order = 440,
+        Description = nameof(Strings.PipsFromLowDescription))]
+    public Filter PipsFromLow
+    {
+        get => _pipsFromLow;
+        set
+        {
+            _pipsFromLow = value;
+            RecalculateValues();
+        }
+    }
 
-	[Range(1, int.MaxValue)]
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.LocationFilters), Name = nameof(Strings.PipsFromLow), Order = 440,
-		Description = nameof(Strings.PipsFromLowDescription))]
-	public Filter PipsFromLow
-	{
-		get => _pipsFromLow;
-		set
-		{
-			_pipsFromLow = value;
-			RecalculateValues();
-		}
-	}
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.LocationFilters), Name = nameof(Strings.PriceLocation), Order = 450,
+        Description = nameof(Strings.PriceLocationDescription))]
+    public PriceLocation PriceLoc
+    {
+        get => _priceLocation;
+        set
+        {
+            _priceLocation = value;
+            RecalculateValues();
+        }
+    }
 
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.LocationFilters), Name = nameof(Strings.PriceLocation), Order = 450,
-		Description = nameof(Strings.PriceLocationDescription))]
-	public PriceLocation PriceLoc
-	{
-		get => _priceLocation;
-		set
-		{
-			_priceLocation = value;
-			RecalculateValues();
-		}
-	}
+    #endregion
 
-	#endregion
+    #region Candle size filters
 
-	#region Candle size filters
+    [Range(1, int.MaxValue)]
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.MinimumCandleHeight), GroupName = nameof(Strings.CandleHeight), Order = 460,
+        Description = nameof(Strings.MinCandleHeightDescription))]
+    public FilterInt MinCandleHeight { get; set; } = new()
+    { Value = 1, Enabled = false };
 
-	[Range(1, int.MaxValue)]
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.MinimumCandleHeight), GroupName = nameof(Strings.CandleHeight), Order = 460,
-		Description = nameof(Strings.MinCandleHeightDescription))]
-	public FilterInt MinCandleHeight { get; set; } = new()
-		{ Value = 1, Enabled = false };
+    [Range(1, int.MaxValue)]
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.MaximumCandleHeight), GroupName = nameof(Strings.CandleHeight), Order = 461,
+        Description = nameof(Strings.MaxCandleHeightDescription))]
+    public FilterInt MaxCandleHeight { get; set; } = new()
+    { Value = 1, Enabled = false };
 
-	[Range(1, int.MaxValue)]
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.MaximumCandleHeight), GroupName = nameof(Strings.CandleHeight), Order = 461,
-		Description = nameof(Strings.MaxCandleHeightDescription))]
-	public FilterInt MaxCandleHeight { get; set; } = new()
-		{ Value = 1, Enabled = false };
+    [Range(1, int.MaxValue)]
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.MinimumCandleBodyHeight), GroupName = nameof(Strings.CandleHeight), Order = 470,
+        Description = nameof(Strings.MinCandleBodyHeightDescription))]
+    public FilterInt MinCandleBodyHeight { get; set; } = new()
+    { Value = 1, Enabled = false };
 
-	[Range(1, int.MaxValue)]
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.MinimumCandleBodyHeight), GroupName = nameof(Strings.CandleHeight), Order = 470,
-		Description = nameof(Strings.MinCandleBodyHeightDescription))]
-	public FilterInt MinCandleBodyHeight { get; set; } = new()
-		{ Value = 1, Enabled = false };
+    [Range(1, int.MaxValue)]
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.MaximumCandleBodyHeight), GroupName = nameof(Strings.CandleHeight), Order = 471,
+        Description = nameof(Strings.MaxCandleBodyHeightDescription))]
+    public FilterInt MaxCandleBodyHeight { get; set; } = new()
+    { Value = 1, Enabled = false };
 
-	[Range(1, int.MaxValue)]
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.MaximumCandleBodyHeight), GroupName = nameof(Strings.CandleHeight), Order = 471,
-		Description = nameof(Strings.MaxCandleBodyHeightDescription))]
-	public FilterInt MaxCandleBodyHeight { get; set; } = new()
-		{ Value = 1, Enabled = false };
+    #endregion
 
-	#endregion
+    #region Time filtration
 
-	#region Time filtration
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.TimeFiltration), Name = nameof(Strings.UseTimeFilter), Order = 500,
+        Description = nameof(Strings.UseTimeFilterDescription))]
+    public bool UseTimeFilter
+    {
+        get => _useTimeFilter;
+        set
+        {
+            _useTimeFilter = value;
+            RecalculateValues();
+        }
+    }
 
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.TimeFiltration), Name = nameof(Strings.UseTimeFilter), Order = 500,
-		Description = nameof(Strings.UseTimeFilterDescription))]
-	public bool UseTimeFilter
-	{
-		get => _useTimeFilter;
-		set
-		{
-			_useTimeFilter = value;
-			RecalculateValues();
-		}
-	}
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.TimeFiltration), Name = nameof(Strings.TimeFrom), Order = 510,
+        Description = nameof(Strings.TimeFromDescription))]
+    public TimeSpan TimeFrom
+    {
+        get => _timeFrom;
+        set
+        {
+            _timeFrom = value;
+            RecalculateValues();
+        }
+    }
 
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.TimeFiltration), Name = nameof(Strings.TimeFrom), Order = 510,
-		Description = nameof(Strings.TimeFromDescription))]
-	public TimeSpan TimeFrom
-	{
-		get => _timeFrom;
-		set
-		{
-			_timeFrom = value;
-			RecalculateValues();
-		}
-	}
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.TimeFiltration), Name = nameof(Strings.TimeTo), Order = 520,
+        Description = nameof(Strings.TimeToDescription))]
+    public TimeSpan TimeTo
+    {
+        get => _timeTo;
+        set
+        {
+            _timeTo = value;
+            RecalculateValues();
+        }
+    }
 
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.TimeFiltration), Name = nameof(Strings.TimeTo), Order = 520,
-		Description = nameof(Strings.TimeToDescription))]
-	public TimeSpan TimeTo
-	{
-		get => _timeTo;
-		set
-		{
-			_timeTo = value;
-			RecalculateValues();
-		}
-	}
+    #endregion
 
-	#endregion
+    #region Visualization
 
-	#region Visualization
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization), Name = nameof(Strings.OnlyOneSelectionPerBar), Order = 590,
+        Description = nameof(Strings.OneSelectionPerBarDescription))]
+    public bool OnlyOneSelectionPerBar
+    {
+        get => _onlyOneSelectionPerBar;
+        set
+        {
+            _onlyOneSelectionPerBar = value;
+            RecalculateValues();
+        }
+    }
 
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization), Name = nameof(Strings.OnlyOneSelectionPerBar), Order = 590,
-		Description = nameof(Strings.OneSelectionPerBarDescription))]
-	public bool OnlyOneSelectionPerBar
-	{
-		get => _onlyOneSelectionPerBar;
-		set
-		{
-			_onlyOneSelectionPerBar = value;
-			RecalculateValues();
-		}
-	}
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization), Name = nameof(Strings.VisualMode), Order = 600,
+        Description = nameof(Strings.VisualModeDescription))]
+    public ObjectType VisualType
+    {
+        get => _visualType;
+        set
+        {
+            _visualType = value;
 
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization), Name = nameof(Strings.VisualMode), Order = 600,
-		Description = nameof(Strings.VisualModeDescription))]
-	public ObjectType VisualType
-	{
-		get => _visualType;
-		set
-		{
-			_visualType = value;
+            for (var i = 0; i < _renderDataSeries.Count; i++)
+                _renderDataSeries[i].ForEach(x => { x.VisualObject = value; });
+        }
+    }
 
-			for (var i = 0; i < _renderDataSeries.Count; i++)
-				_renderDataSeries[i].ForEach(x => { x.VisualObject = value; });
-		}
-	}
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization), Name = nameof(Strings.ObjectsColor), Order = 605,
+        Description = nameof(Strings.VisualObjectsDescription))]
+    public CrossColor ClusterColor
+    {
+        get => _clusterTransColor;
+        set
+        {
+            _clusterTransColor = value;
 
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization), Name = nameof(Strings.ObjectsColor), Order = 605,
-		Description = nameof(Strings.VisualObjectsDescription))]
-	public CrossColor ClusterColor
-	{
-		get => _clusterTransColor;
-		set
-		{
-			_clusterTransColor = value;
+            for (var i = 0; i < _renderDataSeries.Count; i++)
+                _renderDataSeries[i].ForEach(x => { x.ObjectColor = _clusterTransColor; });
+        }
+    }
 
-			for (var i = 0; i < _renderDataSeries.Count; i++)
-				_renderDataSeries[i].ForEach(x => { x.ObjectColor = _clusterTransColor; });
-		}
-	}
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization), Name = nameof(Strings.VisualObjectsTransparency), Order = 610,
+        Description = nameof(Strings.VisualObjectsTransparencyDescription))]
+    [Range(0, 100)]
+    public int VisualObjectsTransparency
+    {
+        get => _visualObjectsTransparency;
+        set
+        {
+            _visualObjectsTransparency = value;
 
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization), Name = nameof(Strings.VisualObjectsTransparency), Order = 610,
-		Description = nameof(Strings.VisualObjectsTransparencyDescription))]
-	[Range(0, 100)]
-	public int VisualObjectsTransparency
-	{
-		get => _visualObjectsTransparency;
-		set
-		{
-			_visualObjectsTransparency = value;
+            for (var i = 0; i < _renderDataSeries.Count; i++)
+            {
+                _renderDataSeries[i].ForEach(x =>
+                {
+                    x.ObjectColor = _clusterTransColor;
+                    x.ObjectsTransparency = _visualObjectsTransparency;
+                });
+            }
+        }
+    }
 
-			for (var i = 0; i < _renderDataSeries.Count; i++)
-			{
-				_renderDataSeries[i].ForEach(x =>
-				{
-					x.ObjectColor = _clusterTransColor;
-					x.ObjectsTransparency = _visualObjectsTransparency;
-				});
-			}
-		}
-	}
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization), Name = nameof(Strings.ShowPriceSelection), Order = 615,
+        Description = nameof(Strings.ShowPriceSelectionDescription))]
+    public bool ShowPriceSelection
+    {
+        get => _showPriceSelection;
+        set
+        {
+            _showPriceSelection = value;
 
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization), Name = nameof(Strings.ShowPriceSelection), Order = 615,
-		Description = nameof(Strings.ShowPriceSelectionDescription))]
-	public bool ShowPriceSelection
-	{
-		get => _showPriceSelection;
-		set
-		{
-			_showPriceSelection = value;
+            for (var i = 0; i < _renderDataSeries.Count; i++)
+                _renderDataSeries[i].ForEach(x => { x.PriceSelectionColor = value ? _clusterPriceColor : CrossColors.Transparent; });
+        }
+    }
 
-			for (var i = 0; i < _renderDataSeries.Count; i++)
-				_renderDataSeries[i].ForEach(x => { x.PriceSelectionColor = value ? _clusterPriceColor : CrossColors.Transparent; });
-		}
-	}
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization), Name = nameof(Strings.PriceSelectionColor), Order = 620,
+        Description = nameof(Strings.PriceSelectionColorDescription))]
+    public CrossColor PriceSelectionColor
+    {
+        get => _clusterPriceColor;
+        set
+        {
+            _clusterPriceColor = value;
 
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization), Name = nameof(Strings.PriceSelectionColor), Order = 620,
-		Description = nameof(Strings.PriceSelectionColorDescription))]
-	public CrossColor PriceSelectionColor
-	{
-		get => _clusterPriceColor;
-		set
-		{
-			_clusterPriceColor = value;
+            for (var i = 0; i < _renderDataSeries.Count; i++)
+                _renderDataSeries[i].ForEach(x => x.PriceSelectionColor = ShowPriceSelection ? _clusterPriceColor : CrossColors.Transparent);
+        }
+    }
 
-			for (var i = 0; i < _renderDataSeries.Count; i++)
-				_renderDataSeries[i].ForEach(x => x.PriceSelectionColor = ShowPriceSelection ? _clusterPriceColor : CrossColors.Transparent);
-		}
-	}
+    [Browsable(false)]
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization), Name = nameof(Strings.ClusterSelectionTransparency), Order = 625,
+        Description = nameof(Strings.PriceSelectionTransparencyDescription))]
+    [Range(0, 100)]
+    public int Transparency { get; set; }
 
-	[Browsable(false)]
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization), Name = nameof(Strings.ClusterSelectionTransparency), Order = 625,
-		Description = nameof(Strings.PriceSelectionTransparencyDescription))]
-	[Range(0, 100)]
-	public int Transparency { get; set; }
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization), Name = nameof(Strings.FixedSizes), Order = 640,
+        Description = nameof(Strings.FixedSizesDescription))]
+    public bool FixedSizes
+    {
+        get => _fixedSizes;
+        set
+        {
+            _fixedSizes = value;
+            SetSize();
+        }
+    }
 
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization), Name = nameof(Strings.FixedSizes), Order = 640,
-		Description = nameof(Strings.FixedSizesDescription))]
-	public bool FixedSizes
-	{
-		get => _fixedSizes;
-		set
-		{
-			_fixedSizes = value;
-			SetSize();
-		}
-	}
+    [Range(1, int.MaxValue)]
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization), Name = nameof(Strings.Size), Order = 650,
+        Description = nameof(Strings.SizeDescription))]
+    public int Size
+    {
+        get => _size;
+        set
+        {
+            _size = value;
+            SetSize();
+        }
+    }
 
-	[Range(1, int.MaxValue)]
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization), Name = nameof(Strings.Size), Order = 650,
-		Description = nameof(Strings.SizeDescription))]
-	public int Size
-	{
-		get => _size;
-		set
-		{
-			_size = value;
-			SetSize();
-		}
-	}
+    [Range(1, int.MaxValue)]
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization), Name = nameof(Strings.MinimumSize), Order = 660,
+        Description = nameof(Strings.MinimumSizeDescription))]
+    public int MinSize
+    {
+        get => _minSize;
+        set
+        {
+            _minSize = value;
 
-	[Range(1, int.MaxValue)]
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization), Name = nameof(Strings.MinimumSize), Order = 660,
-		Description = nameof(Strings.MinimumSizeDescription))]
-	public int MinSize
-	{
-		get => _minSize;
-		set
-		{
-			_minSize = value;
+            if (!_fixedSizes)
+            {
+                var filterValue = MinimalFilter();
 
-			if (!_fixedSizes)
-			{
-				var filterValue = MinimalFilter();
+                for (var i = 0; i < _renderDataSeries.Count; i++)
+                {
+                    _renderDataSeries[i].ForEach(x =>
+                    {
+                        x.Size = (int)((decimal)x.Context * _size / Math.Max(filterValue, 1));
 
-				for (var i = 0; i < _renderDataSeries.Count; i++)
-				{
-					_renderDataSeries[i].ForEach(x =>
-					{
-						x.Size = (int)((decimal)x.Context * _size / Math.Max(filterValue, 1));
+                        if (x.Size > MaxSize)
+                            x.Size = MaxSize;
 
-						if (x.Size > MaxSize)
-							x.Size = MaxSize;
+                        if (x.Size < value)
+                            x.Size = value;
+                    });
+                }
+            }
+        }
+    }
 
-						if (x.Size < value)
-							x.Size = value;
-					});
-				}
-			}
-		}
-	}
+    [Range(1, int.MaxValue)]
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization), Name = nameof(Strings.MaximumSize), Order = 670,
+        Description = nameof(Strings.MaximumSizeDescription))]
+    public int MaxSize
+    {
+        get => _maxSize;
+        set
+        {
+            _maxSize = value;
 
-	[Range(1, int.MaxValue)]
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization), Name = nameof(Strings.MaximumSize), Order = 670,
-		Description = nameof(Strings.MaximumSizeDescription))]
-	public int MaxSize
-	{
-		get => _maxSize;
-		set
-		{
-			_maxSize = value;
+            if (!_fixedSizes)
+            {
+                var filterValue = MinimalFilter();
 
-			if (!_fixedSizes)
-			{
-				var filterValue = MinimalFilter();
+                for (var i = 0; i < _renderDataSeries.Count; i++)
+                {
+                    _renderDataSeries[i].ForEach(x =>
+                    {
+                        x.Size = (int)((decimal)x.Context * _size / Math.Max(filterValue, 1));
 
-				for (var i = 0; i < _renderDataSeries.Count; i++)
-				{
-					_renderDataSeries[i].ForEach(x =>
-					{
-						x.Size = (int)((decimal)x.Context * _size / Math.Max(filterValue, 1));
+                        if (x.Size > value)
+                            x.Size = value;
 
-						if (x.Size > value)
-							x.Size = value;
+                        if (x.Size < MinSize)
+                            x.Size = MinSize;
+                    });
+                }
+            }
+        }
+    }
 
-						if (x.Size < MinSize)
-							x.Size = MinSize;
-					});
-				}
-			}
-		}
-	}
+    #endregion
 
-	#endregion
+    #region Alerts
 
-	#region Alerts
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Alerts), Name = nameof(Strings.UseAlerts), Order = 700,
+        Description = nameof(Strings.UseAlertDescription))]
+    public bool UseAlerts { get; set; }
 
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Alerts), Name = nameof(Strings.UseAlerts), Order = 700,
-		Description = nameof(Strings.UseAlertDescription))]
-	public bool UseAlerts { get; set; }
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Alerts), Name = nameof(Strings.AlertFile), Order = 720,
+        Description = nameof(Strings.AlertFileDescription))]
+    public string AlertFile { get; set; } = "alert2";
 
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Alerts), Name = nameof(Strings.AlertFile), Order = 720,
-		Description = nameof(Strings.AlertFileDescription))]
-	public string AlertFile { get; set; } = "alert2";
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Alerts), Name = nameof(Strings.BackGround), Order = 740,
+        Description = nameof(Strings.AlertBackgroundDescription))]
+    public CrossColor AlertColor { get; set; } = CrossColors.Black;
 
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Alerts), Name = nameof(Strings.BackGround), Order = 740,
-		Description = nameof(Strings.AlertBackgroundDescription))]
-	public CrossColor AlertColor { get; set; } = CrossColors.Black;
+    #endregion
 
-	#endregion
+    #region Calculation
 
-	#region Calculation
+    [Range(0, int.MaxValue)]
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Calculation), Name = nameof(Strings.DaysLookBack), Order = int.MaxValue,
+        Description = nameof(Strings.DaysLookBackDescription))]
+    public int Days
+    {
+        get => _days;
+        set
+        {
+            _days = value;
+            RecalculateValues();
+        }
+    }
 
-	[Range(0, int.MaxValue)]
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Calculation), Name = nameof(Strings.DaysLookBack), Order = int.MaxValue,
-		Description = nameof(Strings.DaysLookBackDescription))]
-	public int Days
-	{
-		get => _days;
-		set
-		{
-			_days = value;
-			RecalculateValues();
-		}
-	}
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Calculation), Name = nameof(Strings.UsePreviousClose), Order = 800,
+        Description = nameof(Strings.CalculateOnBarCloseDescription))]
+    public bool UsePrevClose
+    {
+        get => _usePrevClose;
+        set
+        {
+            _usePrevClose = value;
+            RecalculateValues();
+        }
+    }
 
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Calculation), Name = nameof(Strings.UsePreviousClose), Order = 800,
-		Description = nameof(Strings.CalculateOnBarCloseDescription))]
-	public bool UsePrevClose
-	{
-		get => _usePrevClose;
-		set
-		{
-			_usePrevClose = value;
-			RecalculateValues();
-		}
-	}
-
-	#endregion
+    #endregion
 }


### PR DESCRIPTION
# ClusterSearch — Unified Window-Based Diagonal Imbalance (N = PriceRange), Grouped Stacking, and Robust Color Override

## Summary

This PR **simplifies and strengthens** `CalcMode.DiagonalImbalance` by using **one window-based algorithm** that works for both the common case (`PriceRange = 1`) and **thicker windows** (`PriceRange > 1`). Diagonal and **stacked** imbalances now behave coherently with the chosen thickness:

- With **N = 1**, behavior is identical to the classic tick-by-tick diagonal + stacked.
- With **N > 1**, diagonal and stacked operate on **window blocks** of N rows, stacked by **groups of N** (non-overlapping).
- The selected level is saved **once per price** (no duplicates when N=1), and the **color override** reliably applies.

We also keep a small fix to the average-trade upper bound.

---

## Motivation

By unifying the diagonal logic to a **single window model**, we ensure that:
1) If thickness **doesn’t change**, the number of imbalances **doesn’t increase** just by toggling grouped behavior.
2) With **thickness = 1**, detection remains **exactly one level** per price (as before).
3) The **color override** is consistently applied at save time.

---

## Key Changes

1) **Window-based diagonal detection**
   - **Upper window:** `[price .. endPrice]`, with `N = PriceRange` rows (degenerates to `N = 1`).
   - **Lower window:** `[price − N*tick .. price − 1*tick]` (same N), **aligned to the upper START** and **shifted down 1 tick**.
   - Decision:
     - **BUY:** `Ask_upper / Bid_lower ≥ ImbalanceRatio` AND `(Ask_upper − Bid_lower) ≥ MinVolumeDifference` AND `Ask_upper ≥ MinDominantVolume`.
     - **SELL:** `Bid_lower / Ask_upper ≥ ImbalanceRatio` AND `(Bid_lower − Ask_upper) ≥ MinVolumeDifference` AND `Bid_lower ≥ MinDominantVolume`.

2) **Stacked imbalances by groups**
   - Advance by **blocks of N** rows per step (non-overlapping): `g = 0..ImbalanceStackedRange-1`.
   - With `N = 1` this is identical to the classic per-tick stacking.
   - With `N > 1`, stacking compares **window sums** coherently (no partial overlaps), preventing duplicate selections.

3) **Single save + robust color override**
   - Save **exactly one level** for the current upper window on success; no duplicates when `PriceRange = 1`.
   - Color override is set once in the DI branch and applied in `SaveLevel()` so it can’t be lost by subsequent assignments.

4) **Average-trade upper bound fix**
   - Compare `avgTrade` against **MaxAverageTrade** (was the wrong symbol before).

---

## Implementation Notes

- The unified logic sits **inside `CheckCluster(...)`**, right after the standard aggregation of `ask/bid/between/volume/ticks` for the upper window.
- A local `CrossColor? diColor` is set based on BUY/SELL when DI passes and stacking is satisfied; `SaveLevel()` applies it.
- Stacking windows:
  - Group `g=0` uses `[price .. endPrice]` vs `[price−N .. price−1]`.
  - Group `g>0` uses `[price+g*N .. endPrice+g*N]` vs `[upStart_g−N .. upStart_g−1]`.

---

## Backward Compatibility

- No changes to `Bid`, `Ask`, `Delta`, `Volume`, `MaxVolume`, or `Tick` modes.
- With `PriceRange = 1`, diagonal and stacked behavior remain **unchanged** relative to the classic footprint pairing.

---

## Testing

- Verified with `PriceRange = 1` (single-tick) and `PriceRange = 2..5` (thicker windows).
- Checked stacked detection across multiple blocks and sparse `_mergedLevels`.
- Verified that the color override is applied every time `SaveLevel()` is hit by the DI pipeline.

---

## Patch Highlights (pseudo-diff)

- Inside `CheckCluster(...)`:
  - Compute `ask/bid/...` for the upper window `[price..endPrice]` (existing loop).
  - **New DI block** (after aggregation): sum `Bid` over `[price−N .. price−1]`, decide BUY/SELL, then group-stack by N.
  - If DI + stacked pass:
    - Set `diColor = UseSeparateColors ? (buy ? BuyImbalanceColor : SellImbalanceColor) : (CrossColor?)null;`
    - `return SaveLevel();` (saves one level and applies `diColor`).
  - Else, fall through to the existing filters for other modes.

- In `SaveLevel()`:
  - If `diColor.HasValue`, assign `info.PriceSelectionColor = diColor.Value;`.

---

## Checklist

- [x] One unified window-based DI algorithm (works for N=1 and N>1).
- [x] Grouped stacking by blocks of N (non-overlapping).
- [x] Exactly one saved level per price; no duplicates at N=1.
- [x] Reliable color override.
- [x] Average-trade upper bound fix (`MaxAverageTrade`).

## Screenshots
- **Diagonal Imbalances N =1**

<img width="1779" height="999" alt="image" src="https://github.com/user-attachments/assets/f9856044-9565-47ee-8394-887a711cd1cd" />

- **Diagonal Imbalances N=2**

<img width="1542" height="965" alt="image" src="https://github.com/user-attachments/assets/ec24f080-c6e3-406b-8bfe-439d9614dbff" />

