### PR TITLE
OHLCPlus: Configurable display prefixes (labels only; storage keys remain canonical) (stacked on top of #100)

### DIFF
--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -1248,17 +1248,23 @@ public class OHLCPlus : Indicator
     {
         if (!levelSettings.Enabled || !_levels.TryGetValue(levelKey, out var level) || !level.IsValid)
             return;
-            
+
+        // --- Calculate actual label width for better positioning ---
+        var (prefix, suffix) = SplitKey(levelKey);
+        var levelText = ResolveLevelText(suffix, levelSettings);
+        var displayLabel = BuildDisplayLabel(prefix, levelText);
+        // ----------------------------------------------------
+
         // Validate price is reasonable
         if (level.Price <= 0)
             return;
 
         var y = ChartInfo.GetYByPrice(level.Price, false);
-        
+
         // Check if price is visible on chart
         if (y < 0 || y > ChartInfo.PriceChartContainer.Region.Height)
             return;
-            
+
         var chartWidth = ChartInfo.PriceChartContainer.Region.Width;
         var currentBarX = ChartInfo.GetXByBar(CurrentBar - 1);
         var barWidth = (int)ChartInfo.PriceChartContainer.BarsWidth;
@@ -1274,10 +1280,6 @@ public class OHLCPlus : Indicator
                 // If label is at bar position, start line after the label to avoid overlap
                 if (levelSettings.LabelPosition == LabelPosition.Bar)
                 {
-                    // Calculate actual label width for better positioning
-                    var (prefix, suffix) = SplitKey(levelKey);
-                    var levelText = ResolveLevelText(suffix, levelSettings);
-                    var displayLabel = BuildDisplayLabel(prefix, levelText);
                     var labelSize = context.MeasureString(displayLabel, _font);
                     var labelStartX = currentBarRightX + 5;
                     var lineStartX = labelStartX + labelSize.Width + 4; // 4px padding

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -958,21 +958,54 @@ public class OHLCPlus : Indicator
 
     #endregion
 
+    #region Prefix Settings
+    // Display-only prefixes (do not affect storage keys)
+    [Display(GroupName = "Prefixes", Name = "Current Day", Order = 10)]
+    public string PrefixCurrentDay { get; set; } = "d";
+
+    [Display(GroupName = "Prefixes", Name = "Previous Day", Order = 20)]
+    public string PrefixPrevDay { get; set; } = "p";
+
+    [Display(GroupName = "Prefixes", Name = "Current Week", Order = 30)]
+    public string PrefixCurrentWeek { get; set; } = "w";
+
+    [Display(GroupName = "Prefixes", Name = "Previous Week", Order = 40)]
+    public string PrefixPrevWeek { get; set; } = "pw";
+
+    [Display(GroupName = "Prefixes", Name = "Current Month", Order = 50)]
+    public string PrefixCurrentMonth { get; set; } = "m";
+
+    [Display(GroupName = "Prefixes", Name = "Previous Month", Order = 60)]
+    public string PrefixPrevMonth { get; set; } = "pm";
+
+    [Display(GroupName = "Prefixes", Name = "Contract", Order = 70)]
+    public string PrefixContract { get; set; } = "c";
+    #endregion
+
     #region Labels Settings
 
     // Template supports {prefix} and {level}
-    [Display(Name = "Label template")]
+    [Display(GroupName = "Labels", Name = "Label template", Order = 10)]
     public string LabelTemplate { get; set; } = "{prefix}{level}";
 
-    [Display(Name = "Open label")] public string OpenLabel { get; set; } = "Open";
-    [Display(Name = "High label")] public string HighLabel { get; set; } = "High";
-    [Display(Name = "Low label")] public string LowLabel { get; set; } = "Low";
-    [Display(Name = "Close label")] public string CloseLabel { get; set; } = "Close";
-    [Display(Name = "Equilibrium label")] public string EqLabel { get; set; } = "EQ";
-    [Display(Name = "POC label")] public string POCLabel { get; set; } = "POC";
-    [Display(Name = "VWAP label")] public string VWAPLabel { get; set; } = "VWAP";
-    [Display(Name = "VAH label")] public string VAHLabel { get; set; } = "VAH";
-    [Display(Name = "VAL label")] public string VALLabel { get; set; } = "VAL";
+    [Display(GroupName = "Labels", Name = "Open", Order = 20)]
+    public string OpenLabel { get; set; } = "Open";
+    [Display(GroupName = "Labels", Name = "High", Order = 30)]
+    public string HighLabel { get; set; } = "High";
+    [Display(GroupName = "Labels", Name = "Low", Order = 40)]
+    public string LowLabel { get; set; } = "Low";
+    [Display(GroupName = "Labels", Name = "Close", Order = 50)]
+    public string CloseLabel { get; set; } = "Close";
+    [Display(GroupName = "Labels", Name = "Equilibrium", Order = 60)]
+    public string EqLabel { get; set; } = "EQ";
+    [Display(GroupName = "Labels", Name = "POC", Order = 70)]
+    public string POCLabel { get; set; } = "POC";
+    [Display(GroupName = "Labels", Name = "VWAP", Order = 80)]
+    public string VWAPLabel { get; set; } = "VWAP";
+    [Display(GroupName = "Labels", Name = "VAH", Order = 90)]
+    public string VAHLabel { get; set; } = "VAH";
+    [Display(GroupName = "Labels", Name = "VAL", Order = 100)]
+    public string VALLabel { get; set; } = "VAL";
 
     #endregion
 
@@ -1046,13 +1079,13 @@ public class OHLCPlus : Indicator
             return;
 
         // Render all levels in groups for better organization
-        RenderLevelGroup(context, "d", DayOpenLevel, DayHighLevel, DayLowLevel, DayCloseLevel, DayEquilibriumLevel, DayPOCLevel, DayVWAPLevel, DayVAHLevel, DayVALLevel);
-        RenderLevelGroup(context, "p", PrevDayOpenLevel, PrevDayHighLevel, PrevDayLowLevel, PrevDayCloseLevel, PrevDayEquilibriumLevel, PrevDayPOCLevel, PrevDayVWAPLevel, PrevDayVAHLevel, PrevDayVALLevel);
-        RenderLevelGroup(context, "w", WeekOpenLevel, WeekHighLevel, WeekLowLevel, WeekCloseLevel, WeekEquilibriumLevel, WeekPOCLevel, WeekVWAPLevel, WeekVAHLevel, WeekVALLevel);
-        RenderLevelGroup(context, "pw", PrevWeekOpenLevel, PrevWeekHighLevel, PrevWeekLowLevel, PrevWeekCloseLevel, PrevWeekEquilibriumLevel, PrevWeekPOCLevel, PrevWeekVWAPLevel, PrevWeekVAHLevel, PrevWeekVALLevel);
-        RenderLevelGroup(context, "m", MonthOpenLevel, MonthHighLevel, MonthLowLevel, MonthCloseLevel, MonthEquilibriumLevel, MonthPOCLevel, MonthVWAPLevel, MonthVAHLevel, MonthVALLevel);
-        RenderLevelGroup(context, "pm", PrevMonthOpenLevel, PrevMonthHighLevel, PrevMonthLowLevel, PrevMonthCloseLevel, PrevMonthEquilibriumLevel, PrevMonthPOCLevel, PrevMonthVWAPLevel, PrevMonthVAHLevel, PrevMonthVALLevel);
-        RenderLevelGroup(context, "c", ContractOpenLevel, ContractHighLevel, ContractLowLevel, ContractCloseLevel, ContractEquilibriumLevel, ContractPOCLevel, ContractVWAPLevel, ContractVAHLevel, ContractVALLevel);
+        RenderLevelGroup(context, storagePrefix: "d", displayPrefix: PrefixCurrentDay, DayOpenLevel, DayHighLevel, DayLowLevel, DayCloseLevel, DayEquilibriumLevel, DayPOCLevel, DayVWAPLevel, DayVAHLevel, DayVALLevel);
+        RenderLevelGroup(context, storagePrefix: "p", displayPrefix: PrefixPrevDay, PrevDayOpenLevel, PrevDayHighLevel, PrevDayLowLevel, PrevDayCloseLevel, PrevDayEquilibriumLevel, PrevDayPOCLevel, PrevDayVWAPLevel, PrevDayVAHLevel, PrevDayVALLevel);
+        RenderLevelGroup(context, storagePrefix: "w", displayPrefix: PrefixCurrentWeek, WeekOpenLevel, WeekHighLevel, WeekLowLevel, WeekCloseLevel, WeekEquilibriumLevel, WeekPOCLevel, WeekVWAPLevel, WeekVAHLevel, WeekVALLevel);
+        RenderLevelGroup(context, storagePrefix: "pw", displayPrefix: PrefixPrevWeek, PrevWeekOpenLevel, PrevWeekHighLevel, PrevWeekLowLevel, PrevWeekCloseLevel, PrevWeekEquilibriumLevel, PrevWeekPOCLevel, PrevWeekVWAPLevel, PrevWeekVAHLevel, PrevWeekVALLevel);
+        RenderLevelGroup(context, storagePrefix: "m", displayPrefix: PrefixCurrentMonth, MonthOpenLevel, MonthHighLevel, MonthLowLevel, MonthCloseLevel, MonthEquilibriumLevel, MonthPOCLevel, MonthVWAPLevel, MonthVAHLevel, MonthVALLevel);
+        RenderLevelGroup(context, storagePrefix: "pm", displayPrefix: PrefixPrevMonth, PrevMonthOpenLevel, PrevMonthHighLevel, PrevMonthLowLevel, PrevMonthCloseLevel, PrevMonthEquilibriumLevel, PrevMonthPOCLevel, PrevMonthVWAPLevel, PrevMonthVAHLevel, PrevMonthVALLevel);
+        RenderLevelGroup(context, storagePrefix: "c", displayPrefix: PrefixContract, ContractOpenLevel, ContractHighLevel, ContractLowLevel, ContractCloseLevel, ContractEquilibriumLevel, ContractPOCLevel, ContractVWAPLevel, ContractVAHLevel, ContractVALLevel);
     }
 
     #endregion
@@ -1244,6 +1277,20 @@ public class OHLCPlus : Indicator
         _ => FixedProfilePeriods.CurrentDay
     };
 
+    // Maps the canonical storage prefix ("d", "p", "w", "pw", "m", "pm", "c")
+    // to the user-configurable display prefix for visual labels.
+    private string DisplayPrefixFor(string storagePrefix) => storagePrefix switch
+    {
+        "d" => PrefixCurrentDay,
+        "p" => PrefixPrevDay,
+        "w" => PrefixCurrentWeek,
+        "pw" => PrefixPrevWeek,
+        "m" => PrefixCurrentMonth,
+        "pm" => PrefixPrevMonth,
+        "c" => PrefixContract,
+        _ => storagePrefix ?? string.Empty
+    };
+
     private void RenderLevel(RenderContext context, string levelKey, LevelSettings levelSettings)
     {
         if (!levelSettings.Enabled || !_levels.TryGetValue(levelKey, out var level) || !level.IsValid)
@@ -1252,7 +1299,7 @@ public class OHLCPlus : Indicator
         // --- Calculate actual label width for better positioning ---
         var (prefix, suffix) = SplitKey(levelKey);
         var levelText = ResolveLevelText(suffix, levelSettings);
-        var displayLabel = BuildDisplayLabel(prefix, levelText);
+        var displayLabel = BuildDisplayLabel(DisplayPrefixFor(prefix), levelText);
         // ----------------------------------------------------
 
         // Validate price is reasonable

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -126,6 +126,7 @@ public class LevelSettings : NotifiableObject
 
     private string _overrideLabel = string.Empty;
 
+    // If set, this replaces the ENTIRE visual label (ignores template/prefix/suffix)
     [Display(Name = "Override label (optional)")]
     public string OverrideLabel
     {
@@ -1311,10 +1312,20 @@ public class OHLCPlus : Indicator
         if (!levelSettings.Enabled || !_levels.TryGetValue(levelKey, out var level) || !level.IsValid)
             return;
 
-        // --- Calculate actual label width for better positioning ---
+        // --- Calculate actual label ---
+
         var (prefix, suffix) = SplitKey(levelKey);
-        var levelText = ResolveLevelText(suffix, levelSettings);
-        var displayLabel = BuildDisplayLabel(DisplayPrefixFor(prefix), levelText);
+        // If an override label is provided for this LevelSettings, use it as-is
+        string displayLabel;
+        if (!string.IsNullOrWhiteSpace(levelSettings.OverrideLabel))
+        {
+            displayLabel = levelSettings.OverrideLabel;
+        }
+        else
+        {
+            var levelText = ResolveLevelText(suffix);
+            displayLabel = BuildDisplayLabel(DisplayPrefixFor(prefix), levelText);
+        }
         // ----------------------------------------------------
 
         // Validate price is reasonable
@@ -1343,9 +1354,6 @@ public class OHLCPlus : Indicator
                 if (levelSettings.LabelPosition == LabelPosition.Bar)
                 {
                     // Calculate actual label width for better positioning
-                    var (prefix, suffix) = SplitKey(levelKey);
-                    var levelText = ResolveLevelText(suffix, levelSettings);
-                    var displayLabel = BuildDisplayLabel(prefix, levelText);
                     var labelSize = context.MeasureString(displayLabel, _font);
                     var labelStartX = currentBarRightX + 5;
                     var lineStartX = labelStartX + labelSize.Width + 4; // 4px padding
@@ -1567,11 +1575,8 @@ public class OHLCPlus : Indicator
         return ("", key);
     }
 
-    private string ResolveLevelText(string suffix, LevelSettings ls)
+    private string ResolveLevelText(string suffix)
     {
-        if (!string.IsNullOrWhiteSpace(ls?.OverrideLabel))
-            return ls.OverrideLabel;
-
         return suffix switch
         {
             "Open" => OpenLabel,

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -233,6 +233,10 @@ public class OHLCPlus : Indicator
     private bool _needPrevMonth;
     private bool _needContract;
 
+    // Scoped display-prefix override for the current group render
+    private string? _scopedStoragePrefix = null;
+    private string? _scopedDisplayPrefix = null;
+
     #endregion
 
     #region Properties
@@ -1279,17 +1283,28 @@ public class OHLCPlus : Indicator
 
     // Maps the canonical storage prefix ("d", "p", "w", "pw", "m", "pm", "c")
     // to the user-configurable display prefix for visual labels.
-    private string DisplayPrefixFor(string storagePrefix) => storagePrefix switch
+    // NEW: respects a scoped override set by RenderLevelGroup.
+    private string DisplayPrefixFor(string storagePrefix)
     {
-        "d" => PrefixCurrentDay,
-        "p" => PrefixPrevDay,
-        "w" => PrefixCurrentWeek,
-        "pw" => PrefixPrevWeek,
-        "m" => PrefixCurrentMonth,
-        "pm" => PrefixPrevMonth,
-        "c" => PrefixContract,
-        _ => storagePrefix ?? string.Empty
-    };
+        // Scoped override: only applies while a group with this storagePrefix is rendering
+        if (!string.IsNullOrEmpty(_scopedStoragePrefix) &&
+            string.Equals(storagePrefix, _scopedStoragePrefix, StringComparison.Ordinal) &&
+            !string.IsNullOrEmpty(_scopedDisplayPrefix))
+            return _scopedDisplayPrefix!;
+
+        return storagePrefix switch
+        {
+            "d" => PrefixCurrentDay,
+            "p" => PrefixPrevDay,
+            "w" => PrefixCurrentWeek,
+            "pw" => PrefixPrevWeek,
+            "m" => PrefixCurrentMonth,
+            "pm" => PrefixPrevMonth,
+            "c" => PrefixContract,
+            _ => storagePrefix ?? string.Empty
+        };
+    }
+
 
     private void RenderLevel(RenderContext context, string levelKey, LevelSettings levelSettings)
     {
@@ -1427,22 +1442,38 @@ public class OHLCPlus : Indicator
         context.DrawString(text, _font, textColor, textRect, format);
     }
 
-    private void RenderLevelGroup(RenderContext context, string prefix,
-      LevelSettings openLevel, LevelSettings highLevel, LevelSettings lowLevel, LevelSettings closeLevel,
-      LevelSettings eqLevel, LevelSettings pocLevel, LevelSettings vwapLevel, LevelSettings vahLevel, LevelSettings valLevel)
+    private void RenderLevelGroup(RenderContext context, string storagePrefix, string displayPrefix, // NEW: user-configurable display prefix (UI)
+    LevelSettings openLevel, LevelSettings highLevel, LevelSettings lowLevel, LevelSettings closeLevel,
+    LevelSettings eqLevel, LevelSettings pocLevel, LevelSettings vwapLevel, LevelSettings vahLevel, LevelSettings valLevel)
     {
-        var keys = _keys[PeriodFromPrefix(prefix)];
-        // 0 Open, 1 High, 2 Low, 3 Close, 4 EQ, 5 POC, 6 VWAP, 7 VAH, 8 VAL
+        // Activate scoped override for this group render
+        _scopedStoragePrefix = storagePrefix;
+        _scopedDisplayPrefix = displayPrefix;
 
-        RenderLevel(context, keys[0], openLevel);
-        RenderLevel(context, keys[1], highLevel);
-        RenderLevel(context, keys[2], lowLevel);
-        RenderLevel(context, keys[3], closeLevel);
-        RenderLevel(context, keys[4], eqLevel);
-        RenderLevel(context, keys[5], pocLevel);
-        RenderLevel(context, keys[6], vwapLevel);
-        RenderLevel(context, keys[7], vahLevel);
-        RenderLevel(context, keys[8], valLevel);
+        try
+        {
+            var levels = new[]
+            {
+            ("Open", openLevel),
+            ("High", highLevel),
+            ("Low", lowLevel),
+            ("Close", closeLevel),
+            ("EQ", eqLevel),
+            ("POC", pocLevel),
+            ("VWAP", vwapLevel),
+            ("VAH", vahLevel),
+            ("VAL", valLevel)
+        };
+
+            foreach (var (suffix, levelSettings) in levels)
+                RenderLevel(context, $"{storagePrefix}{suffix}", levelSettings);
+        }
+        finally
+        {
+            // Always clear the override after finishing this group
+            _scopedStoragePrefix = null;
+            _scopedDisplayPrefix = null;
+        }
     }
 
     #endregion

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -1280,6 +1280,11 @@ public class OHLCPlus : Indicator
                 // If label is at bar position, start line after the label to avoid overlap
                 if (levelSettings.LabelPosition == LabelPosition.Bar)
                 {
+                    // Calculate actual label width for better positioning
+                    var (prefix, suffix) = SplitKey(levelKey);
+                    var levelText = ResolveLevelText(suffix, levelSettings);
+                    var displayLabel = BuildDisplayLabel(prefix, levelText);
+                    var labelSize = context.MeasureString(displayLabel, _font);
                     var labelSize = context.MeasureString(displayLabel, _font);
                     var labelStartX = currentBarRightX + 5;
                     var lineStartX = labelStartX + labelSize.Width + 4; // 4px padding

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -124,6 +124,15 @@ public class LevelSettings : NotifiableObject
         set => SetField(ref _labelPosition, value);
     }
 
+    private string _overrideLabel = string.Empty;
+
+    [Display(Name = "Override label (optional)")]
+    public string OverrideLabel
+    {
+        get => _overrideLabel;
+        set => SetField(ref _overrideLabel, value);
+    }
+
     [Browsable(false)]
     public RenderPen RenderPen => new PenSettings { Color = Color, Width = Width, LineDashStyle = LineStyle }.RenderObject;
 
@@ -949,6 +958,24 @@ public class OHLCPlus : Indicator
 
     #endregion
 
+    #region Labels Settings
+
+    // Template supports {prefix} and {level}
+    [Display(Name = "Label template")]
+    public string LabelTemplate { get; set; } = "{prefix}{level}";
+
+    [Display(Name = "Open label")] public string OpenLabel { get; set; } = "Open";
+    [Display(Name = "High label")] public string HighLabel { get; set; } = "High";
+    [Display(Name = "Low label")] public string LowLabel { get; set; } = "Low";
+    [Display(Name = "Close label")] public string CloseLabel { get; set; } = "Close";
+    [Display(Name = "Equilibrium label")] public string EqLabel { get; set; } = "EQ";
+    [Display(Name = "POC label")] public string POCLabel { get; set; } = "POC";
+    [Display(Name = "VWAP label")] public string VWAPLabel { get; set; } = "VWAP";
+    [Display(Name = "VAH label")] public string VAHLabel { get; set; } = "VAH";
+    [Display(Name = "VAL label")] public string VALLabel { get; set; } = "VAL";
+
+    #endregion
+
     #endregion
 
     #region Constructor
@@ -1248,8 +1275,10 @@ public class OHLCPlus : Indicator
                 if (levelSettings.LabelPosition == LabelPosition.Bar)
                 {
                     // Calculate actual label width for better positioning
-                    var labelText = level.Label;
-                    var labelSize = context.MeasureString(labelText, _font);
+                    var (prefix, suffix) = SplitKey(levelKey);
+                    var levelText = ResolveLevelText(suffix, levelSettings);
+                    var displayLabel = BuildDisplayLabel(prefix, levelText);
+                    var labelSize = context.MeasureString(displayLabel, _font);
                     var labelStartX = currentBarRightX + 5;
                     var lineStartX = labelStartX + labelSize.Width + 4; // 4px padding
                     context.DrawLine(renderPen, lineStartX, y, chartWidth, y);
@@ -1279,15 +1308,15 @@ public class OHLCPlus : Indicator
         {
             case LabelPosition.Bar:
                 var barLabelX = currentBarRightX + 5;
-                DrawTextLabel(context, level.Label, barLabelX, y, renderPen, false);
+                DrawTextLabel(context, displayLabel, barLabelX, y, renderPen, false);
                 break;
             case LabelPosition.Right:
                 var rightLabelX = chartWidth - 5;
-                DrawTextLabel(context, level.Label, rightLabelX, y, renderPen, true);
+                DrawTextLabel(context, displayLabel, rightLabelX, y, renderPen, true);
                 break;
             case LabelPosition.Left:
                 var leftLabelX = 5;
-                DrawTextLabel(context, level.Label, leftLabelX, y, renderPen, false);
+                DrawTextLabel(context, displayLabel, leftLabelX, y, renderPen, false);
                 break;
             case LabelPosition.None:
                 // No text label to draw
@@ -1443,6 +1472,42 @@ public class OHLCPlus : Indicator
             FixedProfilePeriods.Contract => _needContract,
             _ => false
         };
+    }
+
+    private static (string Prefix, string Suffix) SplitKey(string key)
+    {
+        // Sufijos conocidos ordenados por longitud para evitar colisiones
+        foreach (var s in new[] { "Close", "Open", "High", "Low", "VWAP", "POC", "VAH", "VAL", "EQ" })
+            if (key.EndsWith(s, StringComparison.Ordinal))
+                return (key.Substring(0, key.Length - s.Length), s);
+        return ("", key);
+    }
+
+    private string ResolveLevelText(string suffix, LevelSettings ls)
+    {
+        if (!string.IsNullOrWhiteSpace(ls?.OverrideLabel))
+            return ls.OverrideLabel;
+
+        return suffix switch
+        {
+            "Open" => OpenLabel,
+            "High" => HighLabel,
+            "Low" => LowLabel,
+            "Close" => CloseLabel,
+            "EQ" => EqLabel,
+            "POC" => POCLabel,
+            "VWAP" => VWAPLabel,
+            "VAH" => VAHLabel,
+            "VAL" => VALLabel,
+            _ => suffix
+        };
+    }
+
+    private string BuildDisplayLabel(string prefix, string levelText)
+    {
+        var template = string.IsNullOrEmpty(LabelTemplate) ? "{prefix}{level}" : LabelTemplate;
+        return template.Replace("{prefix}", prefix ?? string.Empty)
+                       .Replace("{level}", levelText ?? string.Empty);
     }
 
     #endregion

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -16,13 +16,13 @@ public enum LabelPosition
 {
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.None))]
     None = 0,
-    
+
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Bar))]
     Bar = 1,
