### PR TITLE
OHLCPlus: configurable color schemes (by period / by level) with per-line override (colors updated) (stacked on top of #101)

### DIFF
--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -1248,17 +1248,23 @@ public class OHLCPlus : Indicator
     {
         if (!levelSettings.Enabled || !_levels.TryGetValue(levelKey, out var level) || !level.IsValid)
             return;
-            
+
+        // --- Calculate actual label width for better positioning ---
+        var (prefix, suffix) = SplitKey(levelKey);
+        var levelText = ResolveLevelText(suffix, levelSettings);
+        var displayLabel = BuildDisplayLabel(prefix, levelText);
+        // ----------------------------------------------------
+
         // Validate price is reasonable
         if (level.Price <= 0)
             return;
 
         var y = ChartInfo.GetYByPrice(level.Price, false);
-        
+
         // Check if price is visible on chart
         if (y < 0 || y > ChartInfo.PriceChartContainer.Region.Height)
             return;
-            
+
         var chartWidth = ChartInfo.PriceChartContainer.Region.Width;
         var currentBarX = ChartInfo.GetXByBar(CurrentBar - 1);
         var barWidth = (int)ChartInfo.PriceChartContainer.BarsWidth;
@@ -1274,10 +1280,6 @@ public class OHLCPlus : Indicator
                 // If label is at bar position, start line after the label to avoid overlap
                 if (levelSettings.LabelPosition == LabelPosition.Bar)
                 {
-                    // Calculate actual label width for better positioning
-                    var (prefix, suffix) = SplitKey(levelKey);
-                    var levelText = ResolveLevelText(suffix, levelSettings);
-                    var displayLabel = BuildDisplayLabel(prefix, levelText);
                     var labelSize = context.MeasureString(displayLabel, _font);
                     var labelStartX = currentBarRightX + 5;
                     var lineStartX = labelStartX + labelSize.Width + 4; // 4px padding

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -1042,53 +1042,53 @@ public class OHLCPlus : Indicator
     public ColorMode ColorMode { get; set; } = ColorMode.PerLineSettings;
 
     // --- Palette by PERIOD (used when ColorMode == ByPeriod)
-    [Display(GroupName = "Colors — By Period", Name = "Current Day", Order = 10)]
+    [Display(GroupName = "Colors - By Period", Name = "Current Day", Order = 10)]
     public CrossColor PeriodColorCurrentDay { get; set; } = System.Drawing.Color.OrangeRed.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Previous Day", Order = 11)]
+    [Display(GroupName = "Colors - By Period", Name = "Previous Day", Order = 11)]
     public CrossColor PeriodColorPrevDay { get; set; } = System.Drawing.Color.SaddleBrown.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Current Week", Order = 12)]
+    [Display(GroupName = "Colors - By Period", Name = "Current Week", Order = 12)]
     public CrossColor PeriodColorCurrentWeek { get; set; } = System.Drawing.Color.DeepSkyBlue.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Previous Week", Order = 13)]
+    [Display(GroupName = "Colors - By Period", Name = "Previous Week", Order = 13)]
     public CrossColor PeriodColorPrevWeek { get; set; } = System.Drawing.Color.DarkSlateBlue.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Current Month", Order = 14)]
+    [Display(GroupName = "Colors - By Period", Name = "Current Month", Order = 14)]
     public CrossColor PeriodColorCurrentMonth { get; set; } = System.Drawing.Color.MediumSeaGreen.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Previous Month", Order = 15)]
+    [Display(GroupName = "Colors - By Period", Name = "Previous Month", Order = 15)]
     public CrossColor PeriodColorPrevMonth { get; set; } = System.Drawing.Color.DarkOliveGreen.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Contract", Order = 16)]
+    [Display(GroupName = "Colors - By Period", Name = "Contract", Order = 16)]
     public CrossColor PeriodColorContract { get; set; } = System.Drawing.Color.Indigo.Convert();
 
     // --- Palette by LEVEL TYPE (used when ColorMode == ByLevel)
-    [Display(GroupName = "Colors — By Level", Name = "Open", Order = 110)]
+    [Display(GroupName = "Colors - By Level", Name = "Open", Order = 110)]
     public CrossColor LevelColorOpen { get; set; } = System.Drawing.Color.DarkGoldenrod.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "High", Order = 120)]
+    [Display(GroupName = "Colors - By Level", Name = "High", Order = 120)]
     public CrossColor LevelColorHigh { get; set; } = System.Drawing.Color.ForestGreen.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "Low", Order = 130)]
+    [Display(GroupName = "Colors - By Level", Name = "Low", Order = 130)]
     public CrossColor LevelColorLow { get; set; } = System.Drawing.Color.Firebrick.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "Close", Order = 140)]
+    [Display(GroupName = "Colors - By Level", Name = "Close", Order = 140)]
     public CrossColor LevelColorClose { get; set; } = System.Drawing.Color.DimGray.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "Equilibrium (EQ)", Order = 150)]
+    [Display(GroupName = "Colors - By Level", Name = "Equilibrium (EQ)", Order = 150)]
     public CrossColor LevelColorEQ { get; set; } = System.Drawing.Color.DarkKhaki.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "POC", Order = 160)]
+    [Display(GroupName = "Colors - By Level", Name = "POC", Order = 160)]
     public CrossColor LevelColorPOC { get; set; } = System.Drawing.Color.OrangeRed.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "VWAP", Order = 170)]
+    [Display(GroupName = "Colors - By Level", Name = "VWAP", Order = 170)]
     public CrossColor LevelColorVWAP { get; set; } = System.Drawing.Color.DodgerBlue.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "VAH", Order = 180)]
+    [Display(GroupName = "Colors - By Level", Name = "VAH", Order = 180)]
     public CrossColor LevelColorVAH { get; set; } = System.Drawing.Color.CornflowerBlue.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "VAL", Order = 190)]
+    [Display(GroupName = "Colors - By Level", Name = "VAL", Order = 190)]
     public CrossColor LevelColorVAL { get; set; } = System.Drawing.Color.RoyalBlue.Convert();
     #endregion
 
@@ -1680,7 +1680,7 @@ public class OHLCPlus : Indicator
             }
         }
 
