### PR TITLE
OHLCPlus: add label customization (template + global labels + per-line overrides)

### DIFF
--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -1248,17 +1248,23 @@ public class OHLCPlus : Indicator
     {
         if (!levelSettings.Enabled || !_levels.TryGetValue(levelKey, out var level) || !level.IsValid)
             return;
-            
+
+        // --- Calculate actual label width for better positioning ---
+        var (prefix, suffix) = SplitKey(levelKey);
+        var levelText = ResolveLevelText(suffix, levelSettings);
+        var displayLabel = BuildDisplayLabel(prefix, levelText);
+        // ----------------------------------------------------
+
         // Validate price is reasonable
         if (level.Price <= 0)
             return;
 
         var y = ChartInfo.GetYByPrice(level.Price, false);
-        
+
         // Check if price is visible on chart
         if (y < 0 || y > ChartInfo.PriceChartContainer.Region.Height)
             return;
-            
+
         var chartWidth = ChartInfo.PriceChartContainer.Region.Width;
         var currentBarX = ChartInfo.GetXByBar(CurrentBar - 1);
         var barWidth = (int)ChartInfo.PriceChartContainer.BarsWidth;
@@ -1274,10 +1280,6 @@ public class OHLCPlus : Indicator
                 // If label is at bar position, start line after the label to avoid overlap
                 if (levelSettings.LabelPosition == LabelPosition.Bar)
                 {
-                    // Calculate actual label width for better positioning
-                    var (prefix, suffix) = SplitKey(levelKey);
-                    var levelText = ResolveLevelText(suffix, levelSettings);
-                    var displayLabel = BuildDisplayLabel(prefix, levelText);
                     var labelSize = context.MeasureString(displayLabel, _font);
                     var labelStartX = currentBarRightX + 5;
                     var lineStartX = labelStartX + labelSize.Width + 4; // 4px padding

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -124,6 +124,15 @@ public class LevelSettings : NotifiableObject
         set => SetField(ref _labelPosition, value);
     }
 
+    private string _overrideLabel = string.Empty;
+
+    [Display(Name = "Override label (optional)")]
+    public string OverrideLabel
+    {
+        get => _overrideLabel;
+        set => SetField(ref _overrideLabel, value);
+    }
+
     [Browsable(false)]
     public RenderPen RenderPen => new PenSettings { Color = Color, Width = Width, LineDashStyle = LineStyle }.RenderObject;
 
@@ -949,6 +958,24 @@ public class OHLCPlus : Indicator
 
     #endregion
 
+    #region Labels Settings
+
+    // Template supports {prefix} and {level}
+    [Display(Name = "Label template")]
+    public string LabelTemplate { get; set; } = "{prefix}{level}";
+
+    [Display(Name = "Open label")] public string OpenLabel { get; set; } = "Open";
+    [Display(Name = "High label")] public string HighLabel { get; set; } = "High";
+    [Display(Name = "Low label")] public string LowLabel { get; set; } = "Low";
+    [Display(Name = "Close label")] public string CloseLabel { get; set; } = "Close";
+    [Display(Name = "Equilibrium label")] public string EqLabel { get; set; } = "EQ";
+    [Display(Name = "POC label")] public string POCLabel { get; set; } = "POC";
+    [Display(Name = "VWAP label")] public string VWAPLabel { get; set; } = "VWAP";
+    [Display(Name = "VAH label")] public string VAHLabel { get; set; } = "VAH";
+    [Display(Name = "VAL label")] public string VALLabel { get; set; } = "VAL";
+
+    #endregion
+
     #endregion
 
     #region Constructor
@@ -1248,8 +1275,10 @@ public class OHLCPlus : Indicator
                 if (levelSettings.LabelPosition == LabelPosition.Bar)
                 {
                     // Calculate actual label width for better positioning
-                    var labelText = level.Label;
-                    var labelSize = context.MeasureString(labelText, _font);
+                    var (prefix, suffix) = SplitKey(levelKey);
+                    var levelText = ResolveLevelText(suffix, levelSettings);
+                    var displayLabel = BuildDisplayLabel(prefix, levelText);
+                    var labelSize = context.MeasureString(displayLabel, _font);
                     var labelStartX = currentBarRightX + 5;
                     var lineStartX = labelStartX + labelSize.Width + 4; // 4px padding
                     context.DrawLine(renderPen, lineStartX, y, chartWidth, y);
@@ -1279,15 +1308,15 @@ public class OHLCPlus : Indicator
         {
             case LabelPosition.Bar:
                 var barLabelX = currentBarRightX + 5;
-                DrawTextLabel(context, level.Label, barLabelX, y, renderPen, false);
+                DrawTextLabel(context, displayLabel, barLabelX, y, renderPen, false);
                 break;
             case LabelPosition.Right:
                 var rightLabelX = chartWidth - 5;
-                DrawTextLabel(context, level.Label, rightLabelX, y, renderPen, true);
+                DrawTextLabel(context, displayLabel, rightLabelX, y, renderPen, true);
                 break;
             case LabelPosition.Left:
                 var leftLabelX = 5;
-                DrawTextLabel(context, level.Label, leftLabelX, y, renderPen, false);
+                DrawTextLabel(context, displayLabel, leftLabelX, y, renderPen, false);
                 break;
             case LabelPosition.None:
                 // No text label to draw
@@ -1443,6 +1472,42 @@ public class OHLCPlus : Indicator
             FixedProfilePeriods.Contract => _needContract,
             _ => false
         };
+    }
+
+    private static (string Prefix, string Suffix) SplitKey(string key)
+    {
+        // Sufijos conocidos ordenados por longitud para evitar colisiones
+        foreach (var s in new[] { "Close", "Open", "High", "Low", "VWAP", "POC", "VAH", "VAL", "EQ" })
+            if (key.EndsWith(s, StringComparison.Ordinal))
+                return (key.Substring(0, key.Length - s.Length), s);
+        return ("", key);
+    }
+
+    private string ResolveLevelText(string suffix, LevelSettings ls)
+    {
+        if (!string.IsNullOrWhiteSpace(ls?.OverrideLabel))
+            return ls.OverrideLabel;
+
+        return suffix switch
+        {
+            "Open" => OpenLabel,
+            "High" => HighLabel,
+            "Low" => LowLabel,
+            "Close" => CloseLabel,
+            "EQ" => EqLabel,
+            "POC" => POCLabel,
+            "VWAP" => VWAPLabel,
+            "VAH" => VAHLabel,
+            "VAL" => VALLabel,
+            _ => suffix
+        };
+    }
+
+    private string BuildDisplayLabel(string prefix, string levelText)
+    {
+        var template = string.IsNullOrEmpty(LabelTemplate) ? "{prefix}{level}" : LabelTemplate;
+        return template.Replace("{prefix}", prefix ?? string.Empty)
+                       .Replace("{level}", levelText ?? string.Empty);
     }
 
     #endregion


### PR DESCRIPTION
### Summary
This PR adds flexible label customization to `OHLCPlus` without changing existing prefixes or level key logic:

- New `LabelTemplate` (`{prefix}{level}` by default).
- New global label texts for each level type: Open/High/Low/Close/EQ/POC/VWAP/VAH/VAL.
- New `OverrideLabel` property inside `LevelSettings` to override a single line’s label (highest priority).

Labels are now composed at render time:
1) Use `LevelSettings.OverrideLabel` if provided.
2) Otherwise use the global label text (`OpenLabel`, `POCLabel`, etc.).
3) Compose with `LabelTemplate` to prepend the existing fixed prefix (e.g. `d`, `p`, `w`, ...).

### Rationale
- Users often need to rename specific levels (e.g., yesterday’s Close => "YGAP") or retitle groups (e.g., "POC" -> "HVN").
- Doing this at render-time keeps the calculation path intact and avoids expensive rebuilds.
- Fully backwards compatible: if no settings are changed, default visuals remain identical.

### Implementation notes
- Minimal changes to `LevelSettings` (added `OverrideLabel`).
- `RenderLevel` now receives a `displayLabel` string (no behavior change for price/line drawing).
- `RenderLevelGroup` composes the final label using `ResolveLevelText` + `BuildDisplayLabel`.

### Testing
- Verified that enabling/disabling levels has no regression.
- Verified per-line overrides (only the target line changes).
- Verified global label changes update all matching levels.
- Verified template changes (e.g., "({prefix}) {level}") apply consistently.

### Non-goals for this PR
- Prefix customization: intentionally excluded to keep this change focused.
- New sessions (overnight/open hours) and HVN rectangles will be proposed in follow-ups.

### Screenshot
- Override previous close label with "GAP"
<img width="1727" height="882" alt="image" src="https://github.com/user-attachments/assets/afc37526-451f-470a-85ca-3fb5a13c235c" />


Thanks for reviewing!
