### PR TITLE
PR: Initial Balance — session-boundary fix + label anchoring + rendering options

### DIFF
--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -1,3 +1,6 @@
+using ATAS.Indicators;
+using System;
+
 namespace ATAS.Indicators.Technical;
 
 using ATAS.Indicators.Drawing;
@@ -12,6 +15,7 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Drawing;
 using System.Linq;
+using System.Security.Cryptography;
 using Pen = System.Drawing.Pen;
 
 [DisplayName("Initial Balance")]
@@ -211,11 +215,28 @@ public class InitialBalance : Indicator
 
 	private bool _isStarted;
 
-    #endregion
+	// --- ShowDuringFormation state & per-session buffer ---
+	// When false: do not write ValueDataSeries during formation; keep values buffered only.
+	// When true : mirror buffered values to ValueDataSeries (live display).
+	private bool _showDuringFormation = false;
 
-    #region Properties
+	// Snapshot of IB levels per bar (current session)
+	private sealed class IbSnapshot
+	{
+		public int Bar;
+		public decimal Mid, IBH, IBL, IBM;
+		public decimal IBHX1, IBHX2, IBHX3;
+		public decimal IBLX1, IBLX2, IBLX3;
+	}
 
-    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Calculation), 
+	// In-memory buffer while the IB window is forming
+	private readonly List<IbSnapshot> _sessionBuffer = new();
+
+#endregion
+
+#region Properties
+
+[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Calculation), 
 		Name = nameof(Strings.DaysLookBack), Order = int.MaxValue, Description = nameof(Strings.DaysLookBackDescription))]
     [Range(0, 1000)]
     public int Days
@@ -420,6 +441,33 @@ public class InitialBalance : Indicator
             RedrawChart();
         }
     }
+
+	// During IB formation: when false, nothing is drawn (lines/labels) and values are buffered in-memory.
+	// When toggled to true mid-formation, the buffer is backfilled to ValueDataSeries immediately.
+	[Display(Name = "Show During Formation",
+	GroupName = nameof(Strings.Show), Description = "Show IB lines/labels while the initial balance window is forming",	Order = 160)]
+	public bool ShowDuringFormation
+	{
+		get => _showDuringFormation;
+		set
+		{
+			if (_showDuringFormation == value)
+				return;
+
+			_showDuringFormation = value;
+
+			// Live toggle without full historical recalc
+			if (_initialized && _calculate && _lastStartBar >= 0)
+			{
+				if (_showDuringFormation)
+					BackfillBufferToSeries();
+				else
+					TruncateVisibleCurrentSession();
+			}
+
+			RedrawChart();
+		}
+   }
 
 	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBHX32), 
 		GroupName = nameof(Strings.BackGround), Description = nameof(Strings.AreaColorDescription), Order = 200)]
@@ -669,7 +717,12 @@ public class InitialBalance : Indicator
 		}
 		else if (isEnd)
 		{
-			_calculate = _isStarted = false;
+            // IB window finished: if hidden during formation, backfill the session now
+            if (!_showDuringFormation)
+                BackfillBufferToSeries();
+            _calculate = _isStarted = false;
+            _sessionBuffer.Clear();
+            _lastEndBar = Math.Max(_lastEndBar, bar);
         }
 
 		if (_calculate)
@@ -703,28 +756,44 @@ public class InitialBalance : Indicator
 		if (!_highLowIsSet)
 			return;
 
-		_mid[bar] = mid = (_minValue + _maxValue) / 2m;
-		_ibh[bar] = _ibMax;
-		_ibl[bar] = _ibMin;
-		_ibmValue = _ibm[bar] = (_ibMin + _ibMax) / 2m;
-		var diff = _ibMax - _ibMin;
+        // Compute current levels (locals first)
+        mid = (_minValue + _maxValue) / 2m;
+        _ibmValue = (_ibMin + _ibMax) / 2m;
+        var diff = _ibMax - _ibMin;
 
-		ibhx1 = _ibhx1[bar] = _ibMax + diff * _x1;
-		ibhx2 = _ibhx2[bar] = _ibMax + diff * _x2;
-		ibhx3 = _ibhx3[bar] = _ibMax + diff * _x3;
-		iblx1 = _iblx1[bar] = _ibMin - diff * _x1;
-		iblx2 = _iblx2[bar] = _ibMin - diff * _x2;
-		iblx3 = _iblx3[bar] = _ibMin - diff * _x3;
+        ibhx1 = _ibMax + diff * _x1;
+        ibhx2 = _ibMax + diff * _x2;
+        ibhx3 = _ibMax + diff * _x3;
+        iblx1 = _ibMin - diff * _x1;
+        iblx2 = _ibMin - diff * _x2;
+        iblx3 = _ibMin - diff * _x3;
 