-        // Visual-only changes → redraw
+        // Visual-only changes -> redraw
         if (e.PropertyName == nameof(LevelSettings.Color)
             || e.PropertyName == nameof(LevelSettings.OverrideColorInSchemes)
             || e.PropertyName == nameof(LevelSettings.LineStyle)

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -958,21 +958,54 @@ public class OHLCPlus : Indicator
 
     #endregion
 
+    #region Prefix Settings
+    // Display-only prefixes (do not affect storage keys)
+    [Display(GroupName = "Prefixes", Name = "Current Day", Order = 10)]
+    public string PrefixCurrentDay { get; set; } = "d";
+
+    [Display(GroupName = "Prefixes", Name = "Previous Day", Order = 20)]
+    public string PrefixPrevDay { get; set; } = "p";
+
+    [Display(GroupName = "Prefixes", Name = "Current Week", Order = 30)]
+    public string PrefixCurrentWeek { get; set; } = "w";
+
+    [Display(GroupName = "Prefixes", Name = "Previous Week", Order = 40)]
+    public string PrefixPrevWeek { get; set; } = "pw";
+
+    [Display(GroupName = "Prefixes", Name = "Current Month", Order = 50)]
+    public string PrefixCurrentMonth { get; set; } = "m";
+
+    [Display(GroupName = "Prefixes", Name = "Previous Month", Order = 60)]
+    public string PrefixPrevMonth { get; set; } = "pm";
+
+    [Display(GroupName = "Prefixes", Name = "Contract", Order = 70)]
+    public string PrefixContract { get; set; } = "c";
+    #endregion
+
     #region Labels Settings
 
     // Template supports {prefix} and {level}
-    [Display(Name = "Label template")]
+    [Display(GroupName = "Labels", Name = "Label template", Order = 10)]
     public string LabelTemplate { get; set; } = "{prefix}{level}";
 
-    [Display(Name = "Open label")] public string OpenLabel { get; set; } = "Open";
-    [Display(Name = "High label")] public string HighLabel { get; set; } = "High";
-    [Display(Name = "Low label")] public string LowLabel { get; set; } = "Low";
-    [Display(Name = "Close label")] public string CloseLabel { get; set; } = "Close";
-    [Display(Name = "Equilibrium label")] public string EqLabel { get; set; } = "EQ";
-    [Display(Name = "POC label")] public string POCLabel { get; set; } = "POC";
-    [Display(Name = "VWAP label")] public string VWAPLabel { get; set; } = "VWAP";
-    [Display(Name = "VAH label")] public string VAHLabel { get; set; } = "VAH";
-    [Display(Name = "VAL label")] public string VALLabel { get; set; } = "VAL";
+    [Display(GroupName = "Labels", Name = "Open", Order = 20)]
+    public string OpenLabel { get; set; } = "Open";
+    [Display(GroupName = "Labels", Name = "High", Order = 30)]
+    public string HighLabel { get; set; } = "High";
+    [Display(GroupName = "Labels", Name = "Low", Order = 40)]
+    public string LowLabel { get; set; } = "Low";
+    [Display(GroupName = "Labels", Name = "Close", Order = 50)]
+    public string CloseLabel { get; set; } = "Close";
+    [Display(GroupName = "Labels", Name = "Equilibrium", Order = 60)]
+    public string EqLabel { get; set; } = "EQ";
+    [Display(GroupName = "Labels", Name = "POC", Order = 70)]
+    public string POCLabel { get; set; } = "POC";
+    [Display(GroupName = "Labels", Name = "VWAP", Order = 80)]
+    public string VWAPLabel { get; set; } = "VWAP";
+    [Display(GroupName = "Labels", Name = "VAH", Order = 90)]
+    public string VAHLabel { get; set; } = "VAH";
+    [Display(GroupName = "Labels", Name = "VAL", Order = 100)]
+    public string VALLabel { get; set; } = "VAL";
 
     #endregion
 
@@ -1046,13 +1079,13 @@ public class OHLCPlus : Indicator
             return;
 
         // Render all levels in groups for better organization
-        RenderLevelGroup(context, "d", DayOpenLevel, DayHighLevel, DayLowLevel, DayCloseLevel, DayEquilibriumLevel, DayPOCLevel, DayVWAPLevel, DayVAHLevel, DayVALLevel);
-        RenderLevelGroup(context, "p", PrevDayOpenLevel, PrevDayHighLevel, PrevDayLowLevel, PrevDayCloseLevel, PrevDayEquilibriumLevel, PrevDayPOCLevel, PrevDayVWAPLevel, PrevDayVAHLevel, PrevDayVALLevel);
-        RenderLevelGroup(context, "w", WeekOpenLevel, WeekHighLevel, WeekLowLevel, WeekCloseLevel, WeekEquilibriumLevel, WeekPOCLevel, WeekVWAPLevel, WeekVAHLevel, WeekVALLevel);
-        RenderLevelGroup(context, "pw", PrevWeekOpenLevel, PrevWeekHighLevel, PrevWeekLowLevel, PrevWeekCloseLevel, PrevWeekEquilibriumLevel, PrevWeekPOCLevel, PrevWeekVWAPLevel, PrevWeekVAHLevel, PrevWeekVALLevel);
-        RenderLevelGroup(context, "m", MonthOpenLevel, MonthHighLevel, MonthLowLevel, MonthCloseLevel, MonthEquilibriumLevel, MonthPOCLevel, MonthVWAPLevel, MonthVAHLevel, MonthVALLevel);
-        RenderLevelGroup(context, "pm", PrevMonthOpenLevel, PrevMonthHighLevel, PrevMonthLowLevel, PrevMonthCloseLevel, PrevMonthEquilibriumLevel, PrevMonthPOCLevel, PrevMonthVWAPLevel, PrevMonthVAHLevel, PrevMonthVALLevel);
-        RenderLevelGroup(context, "c", ContractOpenLevel, ContractHighLevel, ContractLowLevel, ContractCloseLevel, ContractEquilibriumLevel, ContractPOCLevel, ContractVWAPLevel, ContractVAHLevel, ContractVALLevel);
+        RenderLevelGroup(context, storagePrefix: "d", displayPrefix: PrefixCurrentDay, DayOpenLevel, DayHighLevel, DayLowLevel, DayCloseLevel, DayEquilibriumLevel, DayPOCLevel, DayVWAPLevel, DayVAHLevel, DayVALLevel);
+        RenderLevelGroup(context, storagePrefix: "p", displayPrefix: PrefixPrevDay, PrevDayOpenLevel, PrevDayHighLevel, PrevDayLowLevel, PrevDayCloseLevel, PrevDayEquilibriumLevel, PrevDayPOCLevel, PrevDayVWAPLevel, PrevDayVAHLevel, PrevDayVALLevel);
+        RenderLevelGroup(context, storagePrefix: "w", displayPrefix: PrefixCurrentWeek, WeekOpenLevel, WeekHighLevel, WeekLowLevel, WeekCloseLevel, WeekEquilibriumLevel, WeekPOCLevel, WeekVWAPLevel, WeekVAHLevel, WeekVALLevel);
+        RenderLevelGroup(context, storagePrefix: "pw", displayPrefix: PrefixPrevWeek, PrevWeekOpenLevel, PrevWeekHighLevel, PrevWeekLowLevel, PrevWeekCloseLevel, PrevWeekEquilibriumLevel, PrevWeekPOCLevel, PrevWeekVWAPLevel, PrevWeekVAHLevel, PrevWeekVALLevel);
+        RenderLevelGroup(context, storagePrefix: "m", displayPrefix: PrefixCurrentMonth, MonthOpenLevel, MonthHighLevel, MonthLowLevel, MonthCloseLevel, MonthEquilibriumLevel, MonthPOCLevel, MonthVWAPLevel, MonthVAHLevel, MonthVALLevel);
+        RenderLevelGroup(context, storagePrefix: "pm", displayPrefix: PrefixPrevMonth, PrevMonthOpenLevel, PrevMonthHighLevel, PrevMonthLowLevel, PrevMonthCloseLevel, PrevMonthEquilibriumLevel, PrevMonthPOCLevel, PrevMonthVWAPLevel, PrevMonthVAHLevel, PrevMonthVALLevel);
+        RenderLevelGroup(context, storagePrefix: "c", displayPrefix: PrefixContract, ContractOpenLevel, ContractHighLevel, ContractLowLevel, ContractCloseLevel, ContractEquilibriumLevel, ContractPOCLevel, ContractVWAPLevel, ContractVAHLevel, ContractVALLevel);
     }
 
     #endregion
@@ -1244,6 +1277,20 @@ public class OHLCPlus : Indicator
         _ => FixedProfilePeriods.CurrentDay
     };
 
