### PR TITLE
Feature/dailylines unified archival halfgap

### DIFF
--- a/Technical/DailyLines.cs
+++ b/Technical/DailyLines.cs
@@ -307,12 +307,12 @@ public class DailyLines : Indicator
 
     #endregion
 
-	#region HalfGap
+    #region HalfGap
     // Optional Half Gap visualization (midpoint between previous close and current open)
-    [Display(ResourceType = typeof(Strings), Name = "Half Gap Line", GroupName = "Half Gap", Description = "Line color and style for the Half Gap level", Order = 350)]
+    [Display(Name = "Half Gap Line", GroupName = "Half Gap", Description = "Line color and style for the Half Gap level", Order = 350)]
     public PenSettings HalfGapPen { get; set; } = new() { Color = DefaultColors.Blue.Convert(), Width = 2 };
 
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Text), GroupName = "Half Gap", Description = nameof(Strings.LabelTextDescription), Order = 355)]
+    [Display(Name = "Text", GroupName = "Half Gap", Description = "Label text", Order = 355)]
     public string HalfGapText { get; set; } = "Half Gap";
 
     [Display(Name = "Show Half Gap", GroupName = "Half Gap", Description = "Toggle the display of the Half Gap line", Order = 349)]

--- a/Technical/DailyLines.cs
+++ b/Technical/DailyLines.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Drawing;
 using System.Globalization;
+using System.Linq;
 using System.Reflection;
 
 using ATAS.Indicators.Drawing;
@@ -134,7 +135,6 @@ public class DailyLines : Indicator
 	private bool _drawOverChart;
 	private bool _newWeekWait;
 	private PeriodType _per = PeriodType.PreviousDay;
-	private SessionRange _prevSessionRange;
 	private SessionRange _sessionRange;
 	private bool _showText = true;
 	private int _lastDefaultSession;
@@ -347,11 +347,30 @@ public class DailyLines : Indicator
 			return;
 		}
 
-		var range = isCurrent || (Period is PeriodType.PreviousDay && _sessionRange.OpenBar <= _lastDefaultSession && CustomSession)
-			? _sessionRange
-			: _prevSessionRange;
+        // Select range: current period uses _sessionRange; previous periods use last completed from history
+        SessionRange range = null;
+        switch (Period)
+		{
+			case PeriodType.CurrentDay:
+            case PeriodType.CurrenWeek:
+            case PeriodType.CurrentMonth:
+				range = _sessionRange;
+                break;
+            case PeriodType.PreviousDay:
+            case PeriodType.PreviousWeek:
+            case PeriodType.PreviousMonth:
+				range = GetLastCompletedSession();
+                break;
+			default:
+				range = _sessionRange;
+                break;
+		}
+        
+        // Guard: nothing to draw if no valid range available
+        if (range is null || range.OpenBar < 0)
+			return;
 
-		var periodStr = Period switch
+        var periodStr = Period switch
 		{
 			PeriodType.CurrentDay => "Curr. Day",
 			PeriodType.PreviousDay => "Prev. Day",
@@ -380,7 +399,6 @@ public class DailyLines : Indicator
 
 	protected override void OnRecalculate()
 	{
-		_prevSessionRange = new SessionRange();
 		_sessionRange = new SessionRange();
 
         // Clear new state to avoid stale data after full recalculation
@@ -460,8 +478,6 @@ public class DailyLines : Indicator
                              while (_sessionHistory.Count > MaxSessions)
 								_sessionHistory.Dequeue();
 
-							// Backward compatibility with current OnRender (uses _prevSessionRange)
-							_prevSessionRange = _sessionRange;
 							}
             
 					_sessionRange = new SessionRange(candle, bar);
@@ -631,7 +647,22 @@ public class DailyLines : Indicator
 
 		var rect = new Rectangle(Container.Region.X, Container.Region.Bottom - textSize.Height, textSize.Width, textSize.Height);
 		g.DrawString(text, ChartInfo.PriceAxisFont, DefaultColors.Red, rect);
-	}
+    }
 
+	// Returns the most recent finished session from history (supports day/week/month)
+	private SessionRange GetLastCompletedSession()
+	{
+		if (_sessionHistory.Count == 0)
+			return null;
+
+		// Iterate from newest to oldest
+		foreach (var s in _sessionHistory.Reverse())
+		{
+			if (s.IsFinished && s.OpenBar >= 0)
+				return s;
+		}
+
+		return null;
+	}
 	#endregion
 }

