### PR TITLE
Feat/DOM Power — Histogram mode, per-bar range, and robust visibility/clearing

### DIFF
--- a/Technical/DomPower.cs
+++ b/Technical/DomPower.cs
@@ -269,8 +269,11 @@ public class DomPower : Indicator
 			else // HistogramDom
 			{
 				_domImbalanceSeries[i] = domImbalance;
-				// color set in later commit to ensure RenderColor conversion
-				var max = _maxDomImbalanceCache[i];
+                // Per-bar Colors expects System.Drawing.Color (do NOT use .Convert() here)
+                _domImbalanceSeries.Colors[i] = (domImbalance >= 0
+					? System.Drawing.Color.Green
+					: System.Drawing.Color.Red);
+                var max = _maxDomImbalanceCache[i];
 				var min = _minDomImbalanceCache[i];
 				_domImbalanceRangeSeries[i] = max - min;
 			}

--- a/Technical/DomPower.cs
+++ b/Technical/DomPower.cs
@@ -174,6 +174,9 @@ public class DomPower : Indicator
 
 		if (bar > 0 && bar != _lastBar) 
 		{
+            // Start of a new bar: copy previous values to ensure visual continuity
+            // for both visualization modes (SeparateLines and HistogramDom).
+            // This avoids flicker/empty gaps before the first MarketDepthChanged tick arrives.
 
             _asks[bar] = _asks[bar - 1];
             _bids[bar] = _bids[bar - 1];

--- a/Technical/DomPower.cs
+++ b/Technical/DomPower.cs
@@ -37,6 +37,8 @@ public class DomPower : Indicator
     };
 
 	// New extrema series based on DOM Imbalance (per-bar)
+	// DOM Imbalance is computed as: Cumulative DOM Bids - Cumulative DOM Asks,
+    // optionally constrained by LevelDepth (top N price levels per side).
 	private readonly ValueDataSeries _maxDomImbalance = new("MaxDomImbalance", "Max DOM Imbalance")
 	{
        UseMinimizedModeIfEnabled = true,
@@ -49,15 +51,16 @@ public class DomPower : Indicator
        DescriptionKey = nameof(Strings.MinDeltaSettingsDescription)
 	};
 
-	// DOM Imbalance = Cumulative DOM Bids - Cumulative DOM Asks (optionally limited by LevelDepth)
-	private readonly ValueDataSeries _domImbalanceSeries = new("DomImbalance", "DOM Imbalance")
+    // DOM Imbalance series (histogram): positive when bids>asks, negative when asks>bids.
+    private readonly ValueDataSeries _domImbalanceSeries = new("DomImbalance", "DOM Imbalance")
 	{
 		VisualType = VisualMode.Histogram,
 		UseMinimizedModeIfEnabled = true
 	};
 
 
-	// Per-bar range of DOM Imbalance = max_intra_bar - min_intra_bar
+	// Per-bar range of DOM Imbalance (THIS BAR ONLY): max_intra_bar - min_intra_bar.
+    // Useful to detect expansion/compression of passive DOM during the bar lifetime.
 	private readonly ValueDataSeries _domImbalanceRangeSeries = new("DomImbalanceRange", "DOM Imbalance Range")
 	{
 		Color = System.Drawing.Color.MediumVioletRed.Convert(),
@@ -98,8 +101,13 @@ public class DomPower : Indicator
 			_levelDepth = value;
 			DataSeries.ForEach(x => x.Clear());
 		}
-	}
+    }
 
