### PR TITLE
Feature/Initial Balance: add “Show During Formation” + fix vertical stem at IB completion (stacked on top or #97)

### DIFF
--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -215,6 +215,9 @@ public class InitialBalance : Indicator
     private decimal _sIBHX1, _sIBHX2, _sIBHX3;
     private decimal _sIBLX1, _sIBLX2, _sIBLX3;
 
+    // Track where the whole trading session ended (last bar inside the session).
+    private int _lastSessionEndBar = -1;
+
     #endregion
 
     #region Properties
@@ -597,6 +600,9 @@ public class InitialBalance : Indicator
 			{
 				_isStarted = false;
 
+                //Remember the last bar that belonged to the session
+                _lastSessionEndBar = Math.Max(0, bar - 1);
+
                 foreach (var dataSeries in DataSeries)
 					if (dataSeries is ValueDataSeries series)
 						series.SetPointOfEndLine(bar - 1);
@@ -740,8 +746,10 @@ public class InitialBalance : Indicator
     }
 
     /// <summary>
-    /// Renders a single set of IB labels for the most recent session when LabelPosition is Left or Right.
+    /// Renders a single set of IB labels for the most recent session.
     /// It does not draw historical session labels and does not modify any ValueDataSeries.
+	//// Labels rendering - freeze at the last in-session bar only for CUSTOM sessions.
+	/// For auto sessions, labels always follow the chosen LabelPosition.
     /// </summary>
     protected override void OnRender(RenderContext context, DrawingLayouts layout)
     {
@@ -751,12 +759,23 @@ public class InitialBalance : Indicator
         var chartWidth = ChartInfo.PriceChartContainer.Region.Width;
         var endBar = Math.Max(0, CurrentBar - 1);
 
-        // Si la sesión terminó, usa snapshot; si no, usa valores del último bar
-        bool sessionFinished = _lastIbEndBar >= 0 && endBar >= _lastIbEndBar && !_isStarted;
+        // IB window finished (we have a snapshot of IB levels)
+        bool ibWindowFinished = _lastIbEndBar >= 0 && endBar >= _lastIbEndBar && !_isStarted;
 
+        // Session considered finished ONLY for custom sessions.
+        // For auto sessions we do not freeze labels; they continue to follow LabelPosition.
+        bool afterCustomSession =
+            _customSessionStart &&
+            _lastSessionEndBar >= 0 &&
+            endBar > _lastSessionEndBar &&
+            !_isStarted;
+
+        // Resolve level values:
+        // - If the IB window finished, prefer the snapshot (stable values during/after session).
+        // - Otherwise, use the last formed bar
         decimal vMid, vIbh, vIbl, vIbm, vX1u, vX2u, vX3u, vX1l, vX2l, vX3l;
 
-        if (sessionFinished)
+        if (ibWindowFinished)
         {
             vMid = _sMID; vIbh = _sIBH; vIbl = _sIBL; vIbm = _sIBM;
             vX1u = _sIBHX1; vX2u = _sIBHX2; vX3u = _sIBHX3;
@@ -769,6 +788,7 @@ public class InitialBalance : Indicator
             vX1l = _iblx1[endBar]; vX2l = _iblx2[endBar]; vX3l = _iblx3[endBar];
         }
 
+        // Build the draw list (label text + series reference + value)
         var items = new (string Label, ValueDataSeries Series, decimal Value)[]
         {
         ("Mid",   _mid,   vMid),
@@ -783,21 +803,37 @@ public class InitialBalance : Indicator
         ("IBLX3", _iblx3, vX3l),
         };
 
-        // Anclaje X según LabelPosition (misma estética, distinta posición)
+        // Decide the X anchor for labels:
+        // - If AFTER a CUSTOM session ended: freeze at the last in-session bar (Bar-style), ignoring LabelPosition.
+        // - Else (during session OR auto sessions): follow LabelPosition normally.
         int x; bool alignRight;
-        switch (LabelPosition)
+
+        if (afterCustomSession)
         {
-            case LabelPosition.Right:
-                x = chartWidth - 5; alignRight = true; break;
-            case LabelPosition.Left:
-                x = 5; alignRight = false; break;
-            case LabelPosition.Bar:
-            default:
-                var xBar = ChartInfo.GetXByBar(endBar);
-                var barWidth = (int)ChartInfo.PriceChartContainer.BarsWidth;
-                x = xBar + barWidth + 5; alignRight = false; break;
+            // Freeze at the last bar of the custom session (behaves like Bar position).
+            var xBar = ChartInfo.GetXByBar(_lastSessionEndBar);
+            var barWidth = (int)ChartInfo.PriceChartContainer.BarsWidth;
+            x = xBar + barWidth + 5;
+            alignRight = false;
+        }
+        else
+        {
+            // Live (or auto sessions): honor the chosen LabelPosition
+            switch (LabelPosition)
+            {
+                case LabelPosition.Right:
+                    x = chartWidth - 5; alignRight = true; break;
+                case LabelPosition.Left:
+                    x = 5; alignRight = false; break;
+                case LabelPosition.Bar:
+                default:
+                    var xBar = ChartInfo.GetXByBar(endBar);
+                    var barWidth = (int)ChartInfo.PriceChartContainer.BarsWidth;
+                    x = xBar + barWidth + 5; alignRight = false; break;
+            }
         }
 
+        // Draw labels (after any overlay lines so labels stay on top)
         foreach (var (label, series, price) in items)
         {
             if (price == 0m || price == decimal.MinValue || price == decimal.MaxValue)

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -711,34 +711,34 @@ public class InitialBalance : Indicator
         if (DrawText)
 		{
 			AddText(_lastStartBar + "Mid", "Mid", true, bar, mid, 0, 0, ConvertColor(_mid.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
 
 			AddText(_lastStartBar + "IBH", "IBH", true, bar, _ibMax, 0, 0, ConvertColor(_ibh.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
 
 			AddText(_lastStartBar + "IBL", "IBL", true, bar, _ibMin, 0, 0, ConvertColor(_ibl.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
 
 			AddText(_lastStartBar + "IBM", "IBM", true, bar, _ibmValue, 0, 0, ConvertColor(_ibm.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
 
 			AddText(_lastStartBar + "IBHX1", "IBHX1", true, bar, ibhx1, 0, 0, ConvertColor(_ibhx1.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
 
 			AddText(_lastStartBar + "IBHX2", "IBHX2", true, bar, ibhx2, 0, 0, ConvertColor(_ibhx2.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent, _fontSize	, DrawingText.TextAlign.Right);
 
 			AddText(_lastStartBar + "IBHX3", "IBHX3", true, bar, ibhx3, 0, 0, ConvertColor(_ibhx3.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent,	_fontSize, DrawingText.TextAlign.Right);
 
 			AddText(_lastStartBar + "IBLX1", "IBLX1", true, bar, iblx1, 0, 0, ConvertColor(_iblx1.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
 
 			AddText(_lastStartBar + "IBLX2", "IBLX2", true, bar, iblx2, 0, 0, ConvertColor(_iblx2.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
 
 			AddText(_lastStartBar + "IBLX3", "IBLX3", true, bar, iblx3, 0, 0, ConvertColor(_iblx3.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, 12.0f, DrawingText.TextAlign.Right);
+				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
 		}
 	}
 

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -175,8 +175,7 @@ public class InitialBalance : Indicator
 	private bool _calculate;
 	private bool _customSessionStart;
 	private int _days = 20;
-    private bool _drawText = true;
-	private TimeSpan _endDate;
+    private TimeSpan _endDate;
 	private DateTime _endTime = DateTime.MaxValue;
 	private CrossColor _fillColor = DefaultColors.Yellow.Convert();
 	private bool _highLowIsSet;
@@ -217,6 +216,8 @@ public class InitialBalance : Indicator
 
     // Track where the whole trading session ended (last bar inside the session).
     private int _lastSessionEndBar = -1;
+
+    private bool _showDuringFormation = true;
 
     #endregion
 
@@ -434,6 +435,27 @@ public class InitialBalance : Indicator
 
             _overlayLineType = value;
             RedrawChart();
+        }
+    }
+
+    // ADD: UI switch (default = true keeps current behaviour)
+    [Display(Name = "Show During Formation",
+        GroupName = nameof(Strings.Show),
+        Description = "If disabled, hides ValueDataSeries/labels/ranges during the IB forming period. They appear only from the end bar onward.",
+        Order = 160)]
+    public bool ShowDuringFormation
+    {
+        get => _showDuringFormation;
+        set
+        {
+            if (_showDuringFormation == value)
+                return;
+
+            _showDuringFormation = value;
+
+            // IMPORTANT: refresh both calculation (series/ranges) and drawing (labels/lines)
+            RedrawChart();
+            RecalculateValues();
         }
     }
 
@@ -741,7 +763,23 @@ public class InitialBalance : Indicator
 		if (!_highLowIsSet)
 			return;
 
-		_mid[bar] = mid = (_minValue + _maxValue) / 2m;
+        // ADD: only show current session while forming if allowed;
+        // otherwise, start at the IB end bar (no retrospective)
+        bool canShowThisBar =
+            ShowDuringFormation
+            || (!ShowDuringFormation && _lastIbEndBar >= 0 && bar >= _lastIbEndBar);
+
+        if (!canShowThisBar)
+        {
+            // hide current-session lines during formation without writing zeros
+            foreach (var ds in DataSeries)
+                if (ds is ValueDataSeries vs)
+                    vs.SetPointOfEndLine(Math.Max(0, _lastStartBar - 1));
+
+            return;
+        }
+
+        _mid[bar] = mid = (_minValue + _maxValue) / 2m;
 		_ibh[bar] = _ibMax;
 		_ibl[bar] = _ibMin;
 		_ibmValue = _ibm[bar] = (_ibMin + _ibMax) / 2m;
@@ -779,6 +817,11 @@ public class InitialBalance : Indicator
 
         var chartWidth = ChartInfo.PriceChartContainer.Region.Width;
         var endBar = Math.Max(0, CurrentBar - 1);
+
+        // Hide labels/lines for the CURRENT SESSION while IB is forming, if the user disabled it.
+        // We consider "forming" when the IB end bar is not yet set.
+        if (!ShowDuringFormation && _lastIbEndBar < 0)
+            return;
 
         // IB window finished (we have a snapshot of IB levels)
         bool ibWindowFinished = _lastIbEndBar >= 0 && endBar >= _lastIbEndBar && !_isStarted;

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -853,19 +853,6 @@ public class InitialBalance : Indicator
             }
         }
 
-        // Draw labels (after any overlay lines so labels stay on top)
-        foreach (var (label, series, price) in items)
-        {
-            if (price == 0m || price == decimal.MinValue || price == decimal.MaxValue)
-                continue;
-
-            var y = ChartInfo.GetYByPrice(price, false);
-            if (y < 0 || y > ChartInfo.PriceChartContainer.Region.Height)
-                continue;
-
-            DrawTextLabel(context, label, x, y, series, alignRight);
-        }
-
         // After drawing labels (reuse `ibWindowFinished`, `endBar`, `items`, etc.)
         if (OverlayLineType != LineType.None)
         {
@@ -933,6 +920,19 @@ public class InitialBalance : Indicator
             // 4) Draw connectors for the latest state only (live or snapshot)
             foreach (var (_, s, p) in items)
                 DrawOverlayLine(s, p);
+        }
+
+        // Draw labels (after any overlay lines so labels stay on top)
+        foreach (var (label, series, price) in items)
+        {
+            if (price == 0m || price == decimal.MinValue || price == decimal.MaxValue)
+                continue;
+
+            var y = ChartInfo.GetYByPrice(price, false);
+            if (y < 0 || y > ChartInfo.PriceChartContainer.Region.Height)
+                continue;
+
+            DrawTextLabel(context, label, x, y, series, alignRight);
         }
     }
 

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -866,11 +866,11 @@ public class InitialBalance : Indicator
             DrawTextLabel(context, label, x, y, series, alignRight);
         }
 
-        // After drawing labels (reuse `sessionFinished`, `endBar`, `items`, etc.)
+        // After drawing labels (reuse `ibWindowFinished`, `endBar`, `items`, etc.)
         if (OverlayLineType != LineType.None)
         {
             // 1) Decide the series end X (no gaps):
-            var seriesEndBarForAnchor = sessionFinished ? _lastIbEndBar : endBar;
+            var seriesEndBarForAnchor = ibWindowFinished ? _lastIbEndBar : endBar;
             var xSeriesEnd = ChartInfo.GetXByBar(seriesEndBarForAnchor);
 
             // 2) Decide label anchor X based on LabelPosition (same as labels)
@@ -878,15 +878,23 @@ public class InitialBalance : Indicator
             var chartRight = ChartInfo.PriceChartContainer.Region.Width;
 
             int xAnchor;
-            switch (LabelPosition)
-            {
-                case LabelPosition.Right: xAnchor = chartRight - 5; break;
-                case LabelPosition.Left: xAnchor = 5; break;
-                case LabelPosition.Bar:
-                default:
-                    xAnchor = xSeriesEnd + 4; // small padding right after the series end
-                    break;
-            }
+			if (afterCustomSession)
+			{
+				// Freeze like Bar position (same X you calculaste para las etiquetas)
+				xAnchor = xSeriesEnd + 4; // pequeño padding
+			}
+			else
+			{
+				switch (LabelPosition)
+				{
+					case LabelPosition.Right: xAnchor = chartRight - 5; break;
+					case LabelPosition.Left: xAnchor = 5; break;
+					case LabelPosition.Bar:
+					default:
+						xAnchor = xSeriesEnd + 4; // small padding right after the series end
+						break;
+				}
+			}
 
             // 3) Helper to draw one horizontal connector (or full line)
             void DrawOverlayLine(ValueDataSeries s, decimal price)

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -730,7 +730,13 @@ public class InitialBalance : Indicator
 
             _calculate = _isStarted = false;
 
-        }
+            if (!ShowDuringFormation)
+            {
+                // cut any possible connection up to the IB end bar 
+                foreach (var ds in DataSeries)
+                    if (ds is ValueDataSeries vs)
+                        vs.SetPointOfEndLine(_lastIbEndBar);
+			}
 
 		if (_calculate)
 		{

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -418,6 +418,25 @@ public class InitialBalance : Indicator
         }
     }
 
+    private LineType _overlayLineType = LineType.Bar;
+
+    [Display(Name = "Line Type",
+        GroupName = nameof(Strings.Show),
+        Description = "Connector lines from the series end to the label anchor (Bar/Right/Left), or full width",
+        Order = 138)]
+    public LineType OverlayLineType
+    {
+        get => _overlayLineType;
+        set
+        {
+            if (_overlayLineType == value)
+                return;
+
+            _overlayLineType = value;
+            RedrawChart();
+        }
+    }
+
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBHX32), 
 		GroupName = nameof(Strings.BackGround), Description = nameof(Strings.AreaColorDescription), Order = 200)]
 	public CrossColor Ibhx32
@@ -845,6 +864,67 @@ public class InitialBalance : Indicator
                 continue;
 
             DrawTextLabel(context, label, x, y, series, alignRight);
+        }
+
+        // After drawing labels (reuse `sessionFinished`, `endBar`, `items`, etc.)
+        if (OverlayLineType != LineType.None)
+        {
+            // 1) Decide the series end X (no gaps):
+            var seriesEndBarForAnchor = sessionFinished ? _lastIbEndBar : endBar;
+            var xSeriesEnd = ChartInfo.GetXByBar(seriesEndBarForAnchor);
+
+            // 2) Decide label anchor X based on LabelPosition (same as labels)
+            var chartLeft = 0;
+            var chartRight = ChartInfo.PriceChartContainer.Region.Width;
+
+            int xAnchor;
+            switch (LabelPosition)
+            {
+                case LabelPosition.Right: xAnchor = chartRight - 5; break;
+                case LabelPosition.Left: xAnchor = 5; break;
+                case LabelPosition.Bar:
+                default:
+                    xAnchor = xSeriesEnd + 4; // small padding right after the series end
+                    break;
+            }
+
+            // 3) Helper to draw one horizontal connector (or full line)
+            void DrawOverlayLine(ValueDataSeries s, decimal price)
+            {
+                if (price == 0m || price == decimal.MinValue || price == decimal.MaxValue)
+                    return;
+
+                var y = ChartInfo.GetYByPrice(price, false);
+                if (y < 0 || y > ChartInfo.PriceChartContainer.Region.Height)
+                    return;
+
+                var pen = new PenSettings
+                {
+                    Color = s.Color,
+                    Width = s.Width,
+                    LineDashStyle = s.LineDashStyle
+                }.RenderObject;
+
+                int x1, x2;
+                if (OverlayLineType == LineType.Full)
+                {
+                    // Full width (left -> right), independent of label position
+                    x1 = chartLeft; x2 = chartRight;
+                }
+                else
+                {
+                    // Connector: from the actual series end to the label anchor
+                    // If label is left of the series end, we still draw back to it (right->left).
+                    x1 = xSeriesEnd;
+                    x2 = xAnchor;
+                }
+
+                context.DrawLine(pen, x1, y, x2, y);
+            }
+
+            // 4) Draw connectors for the latest state only (live or snapshot)
+            foreach (var (_, s, p) in items)
+                DrawOverlayLine(s, p);
         }
     }
 

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -13,6 +13,8 @@ using OFT.Localization;
 using OFT.Rendering.Settings;
 
 using Pen = System.Drawing.Pen;
+using OFT.Rendering.Context;
+using OFT.Rendering.Tools;
 
 [DisplayName("Initial Balance")]
 [Category(IndicatorCategories.VolumeOrderFlow)]
@@ -181,8 +183,10 @@ public class InitialBalance : Indicator
 	private decimal _ibMax = decimal.MinValue;
 	private decimal _ibMin = decimal.MaxValue;
 	private decimal _ibmValue = decimal.Zero;
+    private float _fontSize = 12.0f;
+    private RenderFont _font;
 
-	private bool _initialized;
+    private bool _initialized;
 	private int _lastStartBar = -1;
 	private decimal _maxValue = decimal.MinValue;
 	private decimal _minValue = decimal.MaxValue;
@@ -382,7 +386,22 @@ public class InitialBalance : Indicator
 			_drawText = value;
 			RecalculateValues();
 		}
-	}
+    }
+
+	// Label font size (for text drawing)
+    [Display(Name = "Font Size",
+	GroupName = nameof(Strings.Show), Description = "Label font size", Order = 135)]
+    [Range(6, 48)]
+    public float FontSize
+    {
+        get => _fontSize;
+        set
+        {
+            _fontSize = value;
+            _font = new RenderFont("Arial", _fontSize);
+            RecalculateValues();
+        }
+    }
 
 	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBHX32), 
 		GroupName = nameof(Strings.BackGround), Description = nameof(Strings.AreaColorDescription), Order = 200)]
@@ -456,6 +475,9 @@ public class InitialBalance : Indicator
 		: base(true)
 	{
 		DenyToChangePanel = true;
+        EnableCustomDrawing = true;
+        SubscribeToDrawingEvents(DrawingLayouts.Final);
+        _font = new RenderFont("Arial", _fontSize);
 
         DataSeries[0] = _mid;
         DataSeries.Add(_ibh);

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -407,7 +407,20 @@ public class InitialBalance : Indicator
     GroupName = nameof(Strings.Show),
     Description = "Where to draw labels for IB levels",
     Order = 136)]
