### PR TITLE
Feature/Initial Balance - Label position, unified label rendering, and continuity after IB window (stacked on top #95)

### DIFF
--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -215,6 +215,9 @@ public class InitialBalance : Indicator
     private decimal _sIBHX1, _sIBHX2, _sIBHX3;
     private decimal _sIBLX1, _sIBLX2, _sIBLX3;
 
+    // Track where the whole trading session ended (last bar inside the session).
+    private int _lastSessionEndBar = -1;
+
     #endregion
 
     #region Properties
@@ -597,6 +600,9 @@ public class InitialBalance : Indicator
 			{
 				_isStarted = false;
 
+                //Remember the last bar that belonged to the session
+                _lastSessionEndBar = Math.Max(0, bar - 1);
+
                 foreach (var dataSeries in DataSeries)
 					if (dataSeries is ValueDataSeries series)
 						series.SetPointOfEndLine(bar - 1);
@@ -740,8 +746,10 @@ public class InitialBalance : Indicator
     }
 
     /// <summary>
-    /// Renders a single set of IB labels for the most recent session when LabelPosition is Left or Right.
+    /// Renders a single set of IB labels for the most recent session.
     /// It does not draw historical session labels and does not modify any ValueDataSeries.
+	//// Labels rendering - freeze at the last in-session bar only for CUSTOM sessions.
+	/// For auto sessions, labels always follow the chosen LabelPosition.
     /// </summary>
     protected override void OnRender(RenderContext context, DrawingLayouts layout)
     {
@@ -751,12 +759,23 @@ public class InitialBalance : Indicator
         var chartWidth = ChartInfo.PriceChartContainer.Region.Width;
         var endBar = Math.Max(0, CurrentBar - 1);
 
-        // Si la sesión terminó, usa snapshot; si no, usa valores del último bar
-        bool sessionFinished = _lastIbEndBar >= 0 && endBar >= _lastIbEndBar && !_isStarted;
+        // IB window finished (we have a snapshot of IB levels)
+        bool ibWindowFinished = _lastIbEndBar >= 0 && endBar >= _lastIbEndBar && !_isStarted;
 
+        // Session considered finished ONLY for custom sessions.
+        // For auto sessions we do not freeze labels; they continue to follow LabelPosition.
+        bool afterCustomSession =
+            _customSessionStart &&
+            _lastSessionEndBar >= 0 &&
+            endBar > _lastSessionEndBar &&
+            !_isStarted;
+
+        // Resolve level values:
+        // - If the IB window finished, prefer the snapshot (stable values during/after session).
+        // - Otherwise, use the last formed bar
         decimal vMid, vIbh, vIbl, vIbm, vX1u, vX2u, vX3u, vX1l, vX2l, vX3l;
 
-        if (sessionFinished)
+        if (ibWindowFinished)
         {
             vMid = _sMID; vIbh = _sIBH; vIbl = _sIBL; vIbm = _sIBM;
             vX1u = _sIBHX1; vX2u = _sIBHX2; vX3u = _sIBHX3;
@@ -769,6 +788,7 @@ public class InitialBalance : Indicator
             vX1l = _iblx1[endBar]; vX2l = _iblx2[endBar]; vX3l = _iblx3[endBar];
         }
 
+        // Build the draw list (label text + series reference + value)
         var items = new (string Label, ValueDataSeries Series, decimal Value)[]
         {
         ("Mid",   _mid,   vMid),
@@ -783,21 +803,37 @@ public class InitialBalance : Indicator
         ("IBLX3", _iblx3, vX3l),
         };
 
-        // Anclaje X según LabelPosition (misma estética, distinta posición)
+        // Decide the X anchor for labels:
+        // - If AFTER a CUSTOM session ended: freeze at the last in-session bar (Bar-style), ignoring LabelPosition.
+        // - Else (during session OR auto sessions): follow LabelPosition normally.
         int x; bool alignRight;
-        switch (LabelPosition)
+
+        if (afterCustomSession)
         {
-            case LabelPosition.Right:
-                x = chartWidth - 5; alignRight = true; break;
-            case LabelPosition.Left:
-                x = 5; alignRight = false; break;
-            case LabelPosition.Bar:
-            default:
-                var xBar = ChartInfo.GetXByBar(endBar);
-                var barWidth = (int)ChartInfo.PriceChartContainer.BarsWidth;
-                x = xBar + barWidth + 5; alignRight = false; break;
+            // Freeze at the last bar of the custom session (behaves like Bar position).
+            var xBar = ChartInfo.GetXByBar(_lastSessionEndBar);
+            var barWidth = (int)ChartInfo.PriceChartContainer.BarsWidth;
+            x = xBar + barWidth + 5;
+            alignRight = false;
+        }
+        else
+        {
+            // Live (or auto sessions): honor the chosen LabelPosition
+            switch (LabelPosition)
+            {
+                case LabelPosition.Right:
+                    x = chartWidth - 5; alignRight = true; break;
+                case LabelPosition.Left:
+                    x = 5; alignRight = false; break;
+                case LabelPosition.Bar:
+                default:
+                    var xBar = ChartInfo.GetXByBar(endBar);
+                    var barWidth = (int)ChartInfo.PriceChartContainer.BarsWidth;
+                    x = xBar + barWidth + 5; alignRight = false; break;
+            }
         }
 
+        // Draw labels (after any overlay lines so labels stay on top)
         foreach (var (label, series, price) in items)
         {
             if (price == 0m || price == decimal.MinValue || price == decimal.MaxValue)

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -711,34 +711,34 @@ public class InitialBalance : Indicator
         if (DrawText)
 		{
 			AddText(_lastStartBar + "Mid", "Mid", true, bar, mid, 0, 0, ConvertColor(_mid.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
 
 			AddText(_lastStartBar + "IBH", "IBH", true, bar, _ibMax, 0, 0, ConvertColor(_ibh.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
 
 			AddText(_lastStartBar + "IBL", "IBL", true, bar, _ibMin, 0, 0, ConvertColor(_ibl.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
 
 			AddText(_lastStartBar + "IBM", "IBM", true, bar, _ibmValue, 0, 0, ConvertColor(_ibm.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
 
 			AddText(_lastStartBar + "IBHX1", "IBHX1", true, bar, ibhx1, 0, 0, ConvertColor(_ibhx1.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
 
 			AddText(_lastStartBar + "IBHX2", "IBHX2", true, bar, ibhx2, 0, 0, ConvertColor(_ibhx2.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent, _fontSize	, DrawingText.TextAlign.Right);
 
 			AddText(_lastStartBar + "IBHX3", "IBHX3", true, bar, ibhx3, 0, 0, ConvertColor(_ibhx3.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent,	_fontSize, DrawingText.TextAlign.Right);
 
 			AddText(_lastStartBar + "IBLX1", "IBLX1", true, bar, iblx1, 0, 0, ConvertColor(_iblx1.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
 
 			AddText(_lastStartBar + "IBLX2", "IBLX2", true, bar, iblx2, 0, 0, ConvertColor(_iblx2.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
 
 			AddText(_lastStartBar + "IBLX3", "IBLX3", true, bar, iblx3, 0, 0, ConvertColor(_iblx3.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
 		}
 	}
 

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -13,6 +13,8 @@ using OFT.Localization;
 using OFT.Rendering.Settings;
 
 using Pen = System.Drawing.Pen;
+using OFT.Rendering.Context;
+using OFT.Rendering.Tools;
 
 [DisplayName("Initial Balance")]
 [Category(IndicatorCategories.VolumeOrderFlow)]
@@ -181,8 +183,10 @@ public class InitialBalance : Indicator
 	private decimal _ibMax = decimal.MinValue;
 	private decimal _ibMin = decimal.MaxValue;
 	private decimal _ibmValue = decimal.Zero;
+    private float _fontSize = 12.0f;
+    private RenderFont _font;
 
-	private bool _initialized;
+    private bool _initialized;
 	private int _lastStartBar = -1;
 	private decimal _maxValue = decimal.MinValue;
 	private decimal _minValue = decimal.MaxValue;
@@ -382,7 +386,22 @@ public class InitialBalance : Indicator
 			_drawText = value;
 			RecalculateValues();
 		}
-	}
+    }
+
+	// Label font size (for text drawing)
+    [Display(Name = "Font Size",
+	GroupName = nameof(Strings.Show), Description = "Label font size", Order = 135)]
+    [Range(6, 48)]
+    public float FontSize
+    {
+        get => _fontSize;
+        set
+        {
+            _fontSize = value;
+            _font = new RenderFont("Arial", _fontSize);
+            RecalculateValues();
+        }
+    }
 
 	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBHX32), 
 		GroupName = nameof(Strings.BackGround), Description = nameof(Strings.AreaColorDescription), Order = 200)]
@@ -456,6 +475,9 @@ public class InitialBalance : Indicator
 		: base(true)
 	{
 		DenyToChangePanel = true;
+        EnableCustomDrawing = true;
+        SubscribeToDrawingEvents(DrawingLayouts.Final);
+        _font = new RenderFont("Arial", _fontSize);
 
         DataSeries[0] = _mid;
         DataSeries.Add(_ibh);

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -407,7 +407,20 @@ public class InitialBalance : Indicator
     GroupName = nameof(Strings.Show),
     Description = "Where to draw labels for IB levels",
     Order = 136)]
-    public LabelPosition LabelPosition { get; set; } = LabelPosition.Bar;
+    private LabelPosition _labelPosition = LabelPosition.Bar;
+    public LabelPosition LabelPosition
+    {
+        get => _labelPosition;
+        set
+        {
+            if (_labelPosition == value)
+                return;
+
+            _labelPosition = value;
+            RecalculateValues();
+            RedrawChart();
+        }
+    }
 
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBHX32), 
 		GroupName = nameof(Strings.BackGround), Description = nameof(Strings.AreaColorDescription), Order = 200)]
@@ -746,25 +759,32 @@ public class InitialBalance : Indicator
 			AddText(_lastStartBar + "IBLX3", "IBLX3", true, bar, iblx3, 0, 0, ConvertColor(_iblx3.Color), System.Drawing.Color.Transparent,
 				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
 		}
+
+
 	}
 
+    /// <summary>
+    /// Renders a single set of IB labels for the most recent session when LabelPosition is Left or Right.
+    /// It does not draw historical session labels and does not modify any ValueDataSeries.
+    /// </summary>
     protected override void OnRender(RenderContext context, DrawingLayouts layout)
     {
-        // Draw labels only when requested and only for Left/Right positions.
         if (!DrawText || LabelPosition == LabelPosition.None || LabelPosition == LabelPosition.Bar)
             return;
 
         if (ChartInfo is null)
             return;
 
-        // Use the last fully-formed bar as a safe source for values and coordinates.
+        // Use the last formed bar for stable coordinates/values
         var endBar = Math.Max(0, CurrentBar - 1);
-        var chartWidth = ChartInfo.PriceChartContainer.Region.Width;
-        var currentBarX = ChartInfo.GetXByBar(endBar);
-        var barWidth = (int)ChartInfo.PriceChartContainer.BarsWidth;
-        var currentBarRightX = currentBarX + barWidth;
 
-        // List of IB-related levels to label.
+        // If there is no valid session start, skip drawing
+        if (_lastStartBar < 0 || endBar < _lastStartBar)
+            return;
+
+        var chartWidth = ChartInfo.PriceChartContainer.Region.Width;
+
+        // Prepare the current session’s last values only (no past sessions)
         var items = new (string Label, ValueDataSeries Series, decimal Value)[]
         {
         ("Mid",   _mid,   _mid[endBar]),
@@ -779,6 +799,9 @@ public class InitialBalance : Indicator
         ("IBLX3", _iblx3, _iblx3[endBar]),
         };
 
+        var alignRight = LabelPosition == LabelPosition.Right;
+        var x = alignRight ? chartWidth - 5 : 5;
+
         foreach (var (label, series, price) in items)
         {
             if (price == 0m || price == decimal.MinValue || price == decimal.MaxValue)
@@ -788,23 +811,22 @@ public class InitialBalance : Indicator
             if (y < 0 || y > ChartInfo.PriceChartContainer.Region.Height)
                 continue;
 
-            // Compute the target X anchor based on the desired label position.
-            bool alignRight = LabelPosition == LabelPosition.Right;
-            int x = LabelPosition == LabelPosition.Right ? chartWidth - 5 : 5;
-
             DrawTextLabel(context, label, x, y, series, alignRight);
         }
     }
 
-    // Helper: Draws a boxed text label at the given (x,y) position (like OHLCPlus.DrawTextLabel)
     private void DrawTextLabel(RenderContext context, string text, int x, int y, ValueDataSeries series, bool alignRight)
     {
         var size = context.MeasureString(text, _font);
         var textColor = ChartInfo.ColorsStore.MouseTextColor;
-
-        // Fondo y borde como en OHLCPlus
         var backgroundColor = ChartInfo.ColorsStore.BaseBackgroundColor;
-        var pen = new PenSettings { Color = series.Color, Width = series.Width, LineDashStyle = series.LineDashStyle }.RenderObject;
+
+        var pen = new PenSettings
+        {
+            Color = series.Color,
+            Width = series.Width,
+            LineDashStyle = series.LineDashStyle
+        }.RenderObject;
 
         var rectX = alignRight ? x - size.Width : x;
         var rect = new Rectangle(rectX - 2, y - size.Height / 2 - 1, size.Width + 4, size.Height + 2);
@@ -816,6 +838,7 @@ public class InitialBalance : Indicator
         var format = alignRight ? _stringRightFormat : _stringLeftFormat;
         context.DrawString(text, _font, textColor, textRect, format);
     }
+
 
 
     private DateTime GetPrevDateTime(int bar)

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -681,9 +681,6 @@ public class InitialBalance : Indicator
 
             _calculate = _isStarted = false;
 
-            foreach (var ds in DataSeries)
-                if (ds is ValueDataSeries vs)
-                    vs.SetPointOfEndLine(bar);
         }
 
 		if (_calculate)

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -403,7 +403,13 @@ public class InitialBalance : Indicator
         }
     }
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBHX32), 
+    [Display(Name = "Label Position",
+    GroupName = nameof(Strings.Show),
+    Description = "Where to draw labels for IB levels",
+    Order = 136)]
+    public LabelPosition LabelPosition { get; set; } = LabelPosition.Bar;
+
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBHX32), 
 		GroupName = nameof(Strings.BackGround), Description = nameof(Strings.AreaColorDescription), Order = 200)]
 	public CrossColor Ibhx32
 	{
@@ -708,8 +714,8 @@ public class InitialBalance : Indicator
 		_iblx12[bar].Lower = _iblx23[bar].Upper = iblx2;
 		_iblx23[bar].Lower = iblx3;
 
-        if (DrawText)
-		{
+        if (DrawText && LabelPosition == LabelPosition.Bar)
+        {
 			AddText(_lastStartBar + "Mid", "Mid", true, bar, mid, 0, 0, ConvertColor(_mid.Color), System.Drawing.Color.Transparent,
 				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
 
@@ -742,6 +748,76 @@ public class InitialBalance : Indicator
 		}
 	}
 
+    protected override void OnRender(RenderContext context, DrawingLayouts layout)
+    {
+        // Draw labels only when requested and only for Left/Right positions.
+        if (!DrawText || LabelPosition == LabelPosition.None || LabelPosition == LabelPosition.Bar)
+            return;
+
+        if (ChartInfo is null)
+            return;
+
+        // Use the last fully-formed bar as a safe source for values and coordinates.
+        var endBar = Math.Max(0, CurrentBar - 1);
+        var chartWidth = ChartInfo.PriceChartContainer.Region.Width;
+        var currentBarX = ChartInfo.GetXByBar(endBar);
+        var barWidth = (int)ChartInfo.PriceChartContainer.BarsWidth;
+        var currentBarRightX = currentBarX + barWidth;
+
+        // List of IB-related levels to label.
+        var items = new (string Label, ValueDataSeries Series, decimal Value)[]
+        {
+        ("Mid",   _mid,   _mid[endBar]),
+        ("IBH",   _ibh,   _ibh[endBar]),
+        ("IBL",   _ibl,   _ibl[endBar]),
+        ("IBM",   _ibm,   _ibm[endBar]),
+        ("IBHX1", _ibhx1, _ibhx1[endBar]),
+        ("IBHX2", _ibhx2, _ibhx2[endBar]),
+        ("IBHX3", _ibhx3, _ibhx3[endBar]),
+        ("IBLX1", _iblx1, _iblx1[endBar]),
+        ("IBLX2", _iblx2, _iblx2[endBar]),
+        ("IBLX3", _iblx3, _iblx3[endBar]),
+        };
+
+        foreach (var (label, series, price) in items)
+        {
+            if (price == 0m || price == decimal.MinValue || price == decimal.MaxValue)
+                continue;
+
+            var y = ChartInfo.GetYByPrice(price, false);
+            if (y < 0 || y > ChartInfo.PriceChartContainer.Region.Height)
+                continue;
+
+            // Compute the target X anchor based on the desired label position.
+            bool alignRight = LabelPosition == LabelPosition.Right;
+            int x = LabelPosition == LabelPosition.Right ? chartWidth - 5 : 5;
+
+            DrawTextLabel(context, label, x, y, series, alignRight);
+        }
+    }
+
+    // Helper: Draws a boxed text label at the given (x,y) position (like OHLCPlus.DrawTextLabel)
+    private void DrawTextLabel(RenderContext context, string text, int x, int y, ValueDataSeries series, bool alignRight)
+    {
+        var size = context.MeasureString(text, _font);
+        var textColor = ChartInfo.ColorsStore.MouseTextColor;
+
+        // Fondo y borde como en OHLCPlus
+        var backgroundColor = ChartInfo.ColorsStore.BaseBackgroundColor;
+        var pen = new PenSettings { Color = series.Color, Width = series.Width, LineDashStyle = series.LineDashStyle }.RenderObject;
+
+        var rectX = alignRight ? x - size.Width : x;
+        var rect = new Rectangle(rectX - 2, y - size.Height / 2 - 1, size.Width + 4, size.Height + 2);
+
+        context.FillRectangle(backgroundColor, rect);
+        context.DrawRectangle(pen, rect);
+
+        var textRect = new Rectangle(rectX, y - size.Height / 2, size.Width, size.Height);
+        var format = alignRight ? _stringRightFormat : _stringLeftFormat;
+        context.DrawString(text, _font, textColor, textRect, format);
+    }
+
+
     private DateTime GetPrevDateTime(int bar)
     {
 		return GetCandle(bar - 1).Time.AddHours(InstrumentInfo.TimeZone);
@@ -764,5 +840,21 @@ public class InitialBalance : Indicator
 		return System.Drawing.Color.FromArgb(color.A, color.R, color.G, color.B);
 	}
 
-	#endregion
+    private RenderStringFormat _stringRightFormat = new()
+    {
+        Alignment = StringAlignment.Far,
+        LineAlignment = StringAlignment.Center,
+        Trimming = StringTrimming.EllipsisCharacter,
+        FormatFlags = StringFormatFlags.NoWrap
+    };
+
+    private RenderStringFormat _stringLeftFormat = new()
+    {
+        Alignment = StringAlignment.Near,
+        LineAlignment = StringAlignment.Center,
+        Trimming = StringTrimming.EllipsisCharacter,
+        FormatFlags = StringFormatFlags.NoWrap
+    };
+
+    #endregion
 }

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -209,6 +209,12 @@ public class InitialBalance : Indicator
 
 	private bool _isStarted;
 
+    // Last completed IB snapshot (used after the window ends)
+    private int _lastIbEndBar = -1;
+    private decimal _sIBH, _sIBL, _sIBM, _sMID;
+    private decimal _sIBHX1, _sIBHX2, _sIBHX3;
+    private decimal _sIBLX1, _sIBLX2, _sIBLX3;
+
     #endregion
 
     #region Properties
@@ -376,18 +382,6 @@ public class InitialBalance : Indicator
 		}
 	}
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Text),
-		GroupName = nameof(Strings.Show), Description = nameof(Strings.IsNeedShowLabelDescription), Order = 130)]
-	public bool DrawText
-	{
-		get => _drawText;
-		set
-		{
-			_drawText = value;
-			RecalculateValues();
-		}
-    }
-
 	// Label font size (for text drawing)
     [Display(Name = "Font Size",
 	GroupName = nameof(Strings.Show), Description = "Label font size", Order = 135)]