+	/// <summary>
+    /// Visualization:
+    /// - SeparateLines: shows Asks (negative), Bids (positive), and per-bar extrema of DOM Imbalance.
+    /// - HistogramDom:  shows a signed histogram (green/red) and the per-bar range series.
+    /// </summary>
     [Display(Name = "Visualization Mode", GroupName = "View", Order = 110)]
 	public VisualizationMode Mode
 	{

--- a/Technical/DomPower.cs
+++ b/Technical/DomPower.cs
@@ -98,9 +98,22 @@ public class DomPower : Indicator
 		get => _levelDepth;
 		set
 		{
-			_levelDepth = value;
-			DataSeries.ForEach(x => x.Clear());
-		}
+            // Re-wire event handler only if the instance changes
+            if (!ReferenceEquals(_levelDepth, value))
+                {
+					if (_levelDepth != null)
+						_levelDepth.PropertyChanged -= DepthFilterChanged;
+
+					_levelDepth = value ?? _levelDepth;
+
+                    if (_levelDepth != null)
+						_levelDepth.PropertyChanged += DepthFilterChanged;
+                }
+
+            // Fully reset series and internal state for consistency
+            ClearAllSeriesAndState();
+            RedrawChart();
+        }
     }
 
 	/// <summary>

--- a/Technical/DomPower.cs
+++ b/Technical/DomPower.cs
@@ -106,10 +106,11 @@ public class DomPower : Indicator
        set
        {
            _visualMode = value;
-           // visibility adjusted in later commit
-           DataSeries.ForEach(x => x.Clear());
+           // Apply visibility change and fully reset series/state to avoid artifacts
+           ApplyModeVisibility(_visualMode);
+           ClearAllSeriesAndState();
            RedrawChart();
-       }
+        }
 	}
 
 	#endregion
@@ -127,8 +128,10 @@ public class DomPower : Indicator
         DataSeries.Add(_domImbalanceSeries);
         DataSeries.Add(_domImbalanceRangeSeries);
 
+        // Ensure correct default visibility on startup
+        ApplyModeVisibility(_visualMode);
         _levelDepth.PropertyChanged += DepthFilterChanged;
-	}
+    }
 
 	#endregion
 
@@ -278,15 +281,49 @@ public class DomPower : Indicator
 		_lastCalculatedBar = lastCandle;
 	}
 
-	#endregion
+    #endregion
 
-	#region Private methods
+    #region Private methods
+
+    /// <summary>
+    /// Apply visibility for each series depending on the selected visualization mode.
+    /// SeparateLines: show asks/bids + extrema; hide histogram/range.
+    /// HistogramDom:  show histogram/range;  hide asks/bids + extrema.
+    /// </summary>
+    private void ApplyModeVisibility(VisualizationMode mode)
+    {
+        var showSeparate = mode == VisualizationMode.SeparateLines;
+        var showHistogram = mode == VisualizationMode.HistogramDom;
+
+        _asks.IsHidden = !showSeparate;
+        _bids.IsHidden = !showSeparate;
+        _maxDomImbalance.IsHidden = !showSeparate;
+        _minDomImbalance.IsHidden = !showSeparate;
+
+        _domImbalanceSeries.IsHidden = !showHistogram;
+        _domImbalanceRangeSeries.IsHidden = !showHistogram;
+    }
+
+    /// <summary>
+    /// Clears all series data and internal state caches to avoid artifacts on mode/filter changes.
+    /// </summary>
+    private void ClearAllSeriesAndState()
+    {
+        foreach (var ds in DataSeries)
+        {
+            ds.Clear();
+        }
+        
+        _maxDomImbalanceCache.Clear();
+        _minDomImbalanceCache.Clear();
+        _lastCalculatedBar = System.Math.Max(0, CurrentBar - 1);
+    }
 
 	private void DepthFilterChanged(object sender, PropertyChangedEventArgs e)
 	{
-		DataSeries.ForEach(x => x.Clear());
-		RedrawChart();
-	}
+        ClearAllSeriesAndState();
+        RedrawChart();
+    }
 
-	#endregion
+    #endregion
 }

--- a/Technical/DomPower.cs
+++ b/Technical/DomPower.cs
@@ -1,11 +1,10 @@
 namespace ATAS.Indicators.Technical;
 
+using OFT.Attributes;
+using OFT.Localization;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
-
-using OFT.Attributes;
-using OFT.Localization;
 
 [Category(IndicatorCategories.OrderBook)]
 [DisplayName("DOM Power")]