+    // Maps the canonical storage prefix ("d", "p", "w", "pw", "m", "pm", "c")
+    // to the user-configurable display prefix for visual labels.
+    private string DisplayPrefixFor(string storagePrefix) => storagePrefix switch
+    {
+        "d" => PrefixCurrentDay,
+        "p" => PrefixPrevDay,
+        "w" => PrefixCurrentWeek,
+        "pw" => PrefixPrevWeek,
+        "m" => PrefixCurrentMonth,
+        "pm" => PrefixPrevMonth,
+        "c" => PrefixContract,
+        _ => storagePrefix ?? string.Empty
+    };
+
     private void RenderLevel(RenderContext context, string levelKey, LevelSettings levelSettings)
     {
         if (!levelSettings.Enabled || !_levels.TryGetValue(levelKey, out var level) || !level.IsValid)
@@ -1252,7 +1299,7 @@ public class OHLCPlus : Indicator
         // --- Calculate actual label width for better positioning ---
         var (prefix, suffix) = SplitKey(levelKey);
         var levelText = ResolveLevelText(suffix, levelSettings);
-        var displayLabel = BuildDisplayLabel(prefix, levelText);
+        var displayLabel = BuildDisplayLabel(DisplayPrefixFor(prefix), levelText);
         // ----------------------------------------------------
 
         // Validate price is reasonable

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -126,6 +126,7 @@ public class LevelSettings : NotifiableObject
 
     private string _overrideLabel = string.Empty;
 
+    // If set, this replaces the ENTIRE visual label (ignores template/prefix/suffix)
     [Display(Name = "Override label (optional)")]
     public string OverrideLabel
     {
@@ -1311,10 +1312,20 @@ public class OHLCPlus : Indicator
         if (!levelSettings.Enabled || !_levels.TryGetValue(levelKey, out var level) || !level.IsValid)
             return;
 
-        // --- Calculate actual label width for better positioning ---
+        // --- Calculate actual label ---
+
         var (prefix, suffix) = SplitKey(levelKey);
-        var levelText = ResolveLevelText(suffix, levelSettings);
-        var displayLabel = BuildDisplayLabel(DisplayPrefixFor(prefix), levelText);
+        // If an override label is provided for this LevelSettings, use it as-is
+        string displayLabel;
+        if (!string.IsNullOrWhiteSpace(levelSettings.OverrideLabel))
+        {
+            displayLabel = levelSettings.OverrideLabel;
+        }
+        else
+        {
+            var levelText = ResolveLevelText(suffix);
+            displayLabel = BuildDisplayLabel(DisplayPrefixFor(prefix), levelText);
+        }
         // ----------------------------------------------------
 
         // Validate price is reasonable
@@ -1343,9 +1354,6 @@ public class OHLCPlus : Indicator
                 if (levelSettings.LabelPosition == LabelPosition.Bar)
                 {
                     // Calculate actual label width for better positioning
-                    var (prefix, suffix) = SplitKey(levelKey);
-                    var levelText = ResolveLevelText(suffix, levelSettings);
-                    var displayLabel = BuildDisplayLabel(prefix, levelText);
                     var labelSize = context.MeasureString(displayLabel, _font);
                     var labelStartX = currentBarRightX + 5;
                     var lineStartX = labelStartX + labelSize.Width + 4; // 4px padding
@@ -1567,11 +1575,8 @@ public class OHLCPlus : Indicator
         return ("", key);
     }
 
-    private string ResolveLevelText(string suffix, LevelSettings ls)
+    private string ResolveLevelText(string suffix)
     {
-        if (!string.IsNullOrWhiteSpace(ls?.OverrideLabel))
-            return ls.OverrideLabel;
-
         return suffix switch
         {
             "Open" => OpenLabel,

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -1374,20 +1374,18 @@ public class OHLCPlus : Indicator
     }
 
 
-// Resolve the color respecting the precedence (per-line override > scheme > per-line default)
-    private CrossColor ResolveColor(FixedProfilePeriods period, string suffix, LevelSettings ls)
+    // Resolve the color respecting the precedence (per-line override > scheme > per-line default)
+    private CrossColor ResolveColor(string storagePrefix, string suffix, LevelSettings ls)
     {
-        if (ls != null && ls.UsePerLineColor)
-            return ls.Color; // per-line override wins
-
-        switch (ColorMode) // TODO: enum you introduce for the color feature
+        switch (ColorMode)
         {
             case ColorMode.ByPeriod:
-                return ResolvePeriodPalette(period);
+                return ResolvePeriodPalette(storagePrefix);
             case ColorMode.ByLevel:
                 return ResolveLevelPalette(suffix);
+            case ColorMode.PerLineSettings:
             default:
-                return ls?.Color ?? CrossColors.White;
+                return ls?.Color ?? CrossColors.White; // color propio de la línea (comportamiento por defecto)
         }
     }
 
@@ -1396,33 +1394,31 @@ public class OHLCPlus : Indicator
         => new PenSettings { Color = color, Width = ls.Width, LineDashStyle = ls.LineStyle }.RenderObject;
 
     // Palette resolvers
-    private CrossColor ResolvePeriodPalette(FixedProfilePeriods period)
-        => period switch
-        {
-            FixedProfilePeriods.CurrentDay   => PeriodColorCurrentDay,
-            FixedProfilePeriods.LastDay      => PeriodColorPrevDay,
-            FixedProfilePeriods.CurrentWeek  => PeriodColorCurrentWeek,
-            FixedProfilePeriods.LastWeek     => PeriodColorPrevWeek,
-            FixedProfilePeriods.CurrentMonth => PeriodColorCurrentMonth,
-            FixedProfilePeriods.LastMonth    => PeriodColorPrevMonth,
-            FixedProfilePeriods.Contract     => PeriodColorContract,
-            _                                => CrossColors.White
-        };
+    private CrossColor ResolvePeriodPalette(string storagePrefix) => storagePrefix switch
+    {
+        "d" => PeriodColorCurrentDay,
+        "p" => PeriodColorPrevDay,
+        "w" => PeriodColorCurrentWeek,
+        "pw" => PeriodColorPrevWeek,
+        "m" => PeriodColorCurrentMonth,
+        "pm" => PeriodColorPrevMonth,
+        "c" => PeriodColorContract,
+        _ => CrossColors.White
+    };
 
-    private CrossColor ResolveLevelPalette(string suffix)
-        => suffix switch
-        {
-            "Open"  => LevelColorOpen,
-            "High"  => LevelColorHigh,
-            "Low"   => LevelColorLow,
-            "Close" => LevelColorClose,
-            "EQ"    => LevelColorEQ,
-            "POC"   => LevelColorPOC,
-            "VWAP"  => LevelColorVWAP,
-            "VAH"   => LevelColorVAH,
-            "VAL"   => LevelColorVAL,
-            _       => CrossColors.White
-        };
+    private CrossColor ResolveLevelPalette(string suffix) => suffix switch
+    {
+        "Open" => LevelColorOpen,
+        "High" => LevelColorHigh,
+        "Low" => LevelColorLow,
+        "Close" => LevelColorClose,
+        "EQ" => LevelColorEQ,
+        "POC" => LevelColorPOC,
+        "VWAP" => LevelColorVWAP,
+        "VAH" => LevelColorVAH,
+        "VAL" => LevelColorVAL,
+        _ => CrossColors.White
+    };
 
     private void RenderLevel(RenderContext context, string levelKey, LevelSettings levelSettings)
     {

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -233,6 +233,10 @@ public class OHLCPlus : Indicator
     private bool _needPrevMonth;
     private bool _needContract;
 
+    // Scoped display-prefix override for the current group render
+    private string? _scopedStoragePrefix = null;
+    private string? _scopedDisplayPrefix = null;
+
     #endregion
 
     #region Properties
@@ -1279,17 +1283,28 @@ public class OHLCPlus : Indicator
 
     // Maps the canonical storage prefix ("d", "p", "w", "pw", "m", "pm", "c")
     // to the user-configurable display prefix for visual labels.
-    private string DisplayPrefixFor(string storagePrefix) => storagePrefix switch
+    // NEW: respects a scoped override set by RenderLevelGroup.
+    private string DisplayPrefixFor(string storagePrefix)
     {
-        "d" => PrefixCurrentDay,
-        "p" => PrefixPrevDay,
-        "w" => PrefixCurrentWeek,
-        "pw" => PrefixPrevWeek,
-        "m" => PrefixCurrentMonth,
-        "pm" => PrefixPrevMonth,
-        "c" => PrefixContract,
-        _ => storagePrefix ?? string.Empty
-    };
+        // Scoped override: only applies while a group with this storagePrefix is rendering
+        if (!string.IsNullOrEmpty(_scopedStoragePrefix) &&
+            string.Equals(storagePrefix, _scopedStoragePrefix, StringComparison.Ordinal) &&
+            !string.IsNullOrEmpty(_scopedDisplayPrefix))
+            return _scopedDisplayPrefix!;
+
+        return storagePrefix switch
+        {
+            "d" => PrefixCurrentDay,
+            "p" => PrefixPrevDay,
+            "w" => PrefixCurrentWeek,
+            "pw" => PrefixPrevWeek,
+            "m" => PrefixCurrentMonth,
+            "pm" => PrefixPrevMonth,
+            "c" => PrefixContract,
+            _ => storagePrefix ?? string.Empty
+        };
+    }
+
 
     private void RenderLevel(RenderContext context, string levelKey, LevelSettings levelSettings)
     {
@@ -1427,22 +1442,38 @@ public class OHLCPlus : Indicator
         context.DrawString(text, _font, textColor, textRect, format);
     }
 
-    private void RenderLevelGroup(RenderContext context, string prefix,
-      LevelSettings openLevel, LevelSettings highLevel, LevelSettings lowLevel, LevelSettings closeLevel,
-      LevelSettings eqLevel, LevelSettings pocLevel, LevelSettings vwapLevel, LevelSettings vahLevel, LevelSettings valLevel)
+    private void RenderLevelGroup(RenderContext context, string storagePrefix, string displayPrefix, // NEW: user-configurable display prefix (UI)
+    LevelSettings openLevel, LevelSettings highLevel, LevelSettings lowLevel, LevelSettings closeLevel,
+    LevelSettings eqLevel, LevelSettings pocLevel, LevelSettings vwapLevel, LevelSettings vahLevel, LevelSettings valLevel)
     {
-        var keys = _keys[PeriodFromPrefix(prefix)];
-        // 0 Open, 1 High, 2 Low, 3 Close, 4 EQ, 5 POC, 6 VWAP, 7 VAH, 8 VAL
+        // Activate scoped override for this group render
+        _scopedStoragePrefix = storagePrefix;
+        _scopedDisplayPrefix = displayPrefix;
 
-        RenderLevel(context, keys[0], openLevel);
-        RenderLevel(context, keys[1], highLevel);
-        RenderLevel(context, keys[2], lowLevel);
-        RenderLevel(context, keys[3], closeLevel);
-        RenderLevel(context, keys[4], eqLevel);
-        RenderLevel(context, keys[5], pocLevel);
-        RenderLevel(context, keys[6], vwapLevel);
-        RenderLevel(context, keys[7], vahLevel);
-        RenderLevel(context, keys[8], valLevel);
+        try
+        {
+            var levels = new[]
+            {
+            ("Open", openLevel),
+            ("High", highLevel),
+            ("Low", lowLevel),
+            ("Close", closeLevel),
+            ("EQ", eqLevel),
+            ("POC", pocLevel),
+            ("VWAP", vwapLevel),
+            ("VAH", vahLevel),
+            ("VAL", valLevel)
+        };
+
+            foreach (var (suffix, levelSettings) in levels)
+                RenderLevel(context, $"{storagePrefix}{suffix}", levelSettings);
+        }
+        finally
+        {
+            // Always clear the override after finishing this group
+            _scopedStoragePrefix = null;
+            _scopedDisplayPrefix = null;
+        }
     }
 
     #endregion

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -1032,53 +1032,53 @@ public class OHLCPlus : Indicator
 
     // --- Palette by PERIOD (used when ColorMode == ByPeriod)
     [Display(GroupName = "Colors — By Period", Name = "Current Day", Order = 10)]
-    public CrossColor PeriodColorCurrentDay { get; set; } = System.Drawing.Color.Orange.Convert();
+    public CrossColor PeriodColorCurrentDay { get; set; } = System.Drawing.Color.OrangeRed.Convert();
 
     [Display(GroupName = "Colors — By Period", Name = "Previous Day", Order = 11)]
-    public CrossColor PeriodColorPrevDay { get; set; } = System.Drawing.Color.Gray.Convert();
+    public CrossColor PeriodColorPrevDay { get; set; } = System.Drawing.Color.SaddleBrown.Convert();
 
     [Display(GroupName = "Colors — By Period", Name = "Current Week", Order = 12)]
-    public CrossColor PeriodColorCurrentWeek { get; set; } = System.Drawing.Color.SteelBlue.Convert();
+    public CrossColor PeriodColorCurrentWeek { get; set; } = System.Drawing.Color.DeepSkyBlue.Convert();
 
     [Display(GroupName = "Colors — By Period", Name = "Previous Week", Order = 13)]
-    public CrossColor PeriodColorPrevWeek { get; set; } = System.Drawing.Color.MediumPurple.Convert();
+    public CrossColor PeriodColorPrevWeek { get; set; } = System.Drawing.Color.DarkSlateBlue.Convert();
 
     [Display(GroupName = "Colors — By Period", Name = "Current Month", Order = 14)]
-    public CrossColor PeriodColorCurrentMonth { get; set; } = System.Drawing.Color.Teal.Convert();
+    public CrossColor PeriodColorCurrentMonth { get; set; } = System.Drawing.Color.MediumSeaGreen.Convert();
 
     [Display(GroupName = "Colors — By Period", Name = "Previous Month", Order = 15)]
-    public CrossColor PeriodColorPrevMonth { get; set; } = System.Drawing.Color.DarkSlateGray.Convert();
+    public CrossColor PeriodColorPrevMonth { get; set; } = System.Drawing.Color.DarkOliveGreen.Convert();
 
     [Display(GroupName = "Colors — By Period", Name = "Contract", Order = 16)]
-    public CrossColor PeriodColorContract { get; set; } = System.Drawing.Color.DodgerBlue.Convert();
+    public CrossColor PeriodColorContract { get; set; } = System.Drawing.Color.Indigo.Convert();
 
     // --- Palette by LEVEL TYPE (used when ColorMode == ByLevel)
     [Display(GroupName = "Colors — By Level", Name = "Open", Order = 110)]
-    public CrossColor LevelColorOpen { get; set; } = System.Drawing.Color.Orange.Convert();
+    public CrossColor LevelColorOpen { get; set; } = System.Drawing.Color.DarkGoldenrod.Convert();
 
     [Display(GroupName = "Colors — By Level", Name = "High", Order = 120)]
-    public CrossColor LevelColorHigh { get; set; } = System.Drawing.Color.Green.Convert();
+    public CrossColor LevelColorHigh { get; set; } = System.Drawing.Color.ForestGreen.Convert();
 
     [Display(GroupName = "Colors — By Level", Name = "Low", Order = 130)]
-    public CrossColor LevelColorLow { get; set; } = System.Drawing.Color.Red.Convert();
+    public CrossColor LevelColorLow { get; set; } = System.Drawing.Color.Firebrick.Convert();
 
     [Display(GroupName = "Colors — By Level", Name = "Close", Order = 140)]
-    public CrossColor LevelColorClose { get; set; } = System.Drawing.Color.Gray.Convert();
+    public CrossColor LevelColorClose { get; set; } = System.Drawing.Color.DimGray.Convert();
 
     [Display(GroupName = "Colors — By Level", Name = "Equilibrium (EQ)", Order = 150)]
-    public CrossColor LevelColorEQ { get; set; } = System.Drawing.Color.Yellow.Convert();
+    public CrossColor LevelColorEQ { get; set; } = System.Drawing.Color.DarkKhaki.Convert();
 
     [Display(GroupName = "Colors — By Level", Name = "POC", Order = 160)]
-    public CrossColor LevelColorPOC { get; set; } = System.Drawing.Color.Orange.Convert();
+    public CrossColor LevelColorPOC { get; set; } = System.Drawing.Color.OrangeRed.Convert();
 
     [Display(GroupName = "Colors — By Level", Name = "VWAP", Order = 170)]
-    public CrossColor LevelColorVWAP { get; set; } = System.Drawing.Color.SteelBlue.Convert();
+    public CrossColor LevelColorVWAP { get; set; } = System.Drawing.Color.DodgerBlue.Convert();
 
     [Display(GroupName = "Colors — By Level", Name = "VAH", Order = 180)]
-    public CrossColor LevelColorVAH { get; set; } = System.Drawing.Color.Purple.Convert();
+    public CrossColor LevelColorVAH { get; set; } = System.Drawing.Color.CornflowerBlue.Convert();
 
     [Display(GroupName = "Colors — By Level", Name = "VAL", Order = 190)]
-    public CrossColor LevelColorVAL { get; set; } = System.Drawing.Color.Purple.Convert();
+    public CrossColor LevelColorVAL { get; set; } = System.Drawing.Color.RoyalBlue.Convert();
     #endregion
 
     #endregion

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -1,4 +1,4 @@
-namespace ATAS.Indicators.Technical;
+ï»¿namespace ATAS.Indicators.Technical;
 
 using OFT.Localization;
 using OFT.Rendering.Context;
@@ -145,6 +145,16 @@ public class LevelSettings : NotifiableObject
         set => SetField(ref _overrideLabel, value);
     }
 
+    private bool _overrideColorInSchemes;
+
+    [Display(GroupName = "Colors", Name = "Override color in scheme modes")]
+    [Description("If enabled, this line will use its own Color even when ColorMode is ByPeriod or ByLevel.")]
+    public bool OverrideColorInSchemes
+    {
+        get => _overrideColorInSchemes;
+        set => SetField(ref _overrideColorInSchemes, value);
+    }
+
     [Browsable(false)]
     public RenderPen RenderPen => new PenSettings { Color = Color, Width = Width, LineDashStyle = LineStyle }.RenderObject;
 
@@ -170,6 +180,7 @@ public class LevelSettings : NotifiableObject
         ShowPrice = showPrice;
         LabelPosition = labelPosition;
         LineType = lineType;
+        OverrideColorInSchemes = false;
     }
 
     #endregion
@@ -1031,53 +1042,53 @@ public class OHLCPlus : Indicator
     public ColorMode ColorMode { get; set; } = ColorMode.PerLineSettings;
 
     // --- Palette by PERIOD (used when ColorMode == ByPeriod)
-    [Display(GroupName = "Colors — By Period", Name = "Current Day", Order = 10)]
+    [Display(GroupName = "Colors â€” By Period", Name = "Current Day", Order = 10)]
     public CrossColor PeriodColorCurrentDay { get; set; } = System.Drawing.Color.OrangeRed.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Previous Day", Order = 11)]
+    [Display(GroupName = "Colors â€” By Period", Name = "Previous Day", Order = 11)]
     public CrossColor PeriodColorPrevDay { get; set; } = System.Drawing.Color.SaddleBrown.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Current Week", Order = 12)]
+    [Display(GroupName = "Colors â€” By Period", Name = "Current Week", Order = 12)]
     public CrossColor PeriodColorCurrentWeek { get; set; } = System.Drawing.Color.DeepSkyBlue.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Previous Week", Order = 13)]
+    [Display(GroupName = "Colors â€” By Period", Name = "Previous Week", Order = 13)]
     public CrossColor PeriodColorPrevWeek { get; set; } = System.Drawing.Color.DarkSlateBlue.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Current Month", Order = 14)]
+    [Display(GroupName = "Colors â€” By Period", Name = "Current Month", Order = 14)]
     public CrossColor PeriodColorCurrentMonth { get; set; } = System.Drawing.Color.MediumSeaGreen.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Previous Month", Order = 15)]
+    [Display(GroupName = "Colors â€” By Period", Name = "Previous Month", Order = 15)]
     public CrossColor PeriodColorPrevMonth { get; set; } = System.Drawing.Color.DarkOliveGreen.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Contract", Order = 16)]
+    [Display(GroupName = "Colors â€” By Period", Name = "Contract", Order = 16)]
     public CrossColor PeriodColorContract { get; set; } = System.Drawing.Color.Indigo.Convert();
 
     // --- Palette by LEVEL TYPE (used when ColorMode == ByLevel)
-    [Display(GroupName = "Colors — By Level", Name = "Open", Order = 110)]
+    [Display(GroupName = "Colors â€” By Level", Name = "Open", Order = 110)]
     public CrossColor LevelColorOpen { get; set; } = System.Drawing.Color.DarkGoldenrod.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "High", Order = 120)]