-    
+
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Right))]
     Right = 2,
-    
+
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Left))]
     Left = 3
 }
@@ -31,10 +31,10 @@ public enum LineType
 {
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.None))]
     None = 0,
-    
+
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.TillBar))]
     Bar = 1,
-    
+
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.FullWidth))]
     Full = 2
 }
@@ -1332,7 +1332,6 @@ public class OHLCPlus : Indicator
                     var levelText = ResolveLevelText(suffix, levelSettings);
                     var displayLabel = BuildDisplayLabel(prefix, levelText);
                     var labelSize = context.MeasureString(displayLabel, _font);
-                    var labelSize = context.MeasureString(displayLabel, _font);
                     var labelStartX = currentBarRightX + 5;
                     var lineStartX = labelStartX + labelSize.Width + 4; // 4px padding
                     context.DrawLine(renderPen, lineStartX, y, chartWidth, y);
@@ -1381,20 +1380,20 @@ public class OHLCPlus : Indicator
     private void DrawPriceLabel(RenderContext context, decimal price, int y, RenderPen pen, LevelSettings levelSettings)
     {
         var priceText = string.Format(ChartInfo.StringFormat, price);
-        
+
         // Calculate contrasting text color based on background color
         var backgroundColor = levelSettings.Color;
         var textColor = GetContrastingColor(backgroundColor);
-        
+
         this.DrawLabelOnPriceAxis(context, priceText, y, _axisFont, backgroundColor.Convert(), textColor.Convert());
     }