-		_ibhx32[bar].Upper = ibhx3;
-		_ibhx32[bar].Lower = _ibhx21[bar].Upper = ibhx2;
-		_ibhx21[bar].Lower = _ibhx1h[bar].Upper = ibhx1;
-		_ibhx1h[bar].Lower = _ibHm[bar].Upper = _ibh[bar];
-		_ibHm[bar].Lower = _ibMl[bar].Upper = _ibm[bar];
-		_ibMl[bar].Lower = _ibl1[bar].Upper = _ibl[bar];
-		_ibl1[bar].Lower = _iblx12[bar].Upper = iblx1;
-		_iblx12[bar].Lower = _iblx23[bar].Upper = iblx2;
-		_iblx23[bar].Lower = iblx3;
+        // Buffer snapshot for this bar
+        _sessionBuffer.Add(new IbSnapshot
+        {
+			Bar = bar,
+			Mid = mid,
+			IBH = _ibMax,
+			IBL = _ibMin,
+			IBM = _ibmValue,
+			IBHX1 = ibhx1,
+			IBHX2 = ibhx2,
+			IBHX3 = ibhx3,
+			IBLX1 = iblx1,
+			IBLX2 = iblx2,
+			IBLX3 = iblx3
+       });
+
+        // Mirror to series only if we show during formation; otherwise keep the chart clean
+        if (_showDuringFormation)
+        {
+            WriteSnapshotToSeries(bar, _sessionBuffer[^1]);
+        }
+        else
+        {
+			// Hide current session lines while forming
+            TruncateVisibleCurrentSession();
+        }
 
         // Labels are now drawn in OnRender; do not spawn text objects in OnCalculate.
     }
@@ -869,6 +938,64 @@ public class InitialBalance : Indicator
     {
         return aStart < bEnd && aEnd > bStart;
     }
+
+	// --- Buffer helpers ---
+
+	// Write one buffered snapshot into ValueDataSeries and range bands at a specific bar
+	private void WriteSnapshotToSeries(int bar, IbSnapshot s)
+	{
+		_mid[bar]   = s.Mid;
+		_ibh[bar]   = s.IBH;
+		_ibl[bar]   = s.IBL;
+		_ibm[bar]   = s.IBM;
+		_ibhx1[bar] = s.IBHX1;
+		_ibhx2[bar] = s.IBHX2;
+		_ibhx3[bar] = s.IBHX3;
+		_iblx1[bar] = s.IBLX1;
+		_iblx2[bar] = s.IBLX2;
+		_iblx3[bar] = s.IBLX3;
+
+		WriteRanges(bar, s.IBHX1, s.IBHX2, s.IBHX3, s.IBH, s.IBM, s.IBL, s.IBLX1, s.IBLX2, s.IBLX3);
+	}
+
+	// Write/refresh the background ranges for a bar from level values
+	private void WriteRanges(
+		int bar,
+		decimal ibhx1, decimal ibhx2, decimal ibhx3,
+		decimal ibh, decimal ibm, decimal ibl,
+		decimal iblx1, decimal iblx2, decimal iblx3)
+	{
+		_ibhx32[bar].Upper = ibhx3;
+		_ibhx32[bar].Lower = _ibhx21[bar].Upper = ibhx2;
+		_ibhx21[bar].Lower = _ibhx1h[bar].Upper = ibhx1;
+		_ibhx1h[bar].Lower = _ibHm[bar].Upper  = ibh;
+		_ibHm[bar].Lower   = _ibMl[bar].Upper  = ibm;
+		_ibMl[bar].Lower   = _ibl1[bar].Upper  = ibl;
+		_ibl1[bar].Lower   = _iblx12[bar].Upper = iblx1;
+		_iblx12[bar].Lower = _iblx23[bar].Upper = iblx2;
+		_iblx23[bar].Lower = iblx3;
+	}
+
+	// Backfill the whole buffered session (from _lastStartBar to current bar) into visible series
+   private void BackfillBufferToSeries()
+   {
+		if (_lastStartBar < 0 || _sessionBuffer.Count == 0)
+			return;
+
+		foreach (var s in _sessionBuffer)
+			WriteSnapshotToSeries(s.Bar, s);
+   }
+
+	// Visually truncate current session lines while keeping the buffer intact
+   private void TruncateVisibleCurrentSession()
+   {
+		if (_lastStartBar < 0)
+			return;
+    
+        foreach (var ds in DataSeries)
+			if (ds is ValueDataSeries vs)
+				vs.SetPointOfEndLine(Math.Max(0, _lastStartBar - 1));
+   }
 
     #endregion
 }

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -1,5 +1,4 @@
 using ATAS.Indicators;
-using System;
 
 namespace ATAS.Indicators.Technical;
 
@@ -15,7 +14,6 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Drawing;
 using System.Linq;
-using System.Security.Cryptography;
 using Pen = System.Drawing.Pen;
 
 [DisplayName("Initial Balance")]

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -1,20 +1,23 @@
 namespace ATAS.Indicators.Technical;
 
-using System;
-using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
-using System.Drawing;
-using System.Linq;
-
 using ATAS.Indicators.Drawing;
-
 using OFT.Attributes;
 using OFT.Localization;
-using OFT.Rendering.Settings;
-
-using Pen = System.Drawing.Pen;
 using OFT.Rendering.Context;
+using OFT.Rendering.Settings;
 using OFT.Rendering.Tools;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
+using System.Drawing;
+using System.Linq;
+using System.Security.Policy;
+using System.Windows;
+using System.Windows.Media;
+using System.Xml.Linq;
+using Pen = System.Drawing.Pen;
 
 [DisplayName("Initial Balance")]
 [Category(IndicatorCategories.VolumeOrderFlow)]
@@ -174,7 +177,11 @@ public class InitialBalance : Indicator
 	private int _borderWidth = 1;
 	private bool _calculate;
 	private bool _customSessionStart;