+    [Display(GroupName = "Colors â€” By Level", Name = "High", Order = 120)]
     public CrossColor LevelColorHigh { get; set; } = System.Drawing.Color.ForestGreen.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "Low", Order = 130)]
+    [Display(GroupName = "Colors â€” By Level", Name = "Low", Order = 130)]
     public CrossColor LevelColorLow { get; set; } = System.Drawing.Color.Firebrick.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "Close", Order = 140)]
+    [Display(GroupName = "Colors â€” By Level", Name = "Close", Order = 140)]
     public CrossColor LevelColorClose { get; set; } = System.Drawing.Color.DimGray.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "Equilibrium (EQ)", Order = 150)]
+    [Display(GroupName = "Colors â€” By Level", Name = "Equilibrium (EQ)", Order = 150)]
     public CrossColor LevelColorEQ { get; set; } = System.Drawing.Color.DarkKhaki.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "POC", Order = 160)]
+    [Display(GroupName = "Colors â€” By Level", Name = "POC", Order = 160)]
     public CrossColor LevelColorPOC { get; set; } = System.Drawing.Color.OrangeRed.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "VWAP", Order = 170)]
+    [Display(GroupName = "Colors â€” By Level", Name = "VWAP", Order = 170)]
     public CrossColor LevelColorVWAP { get; set; } = System.Drawing.Color.DodgerBlue.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "VAH", Order = 180)]
