### PR TITLE
Feat/ Add ShowDelta option to toggle delta overlay in DOM Strength (stacked on top of #88)

### DIFF
--- a/Technical/DomStrength.cs
+++ b/Technical/DomStrength.cs
@@ -346,14 +346,14 @@ public class DomStrength : Indicator
 				{
 					_cumAsks = 0;
 
-					for (var i = 0; i <= LevelDepth.Value; i++)
+					for (var i = 0; i < LevelDepth.Value; i++)
 						_cumAsks += _mDepthAsk.Values[i];
 				}
 
 				if (_mDepthBid.Count <= LevelDepth.Value)
 				{
-					_cumBids = _mDepthAsk.Values
-						.DefaultIfEmpty(0)
+                    _cumBids = _mDepthBid.Values
+                        .DefaultIfEmpty(0)
 						.Sum();
 				}
 				else
@@ -361,7 +361,7 @@ public class DomStrength : Indicator
 					_cumBids = 0;
 					var lastIdx = _mDepthBid.Values.Count - 1;
 
-					for (var i = 0; i <= LevelDepth.Value; i++)
+					for (var i = 0; i < LevelDepth.Value; i++)
 						_cumBids += _mDepthBid.Values[lastIdx - i];
 				}
 			}

--- a/Technical/DomStrength.cs
+++ b/Technical/DomStrength.cs
@@ -36,12 +36,13 @@ public class DomStrength : Indicator
 	private RenderPen _rectPen = new(Color.Black);
 	private decimal _sellVolume;
 	private List<MarketDataArg> _trades = new();
+    private bool _showDelta = false;
 
-	#endregion
+    #endregion
 
-	#region Properties
+    #region Properties
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.DepthMarketFilter), GroupName = nameof(Strings.Settings), Description = nameof(Strings.DOMMaxFilterDescription), Order = 90)]
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.DepthMarketFilter), GroupName = nameof(Strings.Settings), Description = nameof(Strings.DOMMaxFilterDescription), Order = 90)]
 	[Range(1, 1000)]
 	public FilterInt LevelDepth { get; } = new() { Value = 10 };
 
@@ -97,6 +98,24 @@ public class DomStrength : Indicator
 	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.ColorMinus80), GroupName = nameof(Strings.Color), Description = nameof(Strings.PercentColorDescription), Order = 250)]
 	public Color ColorMinus80 { get; set; } = Color.Red;
 
+    [Parameter]
+ 	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.ShowDelta), GroupName = nameof(Strings.Visualization), Description = nameof(Strings.ShowDeltaDescription), Order = 300)]
+ 	public bool ShowDelta
+ 	{
+ 		get => _showDelta;
+ 		set
+ 		{
+ 			_showDelta = value;
+ 
+ 			// Re-apply colors according to the new flag
+ 			OnApplyDefaultColors();
+ 
+ 			// Request a redraw so the change is visible immediately
+ 			if (Container is not null)
+ 				RedrawChart(new RedrawArg(Container.Region));
+ 		}
+ 	}
+
 	#endregion
 
 	#region ctor
@@ -126,10 +145,19 @@ public class DomStrength : Indicator
 
 		var candles = (CandleDataSeries)DataSeries[0];
 
-		candles.UpCandleColor = ChartInfo.ColorsStore.UpCandleColor.Convert();
-		candles.DownCandleColor = ChartInfo.ColorsStore.DownCandleColor.Convert();
-		candles.BorderColor = ChartInfo.ColorsStore.BarBorderPen.Color.Convert();
-	}
+        if (ShowDelta)
+        {
+			candles.UpCandleColor = ChartInfo.ColorsStore.UpCandleColor.Convert();
+            candles.DownCandleColor = ChartInfo.ColorsStore.DownCandleColor.Convert();
+            candles.BorderColor = ChartInfo.ColorsStore.BarBorderPen.Color.Convert();
+        }
+        else
+        {
+            candles.UpCandleColor = CrossColors.Transparent;
+            candles.DownCandleColor = CrossColors.Transparent;
+            candles.BorderColor = CrossColors.Transparent;
+        }
+    }
 
 	protected override void OnInitialize()
 	{


### PR DESCRIPTION
### Summary
This enhancement adds a `ShowDelta` parameter that lets users toggle the delta overlay without breaking the panel or layout.

### Details
- Parameter: `ShowDelta` (bool), under “Visualization”.
- When `ShowDelta = false`, the delta candles are rendered fully transparent via `OnApplyDefaultColors` (no layout changes).
- Keeps the underlying CumulativeDelta data intact for quick re‑enable and consistent behavior.

### UX / Visual
- Users can now declutter the panel quickly while keeping DOM Strength rectangles and logic unchanged.

### Compatibility
- No API breaking changes. No performance impact of note.

<img width="683" height="233" alt="image" src="https://github.com/user-attachments/assets/56a8032f-d965-4fc0-85b4-7d8ebe3eb554" />