-	private int _days = 20;
+	// NEW: extension/anchor control: lines may extend to the right edge while the session is active;
+    // labels always anchor at the line end (either the right edge if extended, or the last bar).
+    private bool _extendLastLineToRight = true;
+    private int _lastEndBar = -1; // last bar of the custom session; -1 means still active
+    private int _days = 20;
     private bool _drawText = true;
 	private TimeSpan _endDate;
 	private DateTime _endTime = DateTime.MaxValue;
@@ -403,6 +410,22 @@ public class InitialBalance : Indicator
         }
     }
 
+	// Extend current session lines to the chart's right edge while the session is active.
+    // Labels ALWAYS appear where lines end:
+    // - If extended: at the right edge
+    // - If not extended (or session ended): at the last bar (or the recorded session end bar)
+    [Display(Name = "Extend Last Line to Right",
+	GroupName = nameof(Strings.Show), Description = "Extend lines to the right edge while session is active; labels anchor at line end", Order = 137)]
+    public bool ExtendLastLineToRight
+    {
+        get => _extendLastLineToRight;
+        set
+        {
+            _extendLastLineToRight = value;
+            RedrawChart();
+        }
+    }
+
 	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBHX32), 
 		GroupName = nameof(Strings.BackGround), Description = nameof(Strings.AreaColorDescription), Order = 200)]
 	public CrossColor Ibhx32