+    [Display(GroupName = "Colors â€” By Level", Name = "VAH", Order = 180)]
     public CrossColor LevelColorVAH { get; set; } = System.Drawing.Color.CornflowerBlue.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "VAL", Order = 190)]
+    [Display(GroupName = "Colors â€” By Level", Name = "VAL", Order = 190)]
     public CrossColor LevelColorVAL { get; set; } = System.Drawing.Color.RoyalBlue.Convert();
     #endregion
 
@@ -1377,6 +1388,11 @@ public class OHLCPlus : Indicator
     // Resolve the color respecting the precedence (per-line override > scheme > per-line default)
     private CrossColor ResolveColor(string storagePrefix, string suffix, LevelSettings ls)
     {
+        // 1) Per-line hard override
+        if (ls?.OverrideColorInSchemes == true)
+            return ls.Color;
+
+        // 2) Scheme color (when active)
         switch (ColorMode)
         {
             case ColorMode.ByPeriod:
@@ -1385,7 +1401,7 @@ public class OHLCPlus : Indicator
                 return ResolveLevelPalette(suffix);
             case ColorMode.PerLineSettings:
             default:
-                return ls?.Color ?? CrossColors.White; // color propio de la línea (comportamiento por defecto)
+                return ls?.Color ?? CrossColors.White; // line's own color (default behavior)
         }
     }
 