@@ -417,7 +411,6 @@ public class InitialBalance : Indicator
                 return;
 
             _labelPosition = value;
-            RecalculateValues();
             RedrawChart();
         }
     }
@@ -647,6 +640,7 @@ public class InitialBalance : Indicator
 			_lastStartBar = bar;
 			_endTime = candleFullDateTime.AddMinutes(_period);
             _isStarted = true;
+            _lastIbEndBar = -1;
 
             foreach (var dataSeries in DataSeries)
                 if (dataSeries is ValueDataSeries series)
@@ -670,7 +664,26 @@ public class InitialBalance : Indicator
 		}
 		else if (isEnd)
 		{
-			_calculate = _isStarted = false;
+            // Compute final values
+            var finalDiff = _ibMax - _ibMin;
+            var finalMid = (_minValue + _maxValue) / 2m;
+            var finalIbm = (_ibMin + _ibMax) / 2m;
+
+            // Snapshot last session
+            _lastIbEndBar = bar;
+            _sIBH = _ibMax; _sIBL = _ibMin; _sIBM = finalIbm; _sMID = finalMid;
+            _sIBHX1 = _ibMax + finalDiff * _x1;
+            _sIBHX2 = _ibMax + finalDiff * _x2;
+            _sIBHX3 = _ibMax + finalDiff * _x3;
+            _sIBLX1 = _ibMin - finalDiff * _x1;
+            _sIBLX2 = _ibMin - finalDiff * _x2;
+            _sIBLX3 = _ibMin - finalDiff * _x3;
+
+            _calculate = _isStarted = false;
+
+            foreach (var ds in DataSeries)
+                if (ds is ValueDataSeries vs)
+                    vs.SetPointOfEndLine(bar);
         }
 
 		if (_calculate)