-    public LabelPosition LabelPosition { get; set; } = LabelPosition.Bar;
+    private LabelPosition _labelPosition = LabelPosition.Bar;
+    public LabelPosition LabelPosition
+    {
+        get => _labelPosition;
+        set
+        {
+            if (_labelPosition == value)
+                return;
+
+            _labelPosition = value;
+            RecalculateValues();
+            RedrawChart();
+        }
+    }
 
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBHX32), 
 		GroupName = nameof(Strings.BackGround), Description = nameof(Strings.AreaColorDescription), Order = 200)]
@@ -746,25 +759,32 @@ public class InitialBalance : Indicator
 			AddText(_lastStartBar + "IBLX3", "IBLX3", true, bar, iblx3, 0, 0, ConvertColor(_iblx3.Color), System.Drawing.Color.Transparent,
 				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
 		}
+
+
 	}
 
+    /// <summary>
+    /// Renders a single set of IB labels for the most recent session when LabelPosition is Left or Right.
+    /// It does not draw historical session labels and does not modify any ValueDataSeries.
+    /// </summary>
     protected override void OnRender(RenderContext context, DrawingLayouts layout)
     {
-        // Draw labels only when requested and only for Left/Right positions.
         if (!DrawText || LabelPosition == LabelPosition.None || LabelPosition == LabelPosition.Bar)
             return;
 
         if (ChartInfo is null)
             return;
 
-        // Use the last fully-formed bar as a safe source for values and coordinates.
+        // Use the last formed bar for stable coordinates/values
         var endBar = Math.Max(0, CurrentBar - 1);
-        var chartWidth = ChartInfo.PriceChartContainer.Region.Width;
-        var currentBarX = ChartInfo.GetXByBar(endBar);
-        var barWidth = (int)ChartInfo.PriceChartContainer.BarsWidth;
-        var currentBarRightX = currentBarX + barWidth;
 
-        // List of IB-related levels to label.
+        // If there is no valid session start, skip drawing
+        if (_lastStartBar < 0 || endBar < _lastStartBar)
+            return;
+
+        var chartWidth = ChartInfo.PriceChartContainer.Region.Width;
+
+        // Prepare the current session’s last values only (no past sessions)
         var items = new (string Label, ValueDataSeries Series, decimal Value)[]
         {
         ("Mid",   _mid,   _mid[endBar]),
@@ -779,6 +799,9 @@ public class InitialBalance : Indicator
         ("IBLX3", _iblx3, _iblx3[endBar]),
         };
 
+        var alignRight = LabelPosition == LabelPosition.Right;
+        var x = alignRight ? chartWidth - 5 : 5;
+
         foreach (var (label, series, price) in items)
         {
             if (price == 0m || price == decimal.MinValue || price == decimal.MaxValue)
@@ -788,23 +811,22 @@ public class InitialBalance : Indicator
             if (y < 0 || y > ChartInfo.PriceChartContainer.Region.Height)
                 continue;
 
-            // Compute the target X anchor based on the desired label position.
-            bool alignRight = LabelPosition == LabelPosition.Right;
-            int x = LabelPosition == LabelPosition.Right ? chartWidth - 5 : 5;
-
             DrawTextLabel(context, label, x, y, series, alignRight);
         }
     }
 