@@ -1663,6 +1679,18 @@ public class OHLCPlus : Indicator
                     RedrawChart();
             }
         }
+
+        // Visual-only changes â†’ redraw
+        if (e.PropertyName == nameof(LevelSettings.Color)
+            || e.PropertyName == nameof(LevelSettings.OverrideColorInSchemes)
+            || e.PropertyName == nameof(LevelSettings.LineStyle)
+            || e.PropertyName == nameof(LevelSettings.Width)
+            || e.PropertyName == nameof(LevelSettings.LabelPosition)
+            || e.PropertyName == nameof(LevelSettings.ShowPrice)
+            || e.PropertyName == nameof(LevelSettings.OverrideLabel))
+        {
+            RedrawChart();
+        }
     }
 
     private bool IsNeeded(FixedProfilePeriods period)
@@ -1682,7 +1710,7 @@ public class OHLCPlus : Indicator
 
     private static (string Prefix, string Suffix) SplitKey(string key)
     {
-        // Sufijos conocidos ordenados por longitud para evitar colisiones
+        // Known suffixes ordered by length to avoid collisions
         foreach (var s in new[] { "Close", "Open", "High", "Low", "VWAP", "POC", "VAH", "VAL", "EQ" })
             if (key.EndsWith(s, StringComparison.Ordinal))
                 return (key.Substring(0, key.Length - s.Length), s);

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -39,6 +39,17 @@ public enum LineType
     Full = 2
 }
 
+// How colors are chosen at render time
+public enum ColorMode
+{
+    // Use the color in each LevelSettings (current behavior)
+    PerLineSettings = 0,
+    // Override by timeframe (Day/PrevDay/Week/...)
+    ByPeriod = 1,
+    // Override by level type (Open/High/Low/Close/EQ/POC/VWAP/VAH/VAL)
+    ByLevel = 2
+}
+
 public abstract class NotifiableObject : INotifyPropertyChanged
 {
     public event PropertyChangedEventHandler? PropertyChanged;
@@ -1014,6 +1025,62 @@ public class OHLCPlus : Indicator
 
     #endregion
 
+    #region Color scheme
+    // Strategy selector
+    [Display(GroupName = "Colors", Name = "Mode", Order = 5)]
+    public ColorMode ColorMode { get; set; } = ColorMode.PerLineSettings;
+
+    // --- Palette by PERIOD (used when ColorMode == ByPeriod)
+    [Display(GroupName = "Colors — By Period", Name = "Current Day", Order = 10)]
+    public CrossColor PeriodColorCurrentDay { get; set; } = System.Drawing.Color.Orange.Convert();
+
+    [Display(GroupName = "Colors — By Period", Name = "Previous Day", Order = 11)]
+    public CrossColor PeriodColorPrevDay { get; set; } = System.Drawing.Color.Gray.Convert();
+
+    [Display(GroupName = "Colors — By Period", Name = "Current Week", Order = 12)]
+    public CrossColor PeriodColorCurrentWeek { get; set; } = System.Drawing.Color.SteelBlue.Convert();
+
+    [Display(GroupName = "Colors — By Period", Name = "Previous Week", Order = 13)]
+    public CrossColor PeriodColorPrevWeek { get; set; } = System.Drawing.Color.MediumPurple.Convert();
+
+    [Display(GroupName = "Colors — By Period", Name = "Current Month", Order = 14)]
+    public CrossColor PeriodColorCurrentMonth { get; set; } = System.Drawing.Color.Teal.Convert();
+
+    [Display(GroupName = "Colors — By Period", Name = "Previous Month", Order = 15)]
+    public CrossColor PeriodColorPrevMonth { get; set; } = System.Drawing.Color.DarkSlateGray.Convert();
+
+    [Display(GroupName = "Colors — By Period", Name = "Contract", Order = 16)]
+    public CrossColor PeriodColorContract { get; set; } = System.Drawing.Color.DodgerBlue.Convert();
+
+    // --- Palette by LEVEL TYPE (used when ColorMode == ByLevel)
+    [Display(GroupName = "Colors — By Level", Name = "Open", Order = 110)]
+    public CrossColor LevelColorOpen { get; set; } = System.Drawing.Color.Orange.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "High", Order = 120)]
+    public CrossColor LevelColorHigh { get; set; } = System.Drawing.Color.Green.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "Low", Order = 130)]
+    public CrossColor LevelColorLow { get; set; } = System.Drawing.Color.Red.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "Close", Order = 140)]
+    public CrossColor LevelColorClose { get; set; } = System.Drawing.Color.Gray.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "Equilibrium (EQ)", Order = 150)]
+    public CrossColor LevelColorEQ { get; set; } = System.Drawing.Color.Yellow.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "POC", Order = 160)]
+    public CrossColor LevelColorPOC { get; set; } = System.Drawing.Color.Orange.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "VWAP", Order = 170)]
+    public CrossColor LevelColorVWAP { get; set; } = System.Drawing.Color.SteelBlue.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "VAH", Order = 180)]
+    public CrossColor LevelColorVAH { get; set; } = System.Drawing.Color.Purple.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "VAL", Order = 190)]
+    public CrossColor LevelColorVAL { get; set; } = System.Drawing.Color.Purple.Convert();
+    #endregion
+
     #endregion
 
     #region Constructor
@@ -1307,6 +1374,56 @@ public class OHLCPlus : Indicator
     }
 
 
+// Resolve the color respecting the precedence (per-line override > scheme > per-line default)
+    private CrossColor ResolveColor(FixedProfilePeriods period, string suffix, LevelSettings ls)
+    {
+        if (ls != null && ls.UsePerLineColor)
+            return ls.Color; // per-line override wins
+
+        switch (ColorMode) // TODO: enum you introduce for the color feature
+        {
+            case ColorMode.ByPeriod:
+                return ResolvePeriodPalette(period);
+            case ColorMode.ByLevel:
+                return ResolveLevelPalette(suffix);
+            default:
+                return ls?.Color ?? CrossColors.White;
+        }
+    }
+
+    // Build a pen using the resolved color (do not rely on ls.RenderPen anymore when schemes are active)
+    private RenderPen BuildPen(LevelSettings ls, CrossColor color)
+        => new PenSettings { Color = color, Width = ls.Width, LineDashStyle = ls.LineStyle }.RenderObject;
+
+    // Palette resolvers
+    private CrossColor ResolvePeriodPalette(FixedProfilePeriods period)
+        => period switch
+        {
+            FixedProfilePeriods.CurrentDay   => PeriodColorCurrentDay,
+            FixedProfilePeriods.LastDay      => PeriodColorPrevDay,
+            FixedProfilePeriods.CurrentWeek  => PeriodColorCurrentWeek,
+            FixedProfilePeriods.LastWeek     => PeriodColorPrevWeek,
+            FixedProfilePeriods.CurrentMonth => PeriodColorCurrentMonth,
+            FixedProfilePeriods.LastMonth    => PeriodColorPrevMonth,
+            FixedProfilePeriods.Contract     => PeriodColorContract,
+            _                                => CrossColors.White
+        };
+
+    private CrossColor ResolveLevelPalette(string suffix)
+        => suffix switch
+        {
+            "Open"  => LevelColorOpen,
+            "High"  => LevelColorHigh,
+            "Low"   => LevelColorLow,
+            "Close" => LevelColorClose,
+            "EQ"    => LevelColorEQ,
+            "POC"   => LevelColorPOC,
+            "VWAP"  => LevelColorVWAP,
+            "VAH"   => LevelColorVAH,
+            "VAL"   => LevelColorVAL,
+            _       => CrossColors.White
+        };
+
     private void RenderLevel(RenderContext context, string levelKey, LevelSettings levelSettings)
     {
         if (!levelSettings.Enabled || !_levels.TryGetValue(levelKey, out var level) || !level.IsValid)
@@ -1328,6 +1445,10 @@ public class OHLCPlus : Indicator
         }
         // ----------------------------------------------------
 