@@ -727,41 +740,7 @@ public class InitialBalance : Indicator
 		_iblx12[bar].Lower = _iblx23[bar].Upper = iblx2;
 		_iblx23[bar].Lower = iblx3;
 
-        if (DrawText && LabelPosition == LabelPosition.Bar)
-        {
-			AddText(_lastStartBar + "Mid", "Mid", true, bar, mid, 0, 0, ConvertColor(_mid.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
-
-			AddText(_lastStartBar + "IBH", "IBH", true, bar, _ibMax, 0, 0, ConvertColor(_ibh.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
-
-			AddText(_lastStartBar + "IBL", "IBL", true, bar, _ibMin, 0, 0, ConvertColor(_ibl.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
-
-			AddText(_lastStartBar + "IBM", "IBM", true, bar, _ibmValue, 0, 0, ConvertColor(_ibm.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
-
-			AddText(_lastStartBar + "IBHX1", "IBHX1", true, bar, ibhx1, 0, 0, ConvertColor(_ibhx1.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
-
-			AddText(_lastStartBar + "IBHX2", "IBHX2", true, bar, ibhx2, 0, 0, ConvertColor(_ibhx2.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, _fontSize	, DrawingText.TextAlign.Right);
-
-			AddText(_lastStartBar + "IBHX3", "IBHX3", true, bar, ibhx3, 0, 0, ConvertColor(_ibhx3.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent,	_fontSize, DrawingText.TextAlign.Right);
-
-			AddText(_lastStartBar + "IBLX1", "IBLX1", true, bar, iblx1, 0, 0, ConvertColor(_iblx1.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
-
-			AddText(_lastStartBar + "IBLX2", "IBLX2", true, bar, iblx2, 0, 0, ConvertColor(_iblx2.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
-
-			AddText(_lastStartBar + "IBLX3", "IBLX3", true, bar, iblx3, 0, 0, ConvertColor(_iblx3.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
-		}
-
-
-	}
+    }
 
     /// <summary>
     /// Renders a single set of IB labels for the most recent session when LabelPosition is Left or Right.
@@ -769,38 +748,58 @@ public class InitialBalance : Indicator
     /// </summary>
     protected override void OnRender(RenderContext context, DrawingLayouts layout)
     {
-        if (!DrawText || LabelPosition == LabelPosition.None || LabelPosition == LabelPosition.Bar)
-            return;
-
-        if (ChartInfo is null)
-            return;
-
-        // Use the last formed bar for stable coordinates/values
-        var endBar = Math.Max(0, CurrentBar - 1);
-
-        // If there is no valid session start, skip drawing
-        if (_lastStartBar < 0 || endBar < _lastStartBar)
+        if (LabelPosition == LabelPosition.None || ChartInfo is null)
             return;
 
         var chartWidth = ChartInfo.PriceChartContainer.Region.Width;
+        var endBar = Math.Max(0, CurrentBar - 1);
 
-        // Prepare the current session’s last values only (no past sessions)
+        // Si la sesión terminó, usa snapshot; si no, usa valores del último bar
+        bool sessionFinished = _lastIbEndBar >= 0 && endBar >= _lastIbEndBar && !_isStarted;
+
+        decimal vMid, vIbh, vIbl, vIbm, vX1u, vX2u, vX3u, vX1l, vX2l, vX3l;
+
+        if (sessionFinished)
+        {
+            vMid = _sMID; vIbh = _sIBH; vIbl = _sIBL; vIbm = _sIBM;
+            vX1u = _sIBHX1; vX2u = _sIBHX2; vX3u = _sIBHX3;
+            vX1l = _sIBLX1; vX2l = _sIBLX2; vX3l = _sIBLX3;
+        }
+        else
+        {
+            vMid = _mid[endBar]; vIbh = _ibh[endBar]; vIbl = _ibl[endBar]; vIbm = _ibm[endBar];
+            vX1u = _ibhx1[endBar]; vX2u = _ibhx2[endBar]; vX3u = _ibhx3[endBar];
+            vX1l = _iblx1[endBar]; vX2l = _iblx2[endBar]; vX3l = _iblx3[endBar];
+        }
+
         var items = new (string Label, ValueDataSeries Series, decimal Value)[]
         {
-        ("Mid",   _mid,   _mid[endBar]),
-        ("IBH",   _ibh,   _ibh[endBar]),
-        ("IBL",   _ibl,   _ibl[endBar]),
-        ("IBM",   _ibm,   _ibm[endBar]),
-        ("IBHX1", _ibhx1, _ibhx1[endBar]),
-        ("IBHX2", _ibhx2, _ibhx2[endBar]),
-        ("IBHX3", _ibhx3, _ibhx3[endBar]),
-        ("IBLX1", _iblx1, _iblx1[endBar]),
-        ("IBLX2", _iblx2, _iblx2[endBar]),
-        ("IBLX3", _iblx3, _iblx3[endBar]),
+        ("Mid",   _mid,   vMid),
+        ("IBH",   _ibh,   vIbh),
+        ("IBL",   _ibl,   vIbl),
+        ("IBM",   _ibm,   vIbm),
+        ("IBHX1", _ibhx1, vX1u),
+        ("IBHX2", _ibhx2, vX2u),
+        ("IBHX3", _ibhx3, vX3u),
+        ("IBLX1", _iblx1, vX1l),
+        ("IBLX2", _iblx2, vX2l),
+        ("IBLX3", _iblx3, vX3l),
         };
 
-        var alignRight = LabelPosition == LabelPosition.Right;
-        var x = alignRight ? chartWidth - 5 : 5;
+        // Anclaje X según LabelPosition (misma estética, distinta posición)
+        int x; bool alignRight;
+        switch (LabelPosition)
+        {
+            case LabelPosition.Right:
+                x = chartWidth - 5; alignRight = true; break;
+            case LabelPosition.Left:
+                x = 5; alignRight = false; break;
+            case LabelPosition.Bar:
+            default:
+                var xBar = ChartInfo.GetXByBar(endBar);
+                var barWidth = (int)ChartInfo.PriceChartContainer.BarsWidth;
+                x = xBar + barWidth + 5; alignRight = false; break;
+        }
 
         foreach (var (label, series, price) in items)
         {

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -600,8 +600,9 @@ public class InitialBalance : Indicator
 			{
 				_isStarted = false;
 
-                //Remember the last bar that belonged to the session
-                _lastSessionEndBar = Math.Max(0, bar - 1);
+                // Remember the last in-session bar (set only once)
+                if (_lastSessionEndBar < 0)
+                    _lastSessionEndBar = Math.Max(0, bar - 1);
 
                 foreach (var dataSeries in DataSeries)
 					if (dataSeries is ValueDataSeries series)
@@ -647,6 +648,7 @@ public class InitialBalance : Indicator
 			_endTime = candleFullDateTime.AddMinutes(_period);
             _isStarted = true;
             _lastIbEndBar = -1;
+            _lastSessionEndBar = -1;  // <— reset anchor for labels
 
             foreach (var dataSeries in DataSeries)
                 if (dataSeries is ValueDataSeries series)
@@ -767,8 +769,7 @@ public class InitialBalance : Indicator
         bool afterCustomSession =
             _customSessionStart &&
             _lastSessionEndBar >= 0 &&
-            endBar > _lastSessionEndBar &&
-            !_isStarted;
+            endBar >= _lastSessionEndBar;
 
         // Resolve level values:
         // - If the IB window finished, prefer the snapshot (stable values during/after session).


### PR DESCRIPTION
# Initial Balance - Label position, unified label rendering, custom-session freeze & continuity after IB window

> **Stacked on top of PR #95 (FontSize).**  
> Please review the incremental changes only. Once PR #95 is merged into `develop`, I’ll rebase this PR onto `develop`.
> Depends on: PR #95

This PR introduces **configurable label positioning** and a **unified label rendering path** for the `InitialBalance` indicator, aligning the UX with `OHLCPlus` while preserving all upstream calculation and custom-session logic.

---

## ✨ What’s included

1. **Configurable label position**  
   New `LabelPosition` parameter with four options:

   - `Bar` - anchor next to the **last formed bar in session**.  
     • In custom sessions, after the session ends, labels **freeze** at the last in-session bar.  
     • In auto sessions, labels keep following the latest bar.

   - `Right` - anchor to the **right edge** of the price area **during the session**.  
     • In custom sessions, after the session ends, labels **freeze at the last in-session bar** (they no longer move to the right).  
     • In auto sessions, they continue at the right edge.

   - `Left` - anchor to the **left edge** of the price area **during the session**.  
     • In custom sessions, after the session ends, labels **freeze at the last in-session bar**.  
     • In auto sessions, they remain at the left edge.

   - `None` - hide labels.

2. **Unified label rendering in `OnRender`**  
   Labels are drawn with the same boxed style across `Bar/Left/Right`. Only the **X anchor** changes, keeping typography and visuals consistent.  
   This also removes the historical reliance on `AddText(...)` from `OnCalculate`.

3. **Render only the latest labels**  
   When drawing, we render **just the current session’s labels** (or the last completed session snapshot), preventing historical label clutter.

4. **Final IB snapshot**  
   At the end of the IB window, we store a frozen snapshot of the levels so the **last session labels remain visible** even after the window ends.

5. **Line continuity after the IB window ends**  
   We no longer truncate `ValueDataSeries` at the end of the IB window. Lines remain **continuous and flat** for the rest of the session (matching upstream behavior). Truncation only happens when we are **outside the session window**.

6. Custom-session label freeze (bugfix)
   When a custom session ends, labels now freeze exactly at the last in-session bar.

> ✅ No changes to the **calculation logic** or **custom session handling**.

---

## 📦 Commits in this PR

- **40405b9b** — `feat(InitialBalance): configurable label position (Bar/Right/Left/None) inspired by OHLCPlus`  
- **1fa885a8** — `fix(InitialBalance): hide upstream AddText when LabelPosition != Bar and render only latest labels in OnRender`  
- **208b523a** — `refactor(InitialBalance): remove AddText usage; render labels in OnRender with unified style (Bar/Left/Right)`  
  `feat(InitialBalance): persist final IB snapshot to keep last session labels visible after window ends`  
  `chore(InitialBalance): tidy comments and align with OHLCPlus label UX`  
- **7aa83b4b** — `fix(InitialBalance): keep IB lines continuous after the window ends (remove unintended cut)`
- **405e72bd** — `feat(InitialBalance): freeze labels at last in-session bar for custom sessions only`
- **4ffd20d2** — fix(InitialBalance): freeze labels on the exact last custom-session bar (off-by-one);
reset label anchor on new session

*(Short SHAs shown for convenience.)*

---

## 🧩 UI / API notes

- Labels respect the existing `FontSize` parameter.
- Labels share one consistent look across all positions (box + border using series color).
- Legacy `AddText` usage was removed to avoid duplication and keep visuals consistent.

---

## ✅ Testing performed

- **LabelPosition switching** at runtime: `Bar ↔ Left ↔ Right ↔ None`  
  → labels move/hide instantly; same typography/box style everywhere.
- **IB window end**  
  → labels stay visible using the final snapshot; no visual gaps in lines.
- **Session boundaries** (default and custom sessions)  
  → lines remain continuous through the session; lines truncate only when outside session time.
- **FontSize** changes  
  → applied to all label positions consistently.
- **Custom session end** 
  →labels freeze on the exact last in-session bar; switching LabelPosition
  after the end no repositions labels (by design).

---

## 📌 Why this design?

- Mirrors the clean label UX of `OHLCPlus` (position control + consistent visuals).
- Avoids historical artifacts from `AddText` and ensures only the **latest** labels are visible.
- Keeps the **core calculations** and **session logic** exactly as upstream.

---

## Screenshots

a) **Labels at bar position after custom session ends**.
<img width="672" height="670" alt="image" src="https://github.com/user-attachments/assets/02dbd848-a0ca-4561-8316-72cde2281a56" />

b) **Labels at right position during session**
<img width="2084" height="1149" alt="image" src="https://github.com/user-attachments/assets/e4d5af37-ebb6-4a93-b606-9f5a6ede40f6" />

c) **Labels at left position during session**.
<img width="1475" height="1006" alt="image" src="https://github.com/user-attachments/assets/a7d90faa-e2e6-450d-9bf6-01b95929053a" />

d) **No labels**
<img width="1941" height="1204" alt="image" src="https://github.com/user-attachments/assets/6e9d7ff9-68bc-420c-9560-f563a2b24d31" />


---

## Checklist

- [x] Backward compatible with existing calculations and sessions  
- [x] No change to performance-critical paths in `OnCalculate`  
- [x] Labels render consistently across themes  
- [x] No visual gaps after IB window end  
- [x] Only the latest labels are drawn

Thanks for the review!