-    
+
     private CrossColor GetContrastingColor(CrossColor backgroundColor)
     {
         // Calculate luminance using relative luminance formula
         // See: https://www.w3.org/TR/WCAG20/#relativeluminancedef
         double luminance = (0.299 * backgroundColor.R + 0.587 * backgroundColor.G + 0.114 * backgroundColor.B) / 255;
-        
+
         // If background is dark, use white text; if light, use black text
         if (luminance > 0.5)
         {
@@ -1412,16 +1411,16 @@ public class OHLCPlus : Indicator
     {
         var size = context.MeasureString(text, _font);
         var textColor = ChartInfo.ColorsStore.MouseTextColor;
-        
+
         // Calculate rectangle position based on alignment
         var rectX = alignRight ? x - size.Width : x;
         var rect = new Rectangle(rectX - 2, y - size.Height / 2 - 1, size.Width + 4, size.Height + 2);
-        
+
         // Draw background with border
         var backgroundColor = ChartInfo.ColorsStore.BaseBackgroundColor;
         context.FillRectangle(backgroundColor, rect);
         context.DrawRectangle(pen, rect);
-        
+
         // Draw text
         var textRect = new Rectangle(rectX, y - size.Height / 2, size.Width, size.Height);
         var format = alignRight ? _stringRightFormat : _stringLeftFormat;


### PR DESCRIPTION
This PR adds user-configurable period prefixes for display purposes while keeping
the internal level keys canonical (d/p/w/pw/m/pm/c). No changes to calculation
or storage; display labels are composed at render time using the new display
prefix properties plus the label customization introduced in the previous PR.

- New properties: PrefixCurrentDay / PrevDay / CurrentWeek / PrevWeek / CurrentMonth / PrevMonth / Contract.
- Render-level keys continue to use canonical prefixes to avoid cache rebuilds and maintain full backward compatibility.
- Minimal diff: Update RenderLevelGroup to accept both storagePrefix (canonical) and displayPrefix (configurable).

No performance impact and fully backward compatible

---
### Additional improvements (26/10):
- ResolveLevelText no longer checks OverrideLabel (handled in RenderLevel).
----

### Screenshot:
<img width="1021" height="1070" alt="image" src="https://github.com/user-attachments/assets/b382aaf0-b3c2-4712-8014-1f875187b5c3" />