+        // NEW: resolve color & pen
+        var color = ResolveColor(prefix, suffix, levelSettings);
+        var renderPen = BuildPen(levelSettings, color);
+
         // Validate price is reasonable
         if (level.Price <= 0)
             return;
@@ -1343,8 +1464,6 @@ public class OHLCPlus : Indicator
         var barWidth = (int)ChartInfo.PriceChartContainer.BarsWidth;
         var currentBarRightX = currentBarX + barWidth;
 
-        // Get pen from LevelSettings
-        var renderPen = levelSettings.RenderPen;
 
         // Draw line first (if LineType != None)
         switch (levelSettings.LineType)
@@ -1376,7 +1495,7 @@ public class OHLCPlus : Indicator
         // Draw price label (if ShowPrice == true)
         if (levelSettings.ShowPrice)
         {
-            DrawPriceLabel(context, level.Price, y, renderPen, levelSettings);
+            DrawPriceLabel(context, level.Price, y, renderPen, color);
         }
 
         // Draw text label (if LabelPosition != None)
@@ -1400,12 +1519,11 @@ public class OHLCPlus : Indicator
         }
     }
 
-    private void DrawPriceLabel(RenderContext context, decimal price, int y, RenderPen pen, LevelSettings levelSettings)
+    private void DrawPriceLabel(RenderContext context, decimal price, int y, RenderPen pen, CrossColor backgroundColor)
     {
         var priceText = string.Format(ChartInfo.StringFormat, price);
 
         // Calculate contrasting text color based on background color
-        var backgroundColor = levelSettings.Color;
         var textColor = GetContrastingColor(backgroundColor);
 
         this.DrawLabelOnPriceAxis(context, priceText, y, _axisFont, backgroundColor.Convert(), textColor.Convert());

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -1280,6 +1280,11 @@ public class OHLCPlus : Indicator
                 // If label is at bar position, start line after the label to avoid overlap
                 if (levelSettings.LabelPosition == LabelPosition.Bar)
                 {
+                    // Calculate actual label width for better positioning
+                    var (prefix, suffix) = SplitKey(levelKey);
+                    var levelText = ResolveLevelText(suffix, levelSettings);
+                    var displayLabel = BuildDisplayLabel(prefix, levelText);
+                    var labelSize = context.MeasureString(displayLabel, _font);
                     var labelSize = context.MeasureString(displayLabel, _font);
                     var labelStartX = currentBarRightX + 5;
                     var lineStartX = labelStartX + labelSize.Width + 4; // 4px padding

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -124,6 +124,15 @@ public class LevelSettings : NotifiableObject
         set => SetField(ref _labelPosition, value);
     }
 
+    private string _overrideLabel = string.Empty;
+
+    [Display(Name = "Override label (optional)")]
+    public string OverrideLabel
+    {
+        get => _overrideLabel;
+        set => SetField(ref _overrideLabel, value);
+    }
+
     [Browsable(false)]
     public RenderPen RenderPen => new PenSettings { Color = Color, Width = Width, LineDashStyle = LineStyle }.RenderObject;
 
@@ -949,6 +958,24 @@ public class OHLCPlus : Indicator
 
     #endregion
 
+    #region Labels Settings
+
+    // Template supports {prefix} and {level}
+    [Display(Name = "Label template")]
+    public string LabelTemplate { get; set; } = "{prefix}{level}";
+
+    [Display(Name = "Open label")] public string OpenLabel { get; set; } = "Open";
+    [Display(Name = "High label")] public string HighLabel { get; set; } = "High";
+    [Display(Name = "Low label")] public string LowLabel { get; set; } = "Low";
+    [Display(Name = "Close label")] public string CloseLabel { get; set; } = "Close";
+    [Display(Name = "Equilibrium label")] public string EqLabel { get; set; } = "EQ";
+    [Display(Name = "POC label")] public string POCLabel { get; set; } = "POC";
+    [Display(Name = "VWAP label")] public string VWAPLabel { get; set; } = "VWAP";
+    [Display(Name = "VAH label")] public string VAHLabel { get; set; } = "VAH";
+    [Display(Name = "VAL label")] public string VALLabel { get; set; } = "VAL";
+
+    #endregion
+
     #endregion
 
     #region Constructor
@@ -1248,8 +1275,10 @@ public class OHLCPlus : Indicator
                 if (levelSettings.LabelPosition == LabelPosition.Bar)
                 {
                     // Calculate actual label width for better positioning
-                    var labelText = level.Label;
-                    var labelSize = context.MeasureString(labelText, _font);
+                    var (prefix, suffix) = SplitKey(levelKey);
+                    var levelText = ResolveLevelText(suffix, levelSettings);
+                    var displayLabel = BuildDisplayLabel(prefix, levelText);
+                    var labelSize = context.MeasureString(displayLabel, _font);
                     var labelStartX = currentBarRightX + 5;
                     var lineStartX = labelStartX + labelSize.Width + 4; // 4px padding
                     context.DrawLine(renderPen, lineStartX, y, chartWidth, y);
@@ -1279,15 +1308,15 @@ public class OHLCPlus : Indicator
         {
             case LabelPosition.Bar:
                 var barLabelX = currentBarRightX + 5;
-                DrawTextLabel(context, level.Label, barLabelX, y, renderPen, false);
+                DrawTextLabel(context, displayLabel, barLabelX, y, renderPen, false);
                 break;
             case LabelPosition.Right:
                 var rightLabelX = chartWidth - 5;
-                DrawTextLabel(context, level.Label, rightLabelX, y, renderPen, true);
+                DrawTextLabel(context, displayLabel, rightLabelX, y, renderPen, true);
                 break;
             case LabelPosition.Left:
                 var leftLabelX = 5;
-                DrawTextLabel(context, level.Label, leftLabelX, y, renderPen, false);
+                DrawTextLabel(context, displayLabel, leftLabelX, y, renderPen, false);
                 break;
             case LabelPosition.None:
                 // No text label to draw
@@ -1443,6 +1472,42 @@ public class OHLCPlus : Indicator
             FixedProfilePeriods.Contract => _needContract,
             _ => false
         };
+    }
+
+    private static (string Prefix, string Suffix) SplitKey(string key)
+    {
+        // Sufijos conocidos ordenados por longitud para evitar colisiones
+        foreach (var s in new[] { "Close", "Open", "High", "Low", "VWAP", "POC", "VAH", "VAL", "EQ" })
+            if (key.EndsWith(s, StringComparison.Ordinal))
+                return (key.Substring(0, key.Length - s.Length), s);
+        return ("", key);
+    }
+
+    private string ResolveLevelText(string suffix, LevelSettings ls)
+    {
+        if (!string.IsNullOrWhiteSpace(ls?.OverrideLabel))
+            return ls.OverrideLabel;
+
+        return suffix switch
+        {
+            "Open" => OpenLabel,
+            "High" => HighLabel,
+            "Low" => LowLabel,
+            "Close" => CloseLabel,
+            "EQ" => EqLabel,
+            "POC" => POCLabel,
+            "VWAP" => VWAPLabel,
+            "VAH" => VAHLabel,
+            "VAL" => VALLabel,
+            _ => suffix
+        };
+    }
+
+    private string BuildDisplayLabel(string prefix, string levelText)
+    {
+        var template = string.IsNullOrEmpty(LabelTemplate) ? "{prefix}{level}" : LabelTemplate;
+        return template.Replace("{prefix}", prefix ?? string.Empty)
+                       .Replace("{level}", levelText ?? string.Empty);
     }
 
     #endregion

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -16,13 +16,13 @@ public enum LabelPosition
 {
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.None))]
     None = 0,