@@ -13,6 +12,15 @@ using OFT.Localization;
 [HelpLink("https://help.atas.net/support/solutions/articles/72000602374")]
 public class DomPower : Indicator
 {
+
+	#region Enums
+	public enum VisualizationMode
+	{
+       SeparateLines,
+       HistogramDom
+	}
+	#endregion
+
 	#region Fields
 
 	private readonly ValueDataSeries _asks = new("AsksId", "Asks")
@@ -28,6 +36,34 @@ public class DomPower : Indicator
         DescriptionKey = nameof(Strings.BidVisualizationSettingsDescription)
     };
 
+	// New extrema series based on DOM Imbalance (per-bar)
+	private readonly ValueDataSeries _maxDomImbalance = new("MaxDomImbalance", "Max DOM Imbalance")
+	{
+       UseMinimizedModeIfEnabled = true,
+       DescriptionKey = nameof(Strings.MaxDeltaSettingsDescription)
+	};
+ 
+	private readonly ValueDataSeries _minDomImbalance = new("MinDomImbalance", "Min DOM Imbalance")
+	{
+       UseMinimizedModeIfEnabled = true,
+       DescriptionKey = nameof(Strings.MinDeltaSettingsDescription)
+	};
+
+	// DOM Imbalance = Cumulative DOM Bids - Cumulative DOM Asks (optionally limited by LevelDepth)
+	private readonly ValueDataSeries _domImbalanceSeries = new("DomImbalance", "DOM Imbalance")
+	{
+		VisualType = VisualMode.Histogram,
+		UseMinimizedModeIfEnabled = true
+	};
+
+
+	// Per-bar range of DOM Imbalance = max_intra_bar - min_intra_bar
+	private readonly ValueDataSeries _domImbalanceRangeSeries = new("DomImbalanceRange", "DOM Imbalance Range")
+	{
+		Color = System.Drawing.Color.MediumVioletRed.Convert(),
+		UseMinimizedModeIfEnabled = true
+	};
+
 	private bool _first = true;
 	private int _lastCalculatedBar;
 	private Filter _levelDepth = new(true)
@@ -37,25 +73,15 @@ public class DomPower : Indicator
 	};
 	private object _locker = new();
 
-	private ValueDataSeries _maxDelta = new("MaxDelta", "Max Delta")
-	{
-		Color = System.Drawing.Color.FromArgb(255, 27, 134, 198).Convert(),
-		UseMinimizedModeIfEnabled = true,
-        DescriptionKey = nameof(Strings.MaxDeltaSettingsDescription)
-    };
-
 	private SortedList<decimal, decimal> _mDepthAsk = new();
 	private SortedList<decimal, decimal> _mDepthBid = new();
 
-	private ValueDataSeries _minDelta = new("MinDelta", "Min Delta")
-	{
-		Color = System.Drawing.Color.FromArgb(255, 27, 134, 198).Convert(),
-		UseMinimizedModeIfEnabled = true,
-        DescriptionKey = nameof(Strings.MinDeltaSettingsDescription)
-    };
-
 	private int _lastBar = -1;
-    private bool _isLastDeltaCalc;
+
+	// State for new visualization and caches
+	private VisualizationMode _visualMode = VisualizationMode.SeparateLines;
+	private readonly Dictionary<int, decimal> _maxDomImbalanceCache = new();
+	private readonly Dictionary<int, decimal> _minDomImbalanceCache = new();
 
     #endregion
 
@@ -73,6 +99,19 @@ public class DomPower : Indicator
 		}
 	}
 
+    [Display(Name = "Visualization Mode", GroupName = "View", Order = 110)]
+	public VisualizationMode Mode
+	{
+       get => _visualMode;
+       set
+       {
+           _visualMode = value;
+           // visibility adjusted in later commit
+           DataSeries.ForEach(x => x.Clear());
+           RedrawChart();
+       }
+	}
+
 	#endregion
 
 	#region ctor
@@ -83,10 +122,12 @@ public class DomPower : Indicator
 		Panel = IndicatorDataProvider.NewPanel;
 		DataSeries[0] = _asks;
 		DataSeries.Add(_bids);