-    // Helper: Draws a boxed text label at the given (x,y) position (like OHLCPlus.DrawTextLabel)
     private void DrawTextLabel(RenderContext context, string text, int x, int y, ValueDataSeries series, bool alignRight)
     {
         var size = context.MeasureString(text, _font);
         var textColor = ChartInfo.ColorsStore.MouseTextColor;
-
-        // Fondo y borde como en OHLCPlus
         var backgroundColor = ChartInfo.ColorsStore.BaseBackgroundColor;
-        var pen = new PenSettings { Color = series.Color, Width = series.Width, LineDashStyle = series.LineDashStyle }.RenderObject;
+
+        var pen = new PenSettings
+        {
+            Color = series.Color,
+            Width = series.Width,
+            LineDashStyle = series.LineDashStyle
+        }.RenderObject;
 
         var rectX = alignRight ? x - size.Width : x;
         var rect = new Rectangle(rectX - 2, y - size.Height / 2 - 1, size.Width + 4, size.Height + 2);
@@ -816,6 +838,7 @@ public class InitialBalance : Indicator
         var format = alignRight ? _stringRightFormat : _stringLeftFormat;
         context.DrawString(text, _font, textColor, textRect, format);
     }
+
 
 
     private DateTime GetPrevDateTime(int bar)

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -681,9 +681,6 @@ public class InitialBalance : Indicator
 
             _calculate = _isStarted = false;
 