-    
+
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Bar))]
     Bar = 1,
-    
+
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Right))]
     Right = 2,
-    
+
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Left))]
     Left = 3
 }
@@ -31,10 +31,10 @@ public enum LineType
 {
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.None))]
     None = 0,
-    
+
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.TillBar))]
     Bar = 1,
-    
+
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.FullWidth))]
     Full = 2
 }
@@ -1332,7 +1332,6 @@ public class OHLCPlus : Indicator
                     var levelText = ResolveLevelText(suffix, levelSettings);
                     var displayLabel = BuildDisplayLabel(prefix, levelText);
                     var labelSize = context.MeasureString(displayLabel, _font);
-                    var labelSize = context.MeasureString(displayLabel, _font);
                     var labelStartX = currentBarRightX + 5;
                     var lineStartX = labelStartX + labelSize.Width + 4; // 4px padding
                     context.DrawLine(renderPen, lineStartX, y, chartWidth, y);
@@ -1381,20 +1380,20 @@ public class OHLCPlus : Indicator
     private void DrawPriceLabel(RenderContext context, decimal price, int y, RenderPen pen, LevelSettings levelSettings)
     {
         var priceText = string.Format(ChartInfo.StringFormat, price);
-        
+
         // Calculate contrasting text color based on background color
         var backgroundColor = levelSettings.Color;
         var textColor = GetContrastingColor(backgroundColor);
-        
+
         this.DrawLabelOnPriceAxis(context, priceText, y, _axisFont, backgroundColor.Convert(), textColor.Convert());
     }
-    
+
     private CrossColor GetContrastingColor(CrossColor backgroundColor)
     {
         // Calculate luminance using relative luminance formula
         // See: https://www.w3.org/TR/WCAG20/#relativeluminancedef
         double luminance = (0.299 * backgroundColor.R + 0.587 * backgroundColor.G + 0.114 * backgroundColor.B) / 255;
-        
+
         // If background is dark, use white text; if light, use black text
         if (luminance > 0.5)
         {
@@ -1412,16 +1411,16 @@ public class OHLCPlus : Indicator
     {
         var size = context.MeasureString(text, _font);
         var textColor = ChartInfo.ColorsStore.MouseTextColor;
-        
+
         // Calculate rectangle position based on alignment
         var rectX = alignRight ? x - size.Width : x;
         var rect = new Rectangle(rectX - 2, y - size.Height / 2 - 1, size.Width + 4, size.Height + 2);
-        
+
         // Draw background with border
         var backgroundColor = ChartInfo.ColorsStore.BaseBackgroundColor;
         context.FillRectangle(backgroundColor, rect);
         context.DrawRectangle(pen, rect);
-        
+
         // Draw text
         var textRect = new Rectangle(rectX, y - size.Height / 2, size.Width, size.Height);
         var format = alignRight ? _stringRightFormat : _stringLeftFormat;


### PR DESCRIPTION
**Title:** OHLCPlus: configurable color schemes (by period / by level) with per-line override

---

## Summary
This PR adds a flexible color system to **OHLCPlus**:

- **New modes** (`ColorMode`):
  - `PerLineSettings` (default): keeps current behavior.
  - `ByPeriod`: one global palette per timeframe (current/previous day, week, month, contract).
  - `ByLevel`: one global palette per level type (Open/High/Low/Close/EQ/POC/VWAP/VAH/VAL).
- **Per-line override**:
  - Each `LevelSettings` has `UsePerLineColor`. When enabled, that line always uses its own `Color`, ignoring the global scheme.
- **Clear precedence**:
  1) `UsePerLineColor == true` → use `LevelSettings.Color`.  
  2) Otherwise apply global scheme (`ByPeriod` or `ByLevel`).  
  3) Otherwise fall back to `LevelSettings.Color`.

---

## Technical Changes
- Added enum `ColorMode` and UI group **Colors**.
- **Palettes**:
  - **Colors — By Period**: `PeriodColorCurrentDay`, `PeriodColorPrevDay`, `PeriodColorCurrentWeek`, `PeriodColorPrevWeek`, `PeriodColorCurrentMonth`, `PeriodColorPrevMonth`, `PeriodColorContract`.
  - **Colors — By Level**: `LevelColorOpen`, `LevelColorHigh`, `LevelColorLow`, `LevelColorClose`, `LevelColorEQ`, `LevelColorPOC`, `LevelColorVWAP`, `LevelColorVAH`, `LevelColorVAL`.
- `LevelSettings`:
  - Added `UsePerLineColor` flag.
- Rendering:
  - `ResolveColor(period, suffix, ls)` decides the final color.
  - `BuildPen(ls, color)` creates the `RenderPen` with the resolved color.
  - `RenderLevel(...)` now receives `(period, suffix)` and uses the resolved color.
  - `DrawPriceLabel(...)` now takes the resolved `CrossColor` as background.
- Helpers:
  - `ResolvePeriodPalette(FixedProfilePeriods)`
  - `ResolveLevelPalette(string suffix)`
- Minor cleanup: removed unused `System.Windows.Media` import.

---

## Compatibility
- **No storage-key changes**: `_levels` still use immutable **canonical prefixes**.
- **Default behavior unchanged**: `ColorMode = PerLineSettings` until the user explicitly chooses otherwise.
- **No migrations** required.

---

## Testing
- Compiles and renders with:
  - `ColorMode = PerLineSettings` (baseline).
  - `ColorMode = ByPeriod` with distinct per-period palettes.
  - `ColorMode = ByLevel` with per-level palettes.
- Verified **per-line override** by toggling `UsePerLineColor` on a single line.
- Confirmed dynamic price-label contrast (black/white text based on background) still works.
- Ensured we avoid drawing lines/labels outside the vertical viewport.

---

## UI Notes
- The **Colors** group exposes the `Mode` selector on top; palettes are only used when the corresponding mode is active.

---
## 26/10 Updated
Updates OHLCPlus default colors to a high-contrast, semantics-driven palette.

By Period:
- Current Day = OrangeRed vs Previous Day = SaddleBrown
- Current Week = DeepSkyBlue vs Previous Week = DarkSlateBlue
- Current Month = MediumSeaGreen vs Previous Month = DarkOliveGreen
- Contract = Indigo

By Level:
- Open = DarkGoldenrod, High = ForestGreen, Low = Firebrick, Close = DimGray
- EQ = DarkKhaki
- POC = OrangeRed
- VWAP = DodgerBlue, VAH = CornflowerBlue, VAL = RoyalBlue

Goals:
- Instant differentiation between current and previous periods (same family, stronger contrast).
- Avoid low-contrast yellows on light themes and extremes that disappear on dark themes.
- Keep VWAP and VAH/VAL coherent in the blue family and remove Open/POC collision.

---

## Screenshots
### A) Mode by period

<img width="762" height="1003" alt="image" src="https://github.com/user-attachments/assets/34bc90b2-bb10-4f70-ac98-15df31d96df2" />


---

### B) Mode by level

<img width="869" height="1283" alt="image" src="https://github.com/user-attachments/assets/1fd95b3e-ebf4-435b-80c9-3bdfc0635e3f" />

---

### C) Override color

<img width="806" height="637" alt="image" src="https://github.com/user-attachments/assets/6dc874e8-ae04-4ac7-bd1b-89a7f6e4668c" />