-		DataSeries.Add(_maxDelta);
-		DataSeries.Add(_minDelta);
+        DataSeries.Add(_maxDomImbalance);
+        DataSeries.Add(_minDomImbalance);
+        DataSeries.Add(_domImbalanceSeries);
+        DataSeries.Add(_domImbalanceRangeSeries);
 
-		_levelDepth.PropertyChanged += DepthFilterChanged;
+        _levelDepth.PropertyChanged += DepthFilterChanged;
 	}
 
 	#endregion
@@ -115,13 +156,14 @@ public class DomPower : Indicator
 
 		if (bar > 0 && bar != _lastBar) 
 		{
-			lock (_locker)
-				_isLastDeltaCalc = false;
 
             _asks[bar] = _asks[bar - 1];
             _bids[bar] = _bids[bar - 1];
-            _minDelta[bar] = _minDelta[bar - 1];
-            _maxDelta[bar] = _maxDelta[bar - 1];
+            _minDomImbalance[bar] = _minDomImbalance[bar - 1];
+            _maxDomImbalance[bar] = _maxDomImbalance[bar - 1];
+            _domImbalanceSeries[bar] = _domImbalanceSeries[bar - 1];
+            _domImbalanceRangeSeries[bar] = _domImbalanceRangeSeries[bar - 1];
+
         }
 
 		_lastBar = bar;
@@ -192,31 +234,43 @@ public class DomPower : Indicator
 			}
 		}
 
-		var delta = cumBids - cumAsks;
-		var calcDelta = cumAsks != 0 && cumBids != 0;
+        var domImbalance = cumBids - cumAsks;
+        var canCalc = cumAsks != 0 && cumBids != 0;
 
-		if (!calcDelta)
-			return;
+        if (!canCalc)
+            return;
 
 		for (var i = _lastCalculatedBar; i <= lastCandle; i++)
 		{
-			_asks[i] = -cumAsks;
-			_bids[i] = cumBids;
-
-			if (!_isLastDeltaCalc && i == lastCandle)
-			{
-                _maxDelta[i] = delta;
-                _minDelta[i] = delta;
-
-				lock (_locker)
-					_isLastDeltaCalc = true;
+            // update per-bar extrema caches
+            if (!_maxDomImbalanceCache.ContainsKey(i))
+            {
+                _maxDomImbalanceCache[i] = domImbalance;
+                _minDomImbalanceCache[i] = domImbalance;
+            }
+            else
+            {
+				if (domImbalance > _maxDomImbalanceCache[i])
+					_maxDomImbalanceCache[i] = domImbalance;
+                if (domImbalance < _minDomImbalanceCache[i])
+					_minDomImbalanceCache[i] = domImbalance;
             }
 
-			if (delta > _maxDelta[i]) 
-				_maxDelta[i] = delta;
-
-			if (delta < _minDelta[i])
-				_minDelta[i] = delta;			
+			if (_visualMode == VisualizationMode.SeparateLines)
+			{
+				_asks[i] = -cumAsks;
+				_bids[i] = cumBids;
+				_maxDomImbalance[i] = _maxDomImbalanceCache[i];
+				_minDomImbalance[i] = _minDomImbalanceCache[i];
+			}
+			else // HistogramDom
+			{
+				_domImbalanceSeries[i] = domImbalance;
+				// color set in later commit to ensure RenderColor conversion
+				var max = _maxDomImbalanceCache[i];
+				var min = _minDomImbalanceCache[i];
+				_domImbalanceRangeSeries[i] = max - min;
+			}
 
             RaiseBarValueChanged(i);
 		}

--- a/Technical/DomPower.cs
+++ b/Technical/DomPower.cs
@@ -82,6 +82,7 @@ public class DomPower : Indicator
 	private VisualizationMode _visualMode = VisualizationMode.SeparateLines;
 	private readonly Dictionary<int, decimal> _maxDomImbalanceCache = new();
 	private readonly Dictionary<int, decimal> _minDomImbalanceCache = new();
+    private int _lastAlertBar = -1;
 
     #endregion
 
@@ -113,11 +114,25 @@ public class DomPower : Indicator
         }
 	}
 