--- a/Technical/DailyLines.cs
+++ b/Technical/DailyLines.cs
@@ -382,7 +382,12 @@ public class DailyLines : Indicator
 	{
 		_prevSessionRange = new SessionRange();
 		_sessionRange = new SessionRange();
-	}
+
+        // Clear new state to avoid stale data after full recalculation
+        _sessionHistory.Clear();
+        _halfGapPrice = null;
+        _halfGapBar = -1;
+    }
 
 	protected new bool IsNewSession(int bar)
 	{
@@ -443,61 +448,61 @@ public class DailyLines : Indicator
 		if (base.IsNewSession(bar))
 			_lastDefaultSession = bar;
 
-		if (bar != _sessionRange.OpenBar)
-		{
-			var isNewPeriod = IsNewPeriod(bar);
+        var isNewPeriod = IsNewPeriod(bar);
+        
+               if (isNewPeriod)
+                   {
+                       // Unified archival: finish and enqueue the previous range when a new period starts
+                       if (_sessionRange.OpenBar >= 0 && !_sessionRange.IsFinished)
+                           {
+							 _sessionRange.IsFinished = true;
+							 _sessionHistory.Enqueue(_sessionRange);
+                             while (_sessionHistory.Count > MaxSessions)
+								_sessionHistory.Dequeue();
 
-			if (isNewPeriod)
-			{
-				if (_sessionRange.OpenBar >= 0)
-				{
-					_sessionRange.IsFinished = true;
-					_prevSessionRange = _sessionRange;
-				}
-
-				_sessionRange = new SessionRange(candle, bar);
-            }
-			else
-			{
-				if (Period is PeriodType.CurrentDay or PeriodType.PreviousDay)
-				{
-                    if (InsideSession(bar))
-					{
-						_sessionRange.IncCandle(candle, bar);
-					}
-					else 
-					{
-						if (_sessionRange.OpenBar >= 0)
-							_sessionRange.IsFinished = true;
-					}
-				}
-				else
-				{
-					if (_sessionRange.OpenBar >= 0)
-						_sessionRange.IncCandle(candle, bar);
-				}
-			}
-		}
-		else
-		{
-			if (Period is PeriodType.CurrentDay or PeriodType.PreviousDay)
-			{
-				if (InsideSession(bar))
-				{
-					_sessionRange.IncCandle(candle, bar);
-				}
-				else
-				{
-					if (_sessionRange.OpenBar >= 0)
-						_sessionRange.IsFinished = true;
-				}
-			}
-			else
-			{
-				if (_sessionRange.OpenBar >= 0)
-					_sessionRange.IncCandle(candle, bar);
-			}
-		}
+							// Backward compatibility with current OnRender (uses _prevSessionRange)
+							_prevSessionRange = _sessionRange;
+							}
+            
+					_sessionRange = new SessionRange(candle, bar);
+                   }
+               else
+                   {
+                       if (bar != _sessionRange.OpenBar)
+                           {
+								if (Period is PeriodType.CurrentDay or PeriodType.PreviousDay)
+								{
+									if (InsideSession(bar))
+									{
+										_sessionRange.IncCandle(candle, bar);
+									}
+									else 
+									{
+										if (_sessionRange.OpenBar >= 0)
+											_sessionRange.IsFinished = true;
+									}
+								}
+								else
+								{
+									if (_sessionRange.OpenBar >= 0)
+										_sessionRange.IncCandle(candle, bar);
+								}
+							}
+						else
+							{
+                               if (Period is PeriodType.CurrentDay or PeriodType.PreviousDay)
+                                   {
+                                       if (InsideSession(bar))
+										_sessionRange.IncCandle(candle, bar);
+                                       else if (_sessionRange.OpenBar >= 0)
+										_sessionRange.IsFinished = true;
+                                   }
+                               else if (_sessionRange.OpenBar >= 0)
+                                   {
+										_sessionRange.IncCandle(candle, bar);
+                                   }
+                           }
+                   }
     }
 
 	#endregion

