### PR TITLE
Fix bid cumulative depth and off-by-one in depth accumulation

### DIFF
--- a/Technical/DomStrength.cs
+++ b/Technical/DomStrength.cs
@@ -346,14 +346,14 @@ public class DomStrength : Indicator
 				{
 					_cumAsks = 0;
 
-					for (var i = 0; i <= LevelDepth.Value; i++)
+					for (var i = 0; i < LevelDepth.Value; i++)
 						_cumAsks += _mDepthAsk.Values[i];
 				}
 
 				if (_mDepthBid.Count <= LevelDepth.Value)
 				{
-					_cumBids = _mDepthAsk.Values
-						.DefaultIfEmpty(0)
+                    _cumBids = _mDepthBid.Values
+                        .DefaultIfEmpty(0)
 						.Sum();
 				}
 				else
@@ -361,7 +361,7 @@ public class DomStrength : Indicator
 					_cumBids = 0;
 					var lastIdx = _mDepthBid.Values.Count - 1;
 
-					for (var i = 0; i <= LevelDepth.Value; i++)
+					for (var i = 0; i < LevelDepth.Value; i++)
 						_cumBids += _mDepthBid.Values[lastIdx - i];
 				}
 			}


### PR DESCRIPTION
### Summary
This PR fixes a correctness issue in DOM Strength:

- ✅ Corrects bid cumulative depth when LevelDepth is enabled and the bid levels count is small.
- ✅ Adjusts the depth accumulation loop to include exactly `LevelDepth.Value` levels (off-by-one fix).

### Details
- When `_mDepthBid.Count <= LevelDepth.Value`, the code mistakenly summed `_mDepthAsk.Values`. It now sums `_mDepthBid.Values`.
- For both ask and bid branches with `Count > LevelDepth.Value`, the loop now iterates `i < LevelDepth.Value` to sum an exact number of levels.

### Impact
- Behavior is now consistent and mathematically correct for both sides of the book.
- No API or UI changes. No performance impact.

### Regression risk
Low. The change is localized and covered by straightforward logic.