-	#endregion
+    [Display(Name = "Dom Imbalance Range Threshold", GroupName = "Alerts", Order = 120)]
+    [Range(1, 5000)]
+    public int DomRangeThreshold { get; set; } = 800;
 
-	#region ctor
+    [Display(Name = "Enable Alerts", GroupName = "Alerts", Order = 121)]
+    public bool AlertEnabled { get; set; } = true;
 
-	public DomPower()
+    [Display(Name = "Alert Tail Percent", GroupName = "Alerts", Order = 122, Description = "Trigger when value is within the lower/upper tail (in %) of the bar range.")]
+    [Range(1, 49)]
+    public int AlertExtremesPercent { get; set; } = 10;
+
+    [Display(Name = "Alert ID Prefix", GroupName = "Alerts", Order = 123)]
+    public string AlertIdPrefix { get; set; } = "dom_range";
+
+    #endregion
+
+    #region ctor
+
+    public DomPower()
 		: base(true)
 	{
 		Panel = IndicatorDataProvider.NewPanel;
@@ -275,8 +290,22 @@ public class DomPower : Indicator
 					: System.Drawing.Color.Red);
                 var max = _maxDomImbalanceCache[i];
 				var min = _minDomImbalanceCache[i];
-				_domImbalanceRangeSeries[i] = max - min;
-			}
+                var range = max - min;
+                _domImbalanceRangeSeries[i] = range;
+
+                if (AlertEnabled && range >= DomRangeThreshold && _lastAlertBar != i)
+                {
+                    var rel = range != 0 ? (domImbalance - min) / range : 0.5m;
+                    var tail = AlertExtremesPercent / 100m;
+                    if (rel <= tail || rel >= (1m - tail))
+                    {
+                        var id = $"{AlertIdPrefix}_{InstrumentInfo?.Instrument}_{i}";
+                        AddAlert(id, $"Passive DOM range exceeded at bar {i}. RelPos: {rel:F2}, Range: {range}");
+                        _lastAlertBar = i;
+                    }
+                }
+            }
+        
 
             RaiseBarValueChanged(i);
 		}
@@ -319,6 +348,7 @@ public class DomPower : Indicator
         
         _maxDomImbalanceCache.Clear();
         _minDomImbalanceCache.Clear();
+        _lastAlertBar = -1;
         _lastCalculatedBar = System.Math.Max(0, CurrentBar - 1);
     }
 


### PR DESCRIPTION
## Summary
This PR extends **DOM Power** with an optional **HistogramDom** visualization and adds an intra-bar **DOM Imbalance Range** metric, while keeping the classic **SeparateLines** view as default. It also fixes series visibility toggling and centralizes clearing to avoid visual artifacts when switching modes or filters.

## Motivation
Traders often want a compact, directional readout of DOM imbalance (bids − asks) plus a sense of **intra-bar expansion/compression**. The histogram + range view provides that signal at a glance. Updated visibility/clearing logic prevents stale drawings when changing settings.

## Key Changes
- **VisualizationMode (enum)**
  - **SeparateLines** (default): shows Asks (negative), Bids (positive), and per-bar extrema of DOM Imbalance.
  - **HistogramDom**: signed histogram (green/red) of DOM Imbalance + **DOM Imbalance Range** (max − min within the current bar).
- **Per-bar caches** for DOM Imbalance extrema (max/min) to compute range efficiently within the bar lifetime.
- **Visibility & clearing**
  - `ApplyModeVisibility()` ensures only the relevant series are shown per mode.
  - `ClearAllSeriesAndState()` resets DataSeries and internal caches when changing mode or depth filter.
- **Per-bar coloring**: histogram bars colored **green** (≥ 0) / **red** (< 0) using `System.Drawing.Color`.
- **Configurable alerts (optional)**
  - `DomRangeThreshold`, `AlertEnabled`, `AlertExtremesPercent`, `AlertIdPrefix`.
  - One unique alert per bar when range exceeds threshold **and** the current value sits in lower/upper tails.