--- a/Technical/DailyLines.cs
+++ b/Technical/DailyLines.cs
@@ -599,10 +599,14 @@ public class DailyLines : Indicator
 	{
 		var y = ChartInfo.GetYByPrice(price, false);
 
-		if (y + 8 > Container.Region.Height)
-			return;
+        // Guard: avoid drawing outside bounds
+        if (y < 0)
+           return;
 
-		var renderText = price.ToString(CultureInfo.InvariantCulture);
+        if (y + 8 > Container.Region.Height)
+           return;
+
+        var renderText = price.ToString(CultureInfo.InvariantCulture);
 		var size = context.MeasureString(renderText, _axisFont);
 		var priceHeight = size.Height / 2;
 		var x = Container.Region.Right;

--- a/Technical/DailyLines.cs
+++ b/Technical/DailyLines.cs
@@ -307,6 +307,19 @@ public class DailyLines : Indicator
 
     #endregion
 
+	#region HalfGap
+    // Optional Half Gap visualization (midpoint between previous close and current open)
+    [Display(ResourceType = typeof(Strings), Name = "Half Gap Line", GroupName = "Half Gap", Description = "Line color and style for the Half Gap level", Order = 350)]
+    public PenSettings HalfGapPen { get; set; } = new() { Color = DefaultColors.Blue.Convert(), Width = 2 };
+
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Text), GroupName = "Half Gap", Description = nameof(Strings.LabelTextDescription), Order = 355)]
+    public string HalfGapText { get; set; } = "Half Gap";
+
+    [Display(Name = "Show Half Gap", GroupName = "Half Gap", Description = "Toggle the display of the Half Gap line", Order = 349)]
+    public bool ShowHalfGap { get; set; } = true;
+    #endregion
+
+
     #endregion
 
     #region ctor
@@ -377,6 +390,25 @@ public class DailyLines : Indicator
         if (range is null || range.OpenBar < 0)
 			return;
 