-            foreach (var ds in DataSeries)
-                if (ds is ValueDataSeries vs)
-                    vs.SetPointOfEndLine(bar);
         }
 
 		if (_calculate)

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -403,7 +403,13 @@ public class InitialBalance : Indicator
         }
     }
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBHX32), 
+    [Display(Name = "Label Position",
+    GroupName = nameof(Strings.Show),
+    Description = "Where to draw labels for IB levels",
+    Order = 136)]
+    public LabelPosition LabelPosition { get; set; } = LabelPosition.Bar;
+
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.IBHX32), 
 		GroupName = nameof(Strings.BackGround), Description = nameof(Strings.AreaColorDescription), Order = 200)]
 	public CrossColor Ibhx32
 	{
@@ -708,8 +714,8 @@ public class InitialBalance : Indicator
 		_iblx12[bar].Lower = _iblx23[bar].Upper = iblx2;
 		_iblx23[bar].Lower = iblx3;
 
-        if (DrawText)
-		{
+        if (DrawText && LabelPosition == LabelPosition.Bar)
+        {
 			AddText(_lastStartBar + "Mid", "Mid", true, bar, mid, 0, 0, ConvertColor(_mid.Color), System.Drawing.Color.Transparent,
 				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
 
@@ -742,6 +748,76 @@ public class InitialBalance : Indicator
 		}
 	}
 
+    protected override void OnRender(RenderContext context, DrawingLayouts layout)
+    {
+        // Draw labels only when requested and only for Left/Right positions.
+        if (!DrawText || LabelPosition == LabelPosition.None || LabelPosition == LabelPosition.Bar)
+            return;
+
+        if (ChartInfo is null)
+            return;
+
+        // Use the last fully-formed bar as a safe source for values and coordinates.
+        var endBar = Math.Max(0, CurrentBar - 1);
+        var chartWidth = ChartInfo.PriceChartContainer.Region.Width;
+        var currentBarX = ChartInfo.GetXByBar(endBar);
+        var barWidth = (int)ChartInfo.PriceChartContainer.BarsWidth;
+        var currentBarRightX = currentBarX + barWidth;
+
+        // List of IB-related levels to label.
+        var items = new (string Label, ValueDataSeries Series, decimal Value)[]
+        {
+        ("Mid",   _mid,   _mid[endBar]),
+        ("IBH",   _ibh,   _ibh[endBar]),
+        ("IBL",   _ibl,   _ibl[endBar]),
+        ("IBM",   _ibm,   _ibm[endBar]),
+        ("IBHX1", _ibhx1, _ibhx1[endBar]),
+        ("IBHX2", _ibhx2, _ibhx2[endBar]),
+        ("IBHX3", _ibhx3, _ibhx3[endBar]),
+        ("IBLX1", _iblx1, _iblx1[endBar]),
+        ("IBLX2", _iblx2, _iblx2[endBar]),
+        ("IBLX3", _iblx3, _iblx3[endBar]),
+        };
+
+        foreach (var (label, series, price) in items)
+        {
+            if (price == 0m || price == decimal.MinValue || price == decimal.MaxValue)
+                continue;
+
+            var y = ChartInfo.GetYByPrice(price, false);
+            if (y < 0 || y > ChartInfo.PriceChartContainer.Region.Height)
+                continue;
+
+            // Compute the target X anchor based on the desired label position.
+            bool alignRight = LabelPosition == LabelPosition.Right;
+            int x = LabelPosition == LabelPosition.Right ? chartWidth - 5 : 5;
+
+            DrawTextLabel(context, label, x, y, series, alignRight);
+        }
+    }
+
+    // Helper: Draws a boxed text label at the given (x,y) position (like OHLCPlus.DrawTextLabel)
+    private void DrawTextLabel(RenderContext context, string text, int x, int y, ValueDataSeries series, bool alignRight)
+    {
+        var size = context.MeasureString(text, _font);
+        var textColor = ChartInfo.ColorsStore.MouseTextColor;
+
+        // Fondo y borde como en OHLCPlus
+        var backgroundColor = ChartInfo.ColorsStore.BaseBackgroundColor;
+        var pen = new PenSettings { Color = series.Color, Width = series.Width, LineDashStyle = series.LineDashStyle }.RenderObject;
+
+        var rectX = alignRight ? x - size.Width : x;
+        var rect = new Rectangle(rectX - 2, y - size.Height / 2 - 1, size.Width + 4, size.Height + 2);
+
+        context.FillRectangle(backgroundColor, rect);
+        context.DrawRectangle(pen, rect);
+
+        var textRect = new Rectangle(rectX, y - size.Height / 2, size.Width, size.Height);
+        var format = alignRight ? _stringRightFormat : _stringLeftFormat;
+        context.DrawString(text, _font, textColor, textRect, format);
+    }
+
+
     private DateTime GetPrevDateTime(int bar)
     {
 		return GetCandle(bar - 1).Time.AddHours(InstrumentInfo.TimeZone);
@@ -764,5 +840,21 @@ public class InitialBalance : Indicator
 		return System.Drawing.Color.FromArgb(color.A, color.R, color.G, color.B);
 	}
 
-	#endregion
+    private RenderStringFormat _stringRightFormat = new()
+    {
+        Alignment = StringAlignment.Far,
+        LineAlignment = StringAlignment.Center,
+        Trimming = StringTrimming.EllipsisCharacter,
+        FormatFlags = StringFormatFlags.NoWrap
+    };
+
+    private RenderStringFormat _stringLeftFormat = new()
+    {
+        Alignment = StringAlignment.Near,
+        LineAlignment = StringAlignment.Center,
+        Trimming = StringTrimming.EllipsisCharacter,
+        FormatFlags = StringFormatFlags.NoWrap
+    };
+
+    #endregion
 }

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -209,6 +209,12 @@ public class InitialBalance : Indicator
 
 	private bool _isStarted;
 
+    // Last completed IB snapshot (used after the window ends)
+    private int _lastIbEndBar = -1;
+    private decimal _sIBH, _sIBL, _sIBM, _sMID;
+    private decimal _sIBHX1, _sIBHX2, _sIBHX3;
+    private decimal _sIBLX1, _sIBLX2, _sIBLX3;
+
     #endregion
 
     #region Properties
@@ -376,18 +382,6 @@ public class InitialBalance : Indicator
 		}
 	}
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Text),
-		GroupName = nameof(Strings.Show), Description = nameof(Strings.IsNeedShowLabelDescription), Order = 130)]
-	public bool DrawText
-	{
-		get => _drawText;
-		set
-		{
-			_drawText = value;
-			RecalculateValues();
-		}
-    }
-
 	// Label font size (for text drawing)
     [Display(Name = "Font Size",
 	GroupName = nameof(Strings.Show), Description = "Label font size", Order = 135)]