@@ -581,6 +604,8 @@ public class InitialBalance : Indicator
             if (!inSession)
 			{
 				_isStarted = false;
+                // Record where the custom session ended so labels can anchor there after exit.
+                _lastEndBar = Math.Max(0, bar - 1);
 
                 foreach (var dataSeries in DataSeries)
 					if (dataSeries is ValueDataSeries series)
@@ -705,39 +730,8 @@ public class InitialBalance : Indicator
 		_iblx12[bar].Lower = _iblx23[bar].Upper = iblx2;
 		_iblx23[bar].Lower = iblx3;
 
-        if (DrawText)
-		{
-			AddText(_lastStartBar + "Mid", "Mid", true, bar, mid, 0, 0, ConvertColor(_mid.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
-
-			AddText(_lastStartBar + "IBH", "IBH", true, bar, _ibMax, 0, 0, ConvertColor(_ibh.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
-
-			AddText(_lastStartBar + "IBL", "IBL", true, bar, _ibMin, 0, 0, ConvertColor(_ibl.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
-
-			AddText(_lastStartBar + "IBM", "IBM", true, bar, _ibmValue, 0, 0, ConvertColor(_ibm.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
-
-			AddText(_lastStartBar + "IBHX1", "IBHX1", true, bar, ibhx1, 0, 0, ConvertColor(_ibhx1.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
-
-			AddText(_lastStartBar + "IBHX2", "IBHX2", true, bar, ibhx2, 0, 0, ConvertColor(_ibhx2.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
-
-			AddText(_lastStartBar + "IBHX3", "IBHX3", true, bar, ibhx3, 0, 0, ConvertColor(_ibhx3.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
-
-			AddText(_lastStartBar + "IBLX1", "IBLX1", true, bar, iblx1, 0, 0, ConvertColor(_iblx1.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
-
-			AddText(_lastStartBar + "IBLX2", "IBLX2", true, bar, iblx2, 0, 0, ConvertColor(_iblx2.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
-
-			AddText(_lastStartBar + "IBLX3", "IBLX3", true, bar, iblx3, 0, 0, ConvertColor(_iblx3.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
-		}
-	}
+        // Labels are now drawn in OnRender; do not spawn text objects in OnCalculate.
+    }
 
     private DateTime GetPrevDateTime(int bar)
     {
@@ -759,6 +753,104 @@ public class InitialBalance : Indicator
 	private System.Drawing.Color ConvertColor(CrossColor color)
 	{
 		return System.Drawing.Color.FromArgb(color.A, color.R, color.G, color.B);
+    }
+
+	// Convert platform LineDashStyle to System.Drawing dash style for overlay rendering.
+    private static System.Drawing.Drawing2D.DashStyle ConvertDashStyle(LineDashStyle style) =>
+		style switch
+        {
+            LineDashStyle.Solid => System.Drawing.Drawing2D.DashStyle.Solid,
+            LineDashStyle.Dash => System.Drawing.Drawing2D.DashStyle.Dash,
+            LineDashStyle.Dot => System.Drawing.Drawing2D.DashStyle.Dot,
+            LineDashStyle.DashDot => System.Drawing.Drawing2D.DashStyle.DashDot,
+            LineDashStyle.DashDotDot => System.Drawing.Drawing2D.DashStyle.DashDotDot,
+            _ => System.Drawing.Drawing2D.DashStyle.Solid
+        };
+
+	// Render labels at the right edge of the chart for current values
+	protected override void OnRender(RenderContext context, DrawingLayouts layout)
+    {
+        if (!_initialized)
+			return;
+        
+        // Use the last completed/visible bar as the anchor for values and positions.
+        var bar = Math.Max(0, CurrentBar - 1);
+        if (bar <= 0)
+			return;
+        
+        // Determine if custom session is currently active. If no custom session, treat as active (for extension semantics opt-in only).
+        bool sessionActive = true;
+        if (CustomSessionStart)
+        {
+            var lastStart = GetCandle(bar).Time.AddHours(InstrumentInfo.TimeZone);
+            var lastEnd = GetCandle(bar).LastTime.AddHours(InstrumentInfo.TimeZone);
+            var(ss, se) = GetCustomSessionWindow(lastStart);
+            sessionActive = Intersects(lastStart, lastEnd, ss, se);
+        }
+        
+        // Compute X coordinates:
+        // - xLast: where the plotted series already ends (last bar)
+        // - x2: where the line should end (right edge if extending & active; otherwise anchor bar)
+        var xLast = ChartInfo.GetXByBar(bar, false);
+        int x2;
+        if (_extendLastLineToRight && sessionActive)
+        {
+			// Active and extension enabled ? anchor at right edge
+            x2 = context.ClipBounds.Right;
+        }
+        else
+        {
+            // No extension ? anchor at last known session end bar (if recorded), else at last bar
+            var anchorBar = _lastEndBar >= 0 ? _lastEndBar : bar;
+            x2 = ChartInfo.GetXByBar(Math.Max(0, anchorBar), false);
+        }
+        
+        // Only draw the extension segment to avoid overdrawing series; skip if x2 is not beyond last plotted X.
+        var drawExtension = _extendLastLineToRight && sessionActive && x2 > xLast;
+        
+        // Prepare label/series/value triplets using the latest values at 'bar'.
+        var items = new (string Label, ValueDataSeries Series, decimal Value)[]
+        {
+            ("Mid", _mid, _mid[bar]),
+			("IBH", _ibh, _ibh[bar]),
+			("IBL", _ibl, _ibl[bar]),
+			("IBM", _ibm, _ibm[bar]),
+			("IBHX1", _ibhx1, _ibhx1[bar]),
+			("IBHX2", _ibhx2, _ibhx2[bar]),
+			("IBHX3", _ibhx3, _ibhx3[bar]),
+			("IBLX1", _iblx1, _iblx1[bar]),
+			("IBLX2", _iblx2, _iblx2[bar]),
+			("IBLX3", _iblx3, _iblx3[bar]),
+        };
+        
+        const int pad = 2;
+        
+        foreach (var (label, series, price) in items)
+        {
+			// Skip invalid or uninitialized values
+            if (price == 0m || price == decimal.MinValue || price == decimal.MaxValue)
+				continue;
+            
+            var y = ChartInfo.GetYByPrice(price, false);
+            if (y < 0)
+				continue;
+            
+            // 1) Draw only the extension segment (if applicable)
+            if (drawExtension)
+            {
+                var pen = new RenderPen(ConvertColor(series.Color), series.Width, ConvertDashStyle(series.LineDashStyle));
+                context.DrawLine(pen, xLast, y, x2, y);
+            }
+            
+            // 2) Draw label at line end (x2) if labels are enabled
+            if (_drawText)
+            {
+                var size = context.MeasureString(label, _font);
+                var xText = (int)(x2 - size.Width - pad);
+                var yText = (int)(y - size.Height - pad);
+                context.DrawString(label, _font, ConvertColor(series.Color), xText, yText);
+            }
+        }
     }
 
 	// --- Helpers for robust custom-session handling ---

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -10,13 +10,8 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
-using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
-using System.Security.Policy;
-using System.Windows;
-using System.Windows.Media;
-using System.Xml.Linq;
 using Pen = System.Drawing.Pen;
 
 [DisplayName("Initial Balance")]
@@ -650,6 +645,7 @@ public class InitialBalance : Indicator
 			_lastStartBar = bar;
 			_endTime = candleFullDateTime.AddMinutes(_period);
             _isStarted = true;
+            _lastEndBar = -1; // reset anchor for the new session
 
             foreach (var dataSeries in DataSeries)
                 if (dataSeries is ValueDataSeries series)
@@ -767,8 +763,8 @@ public class InitialBalance : Indicator
             _ => System.Drawing.Drawing2D.DashStyle.Solid
         };
 
-	// Render labels at the right edge of the chart for current values
-	protected override void OnRender(RenderContext context, DrawingLayouts layout)
+    // Render labels exactly at the line end (right edge if extension is active; else at last/session-end bar)
+    protected override void OnRender(RenderContext context, DrawingLayouts layout)
     {
         if (!_initialized)
 			return;

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -542,22 +542,19 @@ public class InitialBalance : Indicator
 		_initialized = true;
 		var candle = GetCandle(bar);
 
-		var time = candle.Time.AddHours(InstrumentInfo.TimeZone).TimeOfDay;
-		var lastTime = candle.LastTime.AddHours(InstrumentInfo.TimeZone).TimeOfDay;
-		
+        // Local candle boundaries
+        var candleStartLocal = candle.Time.AddHours(InstrumentInfo.TimeZone);
+        var candleEndLocal = candle.LastTime.AddHours(InstrumentInfo.TimeZone);
+
+        // Preserve upstream variables used later for isStart logic
+		var time = candleStartLocal.TimeOfDay;
+        var lastTime = candleEndLocal.TimeOfDay;
+
+        // Robust custom-session check using absolute datetimes (overnight-safe)
         if (CustomSessionStart)
 		{
-			bool inSession;
-
-            if (StartDate < EndDate)
-				inSession = (time >= StartDate || lastTime >= StartDate) && time < EndDate;
-			else if (StartDate > EndDate)
-			{
-				inSession = ((time >= StartDate || lastTime >= StartDate) && time > EndDate)
-						 || ((time <= EndDate || lastTime <= EndDate) && time < EndDate);
-            }
-			else
-				inSession = true;
+            var (sessionStart, sessionEnd) = GetCustomSessionWindow(candleStartLocal);
+            var inSession = Intersects(candleStartLocal, candleEndLocal, sessionStart, sessionEnd);
 
             if (!inSession)
 			{
@@ -565,7 +562,7 @@ public class InitialBalance : Indicator
 
                 foreach (var dataSeries in DataSeries)
 					if (dataSeries is ValueDataSeries series)
-						series.SetPointOfEndLine(bar - 1);
+						series.SetPointOfEndLine(Math.Max(0, bar - 1));
                 return;
 			}
 		}
@@ -740,7 +737,28 @@ public class InitialBalance : Indicator
 	private System.Drawing.Color ConvertColor(CrossColor color)
 	{
 		return System.Drawing.Color.FromArgb(color.A, color.R, color.G, color.B);
-	}
+    }
 
-	#endregion
+	// --- Helpers for robust custom-session handling ---
+    // Normalizes custom session window to absolute datetimes for the candle's local date.
+    // Handles overnight sessions: if StartDate > EndDate, the end is on the next day.
+    private (DateTime start, DateTime end) GetCustomSessionWindow(DateTime candleLocalStart)
+    {
+        var baseDate = candleLocalStart.Date;
+        var start = baseDate + StartDate;
+        var end = baseDate + EndDate;
+
+        if (StartDate > EndDate)
+            end = end.AddDays(1);
+
+        return (start, end);
+    }
+
+    // Returns true if [aStart, aEnd] intersects [bStart, bEnd)
+    private static bool Intersects(DateTime aStart, DateTime aEnd, DateTime bStart, DateTime bEnd)
+    {
+        return aStart < bEnd && aEnd > bStart;
+    }
+
+    #endregion
 }

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -13,6 +13,8 @@ using OFT.Localization;
 using OFT.Rendering.Settings;
 
 using Pen = System.Drawing.Pen;
+using OFT.Rendering.Context;
+using OFT.Rendering.Tools;
 
 [DisplayName("Initial Balance")]
 [Category(IndicatorCategories.VolumeOrderFlow)]
@@ -181,8 +183,10 @@ public class InitialBalance : Indicator
 	private decimal _ibMax = decimal.MinValue;
 	private decimal _ibMin = decimal.MaxValue;
 	private decimal _ibmValue = decimal.Zero;
+    private float _fontSize = 12.0f;
+    private RenderFont _font;
 
-	private bool _initialized;
+    private bool _initialized;
 	private int _lastStartBar = -1;
 	private decimal _maxValue = decimal.MinValue;
 	private decimal _minValue = decimal.MaxValue;
@@ -382,7 +386,22 @@ public class InitialBalance : Indicator
 			_drawText = value;
 			RecalculateValues();
 		}
-	}
+    }
+
+	// Label font size (for text drawing)
+    [Display(Name = "Font Size",
+	GroupName = nameof(Strings.Show), Description = "Label font size", Order = 135)]
+    [Range(6, 48)]
+    public float FontSize
+    {
+        get => _fontSize;
+        set
+        {
+            _fontSize = value;
+            _font = new RenderFont("Arial", _fontSize);
+            RecalculateValues();
+        }
+    }
 
 	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBHX32), 
 		GroupName = nameof(Strings.BackGround), Description = nameof(Strings.AreaColorDescription), Order = 200)]
@@ -456,6 +475,9 @@ public class InitialBalance : Indicator
 		: base(true)
 	{
 		DenyToChangePanel = true;
+        EnableCustomDrawing = true;
+        SubscribeToDrawingEvents(DrawingLayouts.Final);
+        _font = new RenderFont("Arial", _fontSize);
 
         DataSeries[0] = _mid;
         DataSeries.Add(_ibh);

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -304,6 +304,7 @@ public class InitialBalance : Indicator
 		set
 		{
 			_customSessionStart = value;
+			InvalidateSessionsAndRedraw(); // toggle custom session on/off -> purge old state
 			RecalculateValues();
 		}
 	}
@@ -316,7 +317,8 @@ public class InitialBalance : Indicator
 		set
 		{
 			_startDate = value;
-			RecalculateValues();
+            InvalidateSessionsAndRedraw(); // ensure no stale sessions/labels when the start time moves
+            RecalculateValues();
 		}
 	}
 
@@ -328,7 +330,8 @@ public class InitialBalance : Indicator
 		set
 		{
 			_endDate = value;
-			RecalculateValues();
+            InvalidateSessionsAndRedraw(); // ensure no stale sessions/labels when the start time moves
+            RecalculateValues();
 		}
 	}
 
@@ -342,7 +345,8 @@ public class InitialBalance : Indicator
 		set
 		{
 			_period = value;
-			RecalculateValues();
+            InvalidateSessionsAndRedraw(); // IB window length change affects session cache
+            RecalculateValues();
 		}
 	}
 
@@ -354,7 +358,8 @@ public class InitialBalance : Indicator
 		set
 		{
 			_periodMode = value;
-			RecalculateValues();
+            InvalidateSessionsAndRedraw(); // switching Minutes <-> Bars requires full rebuild
+            RecalculateValues();
 		}
 	}
 
@@ -597,7 +602,8 @@ public class InitialBalance : Indicator
 			_ibmValue = decimal.Zero;
 			_highLowIsSet = false;
 			_lastStartBar = -1;
-			_endTime = DateTime.MaxValue;
+            _lastEndBar = -1;
+            _endTime = DateTime.MaxValue;
 			_calculate = false;
 			_initialized = false;
 			_targetBar = 0;
@@ -692,6 +698,7 @@ public class InitialBalance : Indicator
 			_endTime = candleFullDateTime.AddMinutes(_period);
             _isStarted = true;
             _lastEndBar = -1; // reset anchor for the new session
+            _sessionBuffer.Clear(); // ensure no snapshots from a previous configuration
 
             foreach (var dataSeries in DataSeries)
                 if (dataSeries is ValueDataSeries series)
@@ -993,7 +1000,49 @@ public class InitialBalance : Indicator
         foreach (var ds in DataSeries)
 			if (ds is ValueDataSeries vs)
 				vs.SetPointOfEndLine(Math.Max(0, _lastStartBar - 1));
-   }
+    }
+
+    // Centralized invalidation when session-defining parameters change.
+    // Fully clears buffers, series, and rectangles to prevent stale labels/lines
+    // after editing Start/End/Period/PeriodMode or toggling custom session.
+    private void InvalidateSessionsAndRedraw()
+    {
+        // 1) Visuals
+        Rectangles.Clear(); // remove any previous Open Range rectangle
+
+        // 2) Data series (lines and range fills)
+        foreach (var ds in DataSeries)
+            ds.Clear();
+
+        // 3) Internal state
+        _sessionBuffer.Clear();
+
+        _highLowIsSet = false;
+        _calculate = false;
+        _isStarted = false;
+        _initialized = false;
+
+        _lastStartBar = -1;
+        _lastEndBar = -1;
+        _endTime = DateTime.MaxValue;
+
+        _maxValue = decimal.MinValue;
+        _minValue = decimal.MaxValue;
+
+        _ibMax = decimal.MinValue;
+        _ibMin = decimal.MaxValue;
+        _ibmValue = 0m;
+
+        mid = 0m;
+        ibhx1 = ibhx2 = ibhx3 = 0m;
+        iblx1 = iblx2 = iblx3 = 0m;
+
+        _targetBar = 0;
+
+        // 4) Redraw
+        RedrawChart();
+    }
+
 
     #endregion
 }

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -728,9 +728,14 @@ public class InitialBalance : Indicator
             _calculate = _isStarted = false;
             _sessionBuffer.Clear();
             _lastEndBar = Math.Max(_lastEndBar, bar);
-        }
 
-		if (_calculate)
+            // hard-stop lines at the session end
+            foreach (var ds in DataSeries)
+                if (ds is ValueDataSeries vs)
+                    vs.SetPointOfEndLine(_lastEndBar);
+		}
+
+        if (_calculate)
 		{
 			if (candle.High > _maxValue)
 			{
@@ -842,57 +847,54 @@ public class InitialBalance : Indicator
     {
         if (!_initialized)
 			return;
-        
-        // Use the last completed/visible bar as the anchor for values and positions.
-        var bar = Math.Max(0, CurrentBar - 1);
-        if (bar <= 0)
-			return;
-        
-        // Determine if custom session is currently active. If no custom session, treat as active (for extension semantics opt-in only).
+
+        // Determine the bar where the visible series actually ends:
+        // - If IB finished, it's the exact end of the IB window (_lastEndBar).
+        // - Otherwise (we're showing live formation), use the last plotted bar.
+        var seriesEndBar = _lastEndBar >= 0
+            ? _lastEndBar
+            : Math.Max(0, CurrentBar - 1);
+
+        if (seriesEndBar <= 0)
+            return;
+
+        // Resolve session activity for the current chart time.
+        // Custom session: extend only while the current candle interval intersects the session window.
+        // Default (no custom): keep current behavior (consider active) so extension is opt-in only via the property.
         bool sessionActive = true;
         if (CustomSessionStart)
         {
-            var lastStart = GetCandle(bar).Time.AddHours(InstrumentInfo.TimeZone);
-            var lastEnd = GetCandle(bar).LastTime.AddHours(InstrumentInfo.TimeZone);
-            var(ss, se) = GetCustomSessionWindow(lastStart);
-            sessionActive = Intersects(lastStart, lastEnd, ss, se);
+            var lastStartLocal = GetCandle(Math.Max(0, CurrentBar - 1)).Time.AddHours(InstrumentInfo.TimeZone);
+            var lastEndLocal = GetCandle(Math.Max(0, CurrentBar - 1)).LastTime.AddHours(InstrumentInfo.TimeZone);
+            var (ss, se) = GetCustomSessionWindow(lastStartLocal);
+            sessionActive = Intersects(lastStartLocal, lastEndLocal, ss, se);
         }
-        
+
+        // We only extend if:
+        // - the property is enabled,
+        // - the session is currently active,
+        // - and the IB window has ALREADY finished (so extension starts at IB end and runs to the right edge).
+        var allowExtension = _extendLastLineToRight && sessionActive && _lastEndBar >= 0;
+
         // Compute X coordinates:
-        // - xLast: where the plotted series already ends (last bar)
-        // - x2: where the line should end (right edge if extending & active; otherwise anchor bar)
-        var xLast = ChartInfo.GetXByBar(bar, false);
-        int x2;
-        if (_extendLastLineToRight && sessionActive)
-        {
-			// Active and extension enabled ? anchor at right edge
-            x2 = context.ClipBounds.Right;
-        }
-        else
-        {
-            // No extension ? anchor at last known session end bar (if recorded), else at last bar
-            var anchorBar = _lastEndBar >= 0 ? _lastEndBar : bar;
-            x2 = ChartInfo.GetXByBar(Math.Max(0, anchorBar), false);
-        }
-        
-        // Only draw the extension segment to avoid overdrawing series; skip if x2 is not beyond last plotted X.
-        var drawExtension = _extendLastLineToRight && sessionActive && x2 > xLast;
-        
-        // Prepare label/series/value triplets using the latest values at 'bar'.
+        var xSeriesEnd = ChartInfo.GetXByBar(seriesEndBar, false);
+        var xRight = context.ClipBounds.Right;
+
+        // Prepare label/value triplets using the last valid values at seriesEndBar.
         var items = new (string Label, ValueDataSeries Series, decimal Value)[]
         {
-            ("Mid", _mid, _mid[bar]),
-			("IBH", _ibh, _ibh[bar]),
-			("IBL", _ibl, _ibl[bar]),
-			("IBM", _ibm, _ibm[bar]),
-			("IBHX1", _ibhx1, _ibhx1[bar]),
-			("IBHX2", _ibhx2, _ibhx2[bar]),
-			("IBHX3", _ibhx3, _ibhx3[bar]),
-			("IBLX1", _iblx1, _iblx1[bar]),
-			("IBLX2", _iblx2, _iblx2[bar]),
-			("IBLX3", _iblx3, _iblx3[bar]),
+        ("Mid",   _mid,   _mid[seriesEndBar]),
+        ("IBH",   _ibh,   _ibh[seriesEndBar]),
+        ("IBL",   _ibl,   _ibl[seriesEndBar]),
+        ("IBM",   _ibm,   _ibm[seriesEndBar]),
+        ("IBHX1", _ibhx1, _ibhx1[seriesEndBar]),
+        ("IBHX2", _ibhx2, _ibhx2[seriesEndBar]),
+        ("IBHX3", _ibhx3, _ibhx3[seriesEndBar]),
+        ("IBLX1", _iblx1, _iblx1[seriesEndBar]),
+        ("IBLX2", _iblx2, _iblx2[seriesEndBar]),
+        ("IBLX3", _iblx3, _iblx3[seriesEndBar]),
         };
-        
+
         const int pad = 2;
         
         foreach (var (label, series, price) in items)
@@ -904,21 +906,29 @@ public class InitialBalance : Indicator
             var y = ChartInfo.GetYByPrice(price, false);
             if (y < 0)
 				continue;
-            
-            // 1) Draw only the extension segment (if applicable)
-            if (drawExtension)
+
+            // 1) Optional right-edge visual extension from series end to chart right bound
+            if (allowExtension && xRight > xSeriesEnd)
             {
                 var pen = new RenderPen(ConvertColor(series.Color), series.Width, ConvertDashStyle(series.LineDashStyle));
-                context.DrawLine(pen, xLast, y, x2, y);
+                context.DrawLine(pen, xSeriesEnd, y, xRight, y);
             }
-            
-            // 2) Draw label at line end (x2) if labels are enabled
+
+            // 2) Draw label at the line end:
+            //    - If extending: anchor at the right edge.
+            //    - If not extending: anchor at the series end bar (IB end).
             if (_drawText)
             {
                 var size = context.MeasureString(label, _font);
-                var xText = (int)(x2 - size.Width - pad);
+                var xText = (int)((allowExtension ? xRight : xSeriesEnd) - size.Width - pad);
                 var yText = (int)(y - size.Height - pad);
-                context.DrawString(label, _font, ConvertColor(series.Color), xText, yText);
+
+                // Ensure label remains visible even if the line itself is transparent (e.g., Mid with A=0).
+                var labelColor = ConvertColor(series.Color);
+                if (labelColor.A == 0)
+                    labelColor = System.Drawing.Color.FromArgb(255, labelColor.R, labelColor.G, labelColor.B);
+
+                context.DrawString(label, _font, labelColor, xText, yText);
             }
         }
     }


### PR DESCRIPTION
## Summary

This PR fixes a session-boundary bug in *Initial Balance* and adds rendering improvements while keeping upstream behavior intact.

### Fixes
- **Session boundary (custom sessions, incl. overnight):**
  - Lines no longer “survive” after leaving the custom session window.
  - Robust window handling using absolute datetimes and intersection logic.
  - Record of the last session bar to correctly terminate lines and anchor labels.

### Enhancements
- **Labels anchored to line end**: labels are rendered where the line ends—  
  - if `ExtendLastLineToRight = true` and the session is active → right edge of the chart,  
  - otherwise → at the last bar of the session (or recorded end bar).
- **Optional line extension**: `ExtendLastLineToRight` to visually extend the last segment while the session is active (no historical overdrawing).
- **Configurable label size**: `FontSize` parameter for label text.
- **“Show During Formation”**:
  - When **off**: IB lines/labels are hidden while the IB window is forming; values are buffered in memory (no writes to `ValueDataSeries`).
  - When **toggled on** mid-formation: we **backfill** the buffer into `ValueDataSeries`.
  - When the IB window **finishes** and it was hidden: we backfill the whole window so the full session becomes visible.
  - The Open Range rectangle remains governed by `ShowOpenRange` (independent of this toggle).

These changes keep upstream series semantics for completed windows and prior sessions, while avoiding the visual “leak” across session boundaries.

---

## Rationale

- Upstream wrote labels via `AddText` in `OnCalculate`, which made anchoring to the dynamic line end awkward and could leave artifacts. We moved label drawing into `OnRender` (no change to data), which:
  - prevents overdrawing,
  - lets us anchor labels at the true end segment,
  - and respects the `ExtendLastLineToRight` setting cleanly.

- For overnight custom sessions (`StartDate > EndDate`), we normalize to absolute datetimes (local) and use `Intersects()` between candle and session windows for reliable in/out checks.

---

## User-facing changes

- New options in the **Show** / **Drawing** groups:
  - **Font Size** *(Show)*: label font size (default 12).
  - **Extend Last Line to Right** *(Show/Drawing)*: extend last segment to the right edge while active; labels anchor at the end.
  - **Show During Formation** *(Show)*: show/hide IB lines/labels while the IB window is forming. When off, values are buffered and later backfilled.

---

## Implementation notes

- **Session window handling**
  - `GetCustomSessionWindow(DateTime candleLocalStart)` → absolute start/end (adds +1 day when `StartDate > EndDate`).
  - `Intersects(DateTime aStart, DateTime aEnd, DateTime bStart, DateTime bEnd)` → robust in/out.
  - Tracks `_lastEndBar` to clip lines and anchor labels after session exit.

- **Rendering**
  - `OnRender` computes `xLast` vs `x2`:
    - extended to right edge only for the *current active* window when `ExtendLastLineToRight = true`.
    - otherwise anchors at the last/session-end bar.
  - Draws only the **extension segment** to avoid overdrawing historical series.

- **Show During Formation**
  - Uses a per-session in-memory buffer of IB snapshots.
  - When hidden, we truncate visible lines during formation (`SetPointOfEndLine(_lastStartBar - 1)`).
  - On toggle/finish, we backfill buffer into `ValueDataSeries` and recompute ranges.

- **Open Range rectangle**
  - Still controlled by `ShowOpenRange`. (We can wire it to `ShowDuringFormation` if desired—see follow-ups.)

---

## Compatibility

- No breaking changes to existing inputs or persisted settings.
- Default behavior matches upstream when:
  - `ExtendLastLineToRight = true` (default) → lines extend during active window,
  - `ShowDuringFormation = true` (if you keep default on) → immediate visibility consistent with upstream visual expectations.

---

## Test plan

1. **Baseline (no custom session)**
   - IB forms within regular session; with `ExtendLastLineToRight = true`, lines visually extend to the right only for the active window.
   - Labels appear at the segment end. Toggle `DrawText` on/off to verify.

2. **Custom session, same-day (Start < End)**
   - During the window: with `ShowDuringFormation = false`, IB is hidden; toggle to `true` → buffer backfills and becomes visible.
   - After window ends: IB remains visible from its start to end; labels stay placed at the ending bar.

3. **Custom session, overnight (Start > End)**
   - Before `Start`: nothing drawn.
   - Between `Start` and `End(+1d)`: behavior matches the above (formation visibility toggle works).
   - After exit: lines do not extend beyond `_lastEndBar`; labels anchor at that bar.

4. **Open Range rectangle**
   - With `ShowOpenRange = true`, rectangle tracks high/low during formation.
   - Turning `ShowOpenRange` off hides it; other visuals unaffected.

5. **Toggles live**
   - Flip `ExtendLastLineToRight` while forming and after finish → only the last segment re-renders; no history corruption.
   - Change `FontSize` → labels re-render with the new size.

---

## Performance

- Label drawing moved to `OnRender` (lightweight).
- Buffering per session is linear in bars of the IB window and cleared after backfill.
- No additional allocations on historical replays beyond the buffer.

---

## Commits (logical grouping)

- **feat(rendering):** label anchoring at line end in `OnRender` + `ExtendLastLineToRight`
- **feat(ui):** add `FontSize` parameter for labels
- **feat(visibility):** add `ShowDuringFormation` with per-session buffer and backfill
- **fix(session):** robust custom-session boundary handling (incl. overnight) + end-of-session clipping

---

## Follow-ups (optional)

- **i18n**: migrate literals (“Font Size”, “Extend Last Line to Right”, “Show During Formation”) to `Strings` resources.
- **Tie rectangle to ShowDuringFormation** (if you want it hidden during formation when the toggle is off).
- **Unit/integration tests** for session boundary cases (overnight, edge-case candles at boundary).

---

## Files touched

- `ATAS.Indicators.Technical/InitialBalance.cs`

---

## Checklist

- [x] No breaking changes to public API
- [x] Works with and without custom sessions
- [x] Overnight custom session handled
- [x] Label anchoring verified
- [x] Live toggles: formation visibility / extend / font size
- [x] Open Range rectangle remains controlled by `ShowOpenRange`

---

## Screens / GIFs

a) formation hidden then toggled visible with backfill;
<img width="635" height="524" alt="image" src="https://github.com/user-attachments/assets/e41eeca1-19f2-448a-abe2-e0bfce845fa8" />
<img width="591" height="328" alt="image" src="https://github.com/user-attachments/assets/49e29860-a871-42ad-be3b-90ffff4cb11b" />
 b) extend-to-right on/off; 
<img width="1214" height="515" alt="image" src="https://github.com/user-attachments/assets/28f0814f-1be0-4f20-a2b6-ee62f7bba42d" />
<img width="876" height="561" alt="image" src="https://github.com/user-attachments/assets/3e420398-4567-4e6c-a4fa-7ab6a479a0f6" />
c) overnight session ending with labels anchored at the last bar.)