+        // Compute Half Gap only for CurrentDay and only if a previous completed session exists
+        if (ShowHalfGap && Period == PeriodType.CurrentDay)
+		{
+			var prev = GetLastCompletedSession();
+            if (prev != null && _sessionRange.OpenBar >= 0)
+			{
+				var openPrice = _sessionRange.OpenPrice;
+				var closePrice = prev.ClosePrice;
+				_halfGapPrice = closePrice + (openPrice - closePrice) / 2m;
+				_halfGapBar = _sessionRange.OpenBar;
+            }
+            else
+			{
+				_halfGapPrice = null;
+				_halfGapBar = -1;
+            }
+        }
+        
+
         var periodStr = Period switch
 		{
 			PeriodType.CurrentDay => "Curr. Day",
@@ -391,7 +423,11 @@ public class DailyLines : Indicator
 		var high = ChartInfo.PriceChartContainer.High;
 		var low = ChartInfo.PriceChartContainer.Low;
 
-		if (range.OpenPrice >= low && range.OpenPrice <= high)
+        // Draw Half Gap (if computed) within visible price range
+        if (ShowHalfGap && _halfGapPrice.HasValue && _halfGapBar >= 0 && _halfGapPrice.Value >= low && _halfGapPrice.Value <= high)
+            DrawLevel(context, HalfGapPen, _halfGapBar, _halfGapPrice.Value, HalfGapText, "HalfGap", periodStr);
+
+        if (range.OpenPrice >= low && range.OpenPrice <= high)
 			DrawLevel(context, OpenPen, range.OpenBar, range.OpenPrice, OpenText, "Open", periodStr);
 
 		if (range.HighPrice >= low && range.HighPrice <= high)

--- a/Technical/DailyLines.cs
+++ b/Technical/DailyLines.cs
@@ -341,8 +341,15 @@ public class DailyLines : Indicator
 
 		var isCurrent = Period is PeriodType.CurrentDay or PeriodType.CurrenWeek or PeriodType.CurrentMonth;
 
-		if (isCurrent && _lastDefaultSession > _sessionRange.OpenBar && _sessionRange.IsFinished)
-		{
+        // Show message only when the current period is selected and we are clearly
+		// outside the custom session window in the current viewport.
+		// Avoid blocking rendering solely because the current session is marked as finished,
+		// which may be legitimate in complex custom sessions (e.g., crossing midnight).
+		if (isCurrent
+           && CustomSession
+           && _lastDefaultSession > _sessionRange.OpenBar
+           && !InsideSession(LastVisibleBarNumber))
+        {
 			DrawMessage(context);
 			return;
 		}

--- a/Technical/DailyLines.cs
+++ b/Technical/DailyLines.cs
@@ -401,16 +401,18 @@ public class DailyLines : Indicator
         if (range is null || range.OpenBar < 0)
 			return;
 
-        // Compute Half Gap only for CurrentDay and only if a previous completed session exists
+        // Compute Half Gap only for CurrentDay and only if a previous completed session exists.
+        // Use the currently selected range so the Half Gap starts on the exact same opening bar as the session being rendered.
         if (ShowHalfGap && Period == PeriodType.CurrentDay)
 		{
 			var prev = GetLastCompletedSession();
-            if (prev != null && _sessionRange.OpenBar >= 0)
-			{
-				var openPrice = _sessionRange.OpenPrice;
+            if(prev != null && range != null && range.OpenBar >= 0)
+
+            {
+				var openPrice = range.OpenPrice;
 				var closePrice = prev.ClosePrice;
 				_halfGapPrice = closePrice + (openPrice - closePrice) / 2m;
-				_halfGapBar = _sessionRange.OpenBar;
+				_halfGapBar = range.OpenBar;
             }
             else
 			{

--- a/Technical/DailyLines.cs
+++ b/Technical/DailyLines.cs
@@ -1,6 +1,7 @@
 namespace ATAS.Indicators.Technical;
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Drawing;
@@ -138,13 +139,21 @@ public class DailyLines : Indicator
 	private bool _showText = true;
 	private int _lastDefaultSession;
 
-	#endregion
+	// New: bounded session history to support previous periods across day/week/month
+	private readonly Queue<SessionRange> _sessionHistory = new();
+	private const int MaxSessions = 5;
 
-	#region Properties
+	// New: Half Gap state (not used yet in behavior)
+	private decimal? _halfGapPrice;
+	private int _halfGapBar = -1;
 
-	#region Calculation
+    #endregion
 
-	[Browsable(false)]
+    #region Properties
+
+    #region Calculation
+
+    [Browsable(false)]
 	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Calculation), Name = nameof(Strings.DaysLookBack), Order = int.MaxValue,
 		Description = nameof(Strings.DaysLookBackDescription))]
 	[Range(1, 1000)]

--- a/Technical/DailyLines.cs
+++ b/Technical/DailyLines.cs
@@ -385,7 +385,18 @@ public class DailyLines : Indicator
 				range = _sessionRange;
                 break;
 		}
-        
+
+        // Fallback: for PreviousDay + CustomSession, if there is no completed session yet
+        // (e.g., after session end but before the next session starts), use the finished current range.
+        if ((range is null || range.OpenBar < 0)
+			&& Period == PeriodType.PreviousDay
+            && CustomSession
+			&& _sessionRange.OpenBar >= 0
+            && _sessionRange.IsFinished)
+        {
+            range = _sessionRange;
+        }
+
         // Guard: nothing to draw if no valid range available
         if (range is null || range.OpenBar < 0)
 			return;


### PR DESCRIPTION
## Summary
This PR improves `DailyLines` in three main areas while preserving backward compatibility:

1. **Robust previous-period rendering** — `PreviousDay/Week/Month` now render from the **most recent completed session**, including custom sessions and edge cases (e.g., crossing midnight).
2. **Bounded session history** — Introduces a small, bounded queue to keep recent completed sessions (constant memory), enabling reliable look-back without relying on a single `_prevSessionRange`.
3. **Optional “Half Gap” line for CurrentDay** — Adds an optional line showing the midpoint between **previous close** and **current open**. It aligns with the session’s opening bar and respects visibility guards.

Additional fixes:
- Safer **“custom session inactive”** detection to avoid suppressing rendering in legitimate scenarios.
- Bounds guard in `DrawPrice` to avoid off-viewport artifacts.

No breaking changes. Defaults maintain existing behavior (Half Gap is enabled by default; happy to flip to `false` if preferred).

---

## Motivation
- Prior previous-period logic was fragile with custom sessions and could miss or misuse the prior period when the last session crossed midnight or the platform hadn’t started the next session yet.
- Users frequently request the **Half Gap** reference (midpoint between prev close and current open).
- Minor rendering robustness improvements reduce edge-case UI glitches.

---

## Key changes
- Replace the single `_prevSessionRange` dependency with a **bounded** `_sessionHistory` (`Queue<SessionRange>`, `MaxSessions = 5`).
- Add `GetLastCompletedSession()` to consistently select the prior finished session.
- `PreviousDay/Week/Month`: render from `GetLastCompletedSession()` when available.
  - **Fallback** for `PreviousDay + CustomSession`: if there is no completed session yet (e.g., immediately after session end but before the next session starts), use the **finished current range**.
- **CurrentDay**: compute and render **Half Gap** (optional) only when a previous completed session exists.
  - Uses the **currently-rendered range** for alignment: starts at `range.OpenBar` so it matches the session’s opening bar and mirrors `Open` rendering.
- **Custom session inactive message** is shown only when:
  - the period is current, and
  - `CustomSession == true`, and
  - `_lastDefaultSession > _sessionRange.OpenBar`, and
  - the last visible bar is **outside** the custom session (`!InsideSession(LastVisibleBarNumber)`).
- **DrawPrice guard**: skip drawing when `y < 0` or beyond container height.

---

## Implementation details
- New fields:
  - `_sessionHistory: Queue<SessionRange>` (bounded by `MaxSessions = 5`)
  - `_halfGapPrice?: decimal`, `_halfGapBar: int`
- `OnRecalculate()`: clears `_sessionHistory` and Half Gap state to prevent staleness.
- `OnCalculate(bar, value)`: unified archival on `IsNewPeriod(bar)`:
  - if the current `_sessionRange` is valid and unfinished, set `IsFinished = true` and enqueue it.
  - trim queue to `MaxSessions`.
  - begin a new `SessionRange(candle, bar)`.
- `OnRender(...)`:
  - Selects `range` based on `Period` (current vs. previous), with the `PreviousDay` fallback described above for custom sessions.
  - Computes Half Gap only for `CurrentDay` when a previous completed session exists; sets `_halfGapBar = range.OpenBar`.
  - Draws levels via existing `DrawLevel(...)` and respects user’s `FirstBar` (`DrawFromBar`) preference.
- Display attributes for Half Gap use plain `[Display(Name=..., GroupName=...)]` (no `ResourceType`) to avoid localization mismatches until keys are provided.

---

## Compatibility & behavior
- **No change** when `CustomSession == false` and Half Gap is disabled.
- Previous periods now select a **completed** session (more accurate with custom sessions/midnight crossing).
- **Half Gap**:
  - Enabled by default (configurable).
  - Only for `CurrentDay` and only when a completed prior session exists.
  - Starts at the **same opening bar** as the rendered session; respects `FirstBar` (`DrawFromBar`).
- **Performance**: storage is bounded; lookups are O(1)/O(n) over a tiny queue.

---

## QA / test plan
1. **Baseline (no custom session)**
   - `CurrentDay` → OHLC render as before.
   - `PreviousDay/Week/Month` → uses the last completed session; validate levels vs. historical OHLC.
2. **Custom session (no midnight crossing)**
   - Verify `InsideSession(bar)` gating; “inactive” appears only when outside session window.
   - `PreviousDay` uses the last completed session for levels.
3. **Custom session (crossing midnight, e.g. 22:00–06:00)**
   - End the session; before the next session starts, select `PreviousDay` and confirm fallback draws the finished current range if history isn’t populated yet.
   - When the next session begins, `GetLastCompletedSession()` takes over.
4. **Half Gap**
   - With `CurrentDay` and a completed prior session, enable `ShowHalfGap` and confirm:
     - price = `(prevClose + currentOpen) / 2`
     - it starts at `range.OpenBar` (aligned with `Open` level and `FirstBar` toggle)
     - obeys visibility window.
   - Disable `ShowHalfGap` → no line drawn.
5. **DrawPrice guard**
   - Zoom such that labels would fall off-viewport; confirm no artifacts/exceptions.

---

## Edge cases considered
- First day of data / no prior completed session → Half Gap not drawn (by design).
- `PreviousDay` immediately after session end (before next session) with `CustomSession` → fallback correctly uses the finished current range.
- Sessions with equal start/end (full-day range) → treated as “always inside”.

---

## Risks
- Low. Session history is bounded and used only for selecting completed sessions; existing rendering paths remain intact.

---

## Commits
- `refactor(DailyLines): groundwork (no behavior change)`
- `feat(DailyLines): unified archival on IsNewPeriod(bar)`
- `fix(DailyLines): render PreviousDay/PreviousWeek/PreviousMonth from last completed session`
- `fix(DailyLines): make "custom session inactive" check robust for custom sessions`
- `fix(DailyLines): add bounds guard in DrawPrice to avoid off-viewport artifacts`
- `feat(DailyLines): add optional Half Gap line for CurrentDay`
- `fix(DailyLines): add PreviousDay fallback to current finished session when no history yet`
- `fix(DailyLines): remove ResourceType from Half Gap Display attributes`
- `fix(DailyLines): align Half Gap start bar with rendered session`

(If you prefer, I can squash “fix” commits into their corresponding feature commits before merge.)

---

## Reviewer notes / follow-ups
- Default `ShowHalfGap = true`. If design prefers, I can change the default to `false`.
- Happy to move Half Gap strings to resources in a follow-up once localization keys are available.

---

## Checklist
- [x] Backward compatible
- [x] Bounded memory / no leaks
- [x] Works with and without `CustomSession`
- [x] Handles sessions crossing midnight
- [x] Respects `FirstBar` (`DrawFromBar`) for start-X behavior
- [x] Visual/behavioral verification steps included
- [x] Code comments in English

<img width="1510" height="573" alt="image" src="https://github.com/user-attachments/assets/6a21f516-d231-49e2-8215-4efb168ed07b" />