@@ -417,7 +411,6 @@ public class InitialBalance : Indicator
                 return;
 
             _labelPosition = value;
-            RecalculateValues();
             RedrawChart();
         }
     }
@@ -647,6 +640,7 @@ public class InitialBalance : Indicator
 			_lastStartBar = bar;
 			_endTime = candleFullDateTime.AddMinutes(_period);
             _isStarted = true;
+            _lastIbEndBar = -1;
 
             foreach (var dataSeries in DataSeries)
                 if (dataSeries is ValueDataSeries series)
@@ -670,7 +664,26 @@ public class InitialBalance : Indicator
 		}
 		else if (isEnd)
 		{
-			_calculate = _isStarted = false;
+            // Compute final values
+            var finalDiff = _ibMax - _ibMin;
+            var finalMid = (_minValue + _maxValue) / 2m;
+            var finalIbm = (_ibMin + _ibMax) / 2m;
+
+            // Snapshot last session
+            _lastIbEndBar = bar;
+            _sIBH = _ibMax; _sIBL = _ibMin; _sIBM = finalIbm; _sMID = finalMid;
+            _sIBHX1 = _ibMax + finalDiff * _x1;
+            _sIBHX2 = _ibMax + finalDiff * _x2;
+            _sIBHX3 = _ibMax + finalDiff * _x3;
+            _sIBLX1 = _ibMin - finalDiff * _x1;
+            _sIBLX2 = _ibMin - finalDiff * _x2;
+            _sIBLX3 = _ibMin - finalDiff * _x3;
+
+            _calculate = _isStarted = false;
+
+            foreach (var ds in DataSeries)
+                if (ds is ValueDataSeries vs)
+                    vs.SetPointOfEndLine(bar);
         }
 
 		if (_calculate)