## Backward Compatibility
- Default remains **SeparateLines**; no behavior changes if users don’t enable HistogramDom or alerts.
- `LevelDepth` logic preserved and respected in both modes.

## Implementation Notes
- **DOM Imbalance** = `Cumulative DOM Bids − Cumulative DOM Asks`, optionally constrained by **LevelDepth** (top N price levels per side).
- **Start-of-bar continuity**: copy previous values at bar open to avoid flicker until the first depth tick arrives.
- **Per-bar Colors**: use `System.Drawing.Color` for `series.Colors[i]`. (Series-wide color may still use `.Convert()`.)

## Parameters
- **View**
  - `Visualization Mode` (SeparateLines | HistogramDom)
- **Alerts**
  - `Enable Alerts`
  - `Dom Imbalance Range Threshold`
  - `Alert Tail Percent`
  - `Alert ID Prefix`
- **Period**
  - `Depth Market Filter` (existing `LevelDepth`)

## Testing Plan (ATAS)
1. **Basic load & compatibility**
   - New panel, default parameters (SeparateLines, LevelDepth off).
   - Expect Asks (−), Bids (+); no histogram/range; no errors in logs.
2. **Mode switching**
   - Switch to HistogramDom.
   - Expect Asks/Bids/extrema hidden; histogram + range visible; no stale drawings.
3. **Start-of-bar continuity**
   - Observe bar open (live or Market Replay).
   - Expect no gaps/flicker before first depth tick.
4. **LevelDepth ON/OFF**
   - Toggle LevelDepth and vary its value (e.g., 5).
   - Expect sensible amplitude changes; stable behavior.
5. **LevelDepth > available levels**
   - Set a large value (e.g., 100).
   - Expect fallback to full cumulative; no errors.
6. **Per-bar colors**
   - Verify green (≥0) vs red (<0) changes as imbalance sign flips.
7. **Alerts**
   - Enable alerts; set `DomRangeThreshold` low for testing; `AlertExtremesPercent = 10`.
   - Expect exactly one alert per bar when (range ≥ threshold) and value is in tails.
8. **Repeated mode changes**
   - Switch modes multiple times.
   - Expect clean redraws; no ghost colors/values.
9. **Performance**
   - Let it run 10–15 minutes with active depth.
   - Expect no abnormal memory growth or UI lag.
10. **Other bar types/timeframes**
    - Test 5-min and (optionally) renko/volume bars.
    - Expect consistent logic and rendering.
11. **Reconnect/Instrument change**
    - Switch instrument or reconnect feed.
    - Expect fresh state; no stale caches.
12. **Logs**
    - Check ATAS logs for warnings/exceptions (expect none).

## Commits (atomic; can be squashed)
- `fix(dom-power): toggle visibility per mode and centralize clearing`
- `fix(dom-power): correct per-bar histogram coloring using System.Drawing.Color`
- `feat(dom-power): add configurable alerts for extreme DOM range; reset state on clear`
- `chore(dom-power): ensure start-of-bar continuity across all series`
- `docs(dom-power): clarify DOM Imbalance terminology and per-bar range comments`

## How to Use
1. Add indicator to a new panel.
2. Switch **Visualization Mode** to **HistogramDom** to see signed histogram and **DOM Imbalance Range**.
3. (Optional) Enable alerts and tune `DomRangeThreshold` / `AlertExtremesPercent`.
4. (Optional) Enable `Depth Market Filter` to limit levels included in the imbalance.

<img width="703" height="160" alt="image" src="https://github.com/user-attachments/assets/393c63c0-72bb-4ac8-87be-f8f1766d0a96" />


## Future Enhancements (optional)
- Adaptive threshold (e.g., percentile over last N bars).
- Normalized imbalance (ratio vs. `cumAsks + cumBids`) for cross-session comparability.
- Optional smoothing (SMA) for histogram.