@@ -727,41 +740,7 @@ public class InitialBalance : Indicator
 		_iblx12[bar].Lower = _iblx23[bar].Upper = iblx2;
 		_iblx23[bar].Lower = iblx3;
 
-        if (DrawText && LabelPosition == LabelPosition.Bar)
-        {
-			AddText(_lastStartBar + "Mid", "Mid", true, bar, mid, 0, 0, ConvertColor(_mid.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
-
-			AddText(_lastStartBar + "IBH", "IBH", true, bar, _ibMax, 0, 0, ConvertColor(_ibh.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
-
-			AddText(_lastStartBar + "IBL", "IBL", true, bar, _ibMin, 0, 0, ConvertColor(_ibl.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
-
-			AddText(_lastStartBar + "IBM", "IBM", true, bar, _ibmValue, 0, 0, ConvertColor(_ibm.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
-
-			AddText(_lastStartBar + "IBHX1", "IBHX1", true, bar, ibhx1, 0, 0, ConvertColor(_ibhx1.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
-
-			AddText(_lastStartBar + "IBHX2", "IBHX2", true, bar, ibhx2, 0, 0, ConvertColor(_ibhx2.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, _fontSize	, DrawingText.TextAlign.Right);
-
-			AddText(_lastStartBar + "IBHX3", "IBHX3", true, bar, ibhx3, 0, 0, ConvertColor(_ibhx3.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent,	_fontSize, DrawingText.TextAlign.Right);
-
-			AddText(_lastStartBar + "IBLX1", "IBLX1", true, bar, iblx1, 0, 0, ConvertColor(_iblx1.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
-
-			AddText(_lastStartBar + "IBLX2", "IBLX2", true, bar, iblx2, 0, 0, ConvertColor(_iblx2.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
-
-			AddText(_lastStartBar + "IBLX3", "IBLX3", true, bar, iblx3, 0, 0, ConvertColor(_iblx3.Color), System.Drawing.Color.Transparent,
-				System.Drawing.Color.Transparent, _fontSize, DrawingText.TextAlign.Right);
-		}
-
-
-	}
+    }
 
     /// <summary>
     /// Renders a single set of IB labels for the most recent session when LabelPosition is Left or Right.
@@ -769,38 +748,58 @@ public class InitialBalance : Indicator
     /// </summary>
     protected override void OnRender(RenderContext context, DrawingLayouts layout)
     {
-        if (!DrawText || LabelPosition == LabelPosition.None || LabelPosition == LabelPosition.Bar)
-            return;
-
-        if (ChartInfo is null)
-            return;
-
-        // Use the last formed bar for stable coordinates/values
-        var endBar = Math.Max(0, CurrentBar - 1);
-
-        // If there is no valid session start, skip drawing
-        if (_lastStartBar < 0 || endBar < _lastStartBar)
+        if (LabelPosition == LabelPosition.None || ChartInfo is null)
             return;
 
         var chartWidth = ChartInfo.PriceChartContainer.Region.Width;
+        var endBar = Math.Max(0, CurrentBar - 1);
 
-        // Prepare the current session’s last values only (no past sessions)
+        // Si la sesión terminó, usa snapshot; si no, usa valores del último bar
+        bool sessionFinished = _lastIbEndBar >= 0 && endBar >= _lastIbEndBar && !_isStarted;
+
+        decimal vMid, vIbh, vIbl, vIbm, vX1u, vX2u, vX3u, vX1l, vX2l, vX3l;
+
+        if (sessionFinished)
+        {
+            vMid = _sMID; vIbh = _sIBH; vIbl = _sIBL; vIbm = _sIBM;
+            vX1u = _sIBHX1; vX2u = _sIBHX2; vX3u = _sIBHX3;
+            vX1l = _sIBLX1; vX2l = _sIBLX2; vX3l = _sIBLX3;
+        }
+        else
+        {
+            vMid = _mid[endBar]; vIbh = _ibh[endBar]; vIbl = _ibl[endBar]; vIbm = _ibm[endBar];
+            vX1u = _ibhx1[endBar]; vX2u = _ibhx2[endBar]; vX3u = _ibhx3[endBar];
+            vX1l = _iblx1[endBar]; vX2l = _iblx2[endBar]; vX3l = _iblx3[endBar];
+        }
+
         var items = new (string Label, ValueDataSeries Series, decimal Value)[]
         {
-        ("Mid",   _mid,   _mid[endBar]),
-        ("IBH",   _ibh,   _ibh[endBar]),
-        ("IBL",   _ibl,   _ibl[endBar]),
-        ("IBM",   _ibm,   _ibm[endBar]),
-        ("IBHX1", _ibhx1, _ibhx1[endBar]),
-        ("IBHX2", _ibhx2, _ibhx2[endBar]),
-        ("IBHX3", _ibhx3, _ibhx3[endBar]),
-        ("IBLX1", _iblx1, _iblx1[endBar]),
-        ("IBLX2", _iblx2, _iblx2[endBar]),
-        ("IBLX3", _iblx3, _iblx3[endBar]),
+        ("Mid",   _mid,   vMid),
+        ("IBH",   _ibh,   vIbh),
+        ("IBL",   _ibl,   vIbl),
+        ("IBM",   _ibm,   vIbm),
+        ("IBHX1", _ibhx1, vX1u),
+        ("IBHX2", _ibhx2, vX2u),
+        ("IBHX3", _ibhx3, vX3u),
+        ("IBLX1", _iblx1, vX1l),
+        ("IBLX2", _iblx2, vX2l),
+        ("IBLX3", _iblx3, vX3l),
         };
 
-        var alignRight = LabelPosition == LabelPosition.Right;
-        var x = alignRight ? chartWidth - 5 : 5;
+        // Anclaje X según LabelPosition (misma estética, distinta posición)
+        int x; bool alignRight;
+        switch (LabelPosition)
+        {
+            case LabelPosition.Right:
+                x = chartWidth - 5; alignRight = true; break;
+            case LabelPosition.Left:
+                x = 5; alignRight = false; break;
+            case LabelPosition.Bar:
+            default:
+                var xBar = ChartInfo.GetXByBar(endBar);
+                var barWidth = (int)ChartInfo.PriceChartContainer.BarsWidth;
+                x = xBar + barWidth + 5; alignRight = false; break;
+        }
 
         foreach (var (label, series, price) in items)
         {

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -600,8 +600,9 @@ public class InitialBalance : Indicator
 			{
 				_isStarted = false;
 
-                //Remember the last bar that belonged to the session
-                _lastSessionEndBar = Math.Max(0, bar - 1);
+                // Remember the last in-session bar (set only once)
+                if (_lastSessionEndBar < 0)
+                    _lastSessionEndBar = Math.Max(0, bar - 1);
 
                 foreach (var dataSeries in DataSeries)
 					if (dataSeries is ValueDataSeries series)
@@ -647,6 +648,7 @@ public class InitialBalance : Indicator
 			_endTime = candleFullDateTime.AddMinutes(_period);
             _isStarted = true;
             _lastIbEndBar = -1;
+            _lastSessionEndBar = -1;  // <— reset anchor for labels
 
             foreach (var dataSeries in DataSeries)
                 if (dataSeries is ValueDataSeries series)
@@ -767,8 +769,7 @@ public class InitialBalance : Indicator
         bool afterCustomSession =
             _customSessionStart &&
             _lastSessionEndBar >= 0 &&
-            endBar > _lastSessionEndBar &&
-            !_isStarted;
+            endBar >= _lastSessionEndBar;
 
         // Resolve level values:
         // - If the IB window finished, prefer the snapshot (stable values during/after session).


### PR DESCRIPTION
# Initial Balance: add “Show During Formation” + fix vertical stem at IB completion

**Branch:** `feat/ib-formation-visibility`  
**Scope:** `ATAS.Indicators.Technical.InitialBalance`

> **Note:** This PR is **stacked on top of PR #97**. Please review/merge #97 first.
> This PR only contains the incremental changes for **“Show During Formation”** + the **vertical-stem fix**.

## Summary

This PR introduces a UI switch to control visibility of the current session while the Initial Balance (IB) is forming and fixes the vertical stem that appeared at IB completion when formation was hidden.

- **Feature:** `ShowDuringFormation` (default: **true**)  
  - When **false**, the indicator hides ValueDataSeries, ranges, and labels during the IB forming window, and starts displaying them **only from the IB end onward** (no retrospective painting).
- **Fix:** prevent a vertical “stem” on the first visible bar after IB completion when `ShowDuringFormation == false`.

## User-facing changes

- **New property (UI):**  
  `Show During Formation` — *"If disabled, hides ValueDataSeries/labels/ranges while the IB window is forming; they appear only from the IB end bar onward."*  
  - Toggling the property triggers both `RecalculateValues()` (for series/ranges) and `RedrawChart()` (for labels/lines).

- **Behavior:**  
  - **ON (default):** same as before, levels visible during formation.  
  - **OFF:** nothing is drawn during formation; once IB completes, levels appear from the completion anchor forward (no retro).  
  - **Vertical stem resolved:** no abrupt vertical segment at the transition from hidden → visible after IB completion.

## Implementation details

- Reused existing session anchors:
  - `_lastIbEndBar` is the **completion anchor** for the current session.
- **OnCalculate (gate):**
  - During formation and when `ShowDuringFormation == false`, we **do not write** to ValueDataSeries/RangeDataSeries and **truncate** lines to `_lastStartBar - 1`.
  - After completion, plotting resumes from the completion anchor forward (no retrospective).
- **OnRender (gate):**
  - Early return for the **current session** when `!ShowDuringFormation && _lastIbEndBar < 0` to hide labels/lines while forming.
- **Fix for vertical stem (core fragment in `isEnd`):**
  - Snapshot final IB values into `*_s` fields.
  - Set `_lastIbEndBar = bar;`
  - If `ShowDuringFormation == false`, cut all ValueDataSeries up to `_lastIbEndBar - 1` using `SetPointOfEndLine(...)` to avoid an implicit join into the first visible point.

## IB rectangle (Open Range) behavior

- The **Open Range rectangle** remains governed **only** by the existing `ShowOpenRange` flag.
- `ShowDuringFormation` does **not** affect the rectangle’s visibility. This is intentional to preserve session context while lines/labels are hidden.
- PR note: This is the **only exception** to the new visibility switch and is documented to match current UI semantics.

## Screenshots

A) Show during formation
<img width="1763" height="962" alt="image" src="https://github.com/user-attachments/assets/88564ba1-5fd1-4e4d-8923-07fa25d4d316" />

B) Not Show during formation after calculation end
<img width="1807" height="972" alt="image" src="https://github.com/user-attachments/assets/1408de20-ea27-41b0-a396-f14a67de30da" />

C) Not Show during formation before calculation end (only shows open range)
<img width="1359" height="827" alt="image" src="https://github.com/user-attachments/assets/8582ac77-b92b-4d63-b238-87c2cd73c35b" />

## Test plan

1. **Default (ShowDuringFormation = true):**
   - During formation: levels/labels/ranges visible (legacy behavior).
   - Rectangle visibility unchanged (controlled by `ShowOpenRange`).
2. **ShowDuringFormation = false (before IB starts):**
   - During formation: ValueDataSeries and ranges not written; labels/lines skipped in `OnRender`.
   - Rectangle still follows `ShowOpenRange` (exception documented).
   - At IB completion: levels/ranges appear from `_lastIbEndBar` forward; **no vertical stem**.
3. **Toggle OFF → ON mid-formation:**
   - After `RecalculateValues()`, prior bars are backfilled (legacy behavior).
4. **Toggle ON → OFF mid-formation:**
   - Immediately hidden; at completion, appears from the anchor forward; no stem.
5. **Custom vs auto sessions:**
   - Anchoring at `_lastIbEndBar` respected; historical sessions unaffected.

## Backwards compatibility

- Default value preserves existing behavior (show during formation).
- Historical sessions and rectangle behavior (`ShowOpenRange`) unchanged.
- No new resource keys required (property label provided in English).

## Risks & mitigations

- **Risk:** stale visuals after toggling.  
  **Mitigation:** the property setter triggers **both** `RecalculateValues()` and `RedrawChart()`.

## Checklist

- [x] New UI property `ShowDuringFormation` with description  
- [x] Calculation gate for ValueDataSeries and RangeDataSeries  
- [x] Render gate for labels/lines (current session only)  
- [x] Vertical stem fix at IB completion  
- [x] Rectangle behavior documented as exception (follows `ShowOpenRange`)  
- [x] Manual verification on custom and auto sessions
