### PR TITLE
OHLCPlus — HVN bands by period with priority, partial occlusion, and color schemes (stacked on top of #102)

### DIFF
--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -1248,17 +1248,23 @@ public class OHLCPlus : Indicator
     {
         if (!levelSettings.Enabled || !_levels.TryGetValue(levelKey, out var level) || !level.IsValid)
             return;
-            
+
+        // --- Calculate actual label width for better positioning ---
+        var (prefix, suffix) = SplitKey(levelKey);
+        var levelText = ResolveLevelText(suffix, levelSettings);
+        var displayLabel = BuildDisplayLabel(prefix, levelText);
+        // ----------------------------------------------------
+
         // Validate price is reasonable
         if (level.Price <= 0)
             return;
 
         var y = ChartInfo.GetYByPrice(level.Price, false);
-        
+
         // Check if price is visible on chart
         if (y < 0 || y > ChartInfo.PriceChartContainer.Region.Height)
             return;
-            
+
         var chartWidth = ChartInfo.PriceChartContainer.Region.Width;
         var currentBarX = ChartInfo.GetXByBar(CurrentBar - 1);
         var barWidth = (int)ChartInfo.PriceChartContainer.BarsWidth;
@@ -1274,10 +1280,6 @@ public class OHLCPlus : Indicator
                 // If label is at bar position, start line after the label to avoid overlap
                 if (levelSettings.LabelPosition == LabelPosition.Bar)
                 {
-                    // Calculate actual label width for better positioning
-                    var (prefix, suffix) = SplitKey(levelKey);
-                    var levelText = ResolveLevelText(suffix, levelSettings);
-                    var displayLabel = BuildDisplayLabel(prefix, levelText);
                     var labelSize = context.MeasureString(displayLabel, _font);
                     var labelStartX = currentBarRightX + 5;
                     var lineStartX = labelStartX + labelSize.Width + 4; // 4px padding

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -1046,7 +1046,7 @@ public class OHLCPlus : Indicator
     [Range(0, 10)]
     public int HVNGapToleranceTicks { get; set; } = 1;
 
-    // Overlap tolerance in ticks: if a price falls within ±N ticks of another already drawn, it is hidden.
+    // Overlap tolerance in ticks: if a price falls within ï¿½N ticks of another already drawn, it is hidden.
     [Display(GroupName = "HVN Settings", Name = "Occlusion tolerance (ticks)", Order = 30)]
     [Range(0, 10)]
     public int HVNOcclusionTicks { get; set; } = 1;
@@ -1102,62 +1102,6 @@ public class OHLCPlus : Indicator
     [Display(GroupName = "Labels", Name = "VAL", Order = 100)]
     public string VALLabel { get; set; } = "VAL";
 
-    #endregion
-
-    #region Color scheme
-    // Strategy selector
-    [Display(GroupName = "Colors", Name = "Mode", Order = 5)]
-    public ColorMode ColorMode { get; set; } = ColorMode.PerLineSettings;
-
-    // --- Palette by PERIOD (used when ColorMode == ByPeriod)
-    [Display(GroupName = "Colors ï¿½ By Period", Name = "Current Day", Order = 10)]
-    public CrossColor PeriodColorCurrentDay { get; set; } = System.Drawing.Color.Orange.Convert();
-
-    [Display(GroupName = "Colors ï¿½ By Period", Name = "Previous Day", Order = 11)]
-    public CrossColor PeriodColorPrevDay { get; set; } = System.Drawing.Color.Gray.Convert();
-
-    [Display(GroupName = "Colors ï¿½ By Period", Name = "Current Week", Order = 12)]
-    public CrossColor PeriodColorCurrentWeek { get; set; } = System.Drawing.Color.SteelBlue.Convert();
-
-    [Display(GroupName = "Colors ï¿½ By Period", Name = "Previous Week", Order = 13)]
-    public CrossColor PeriodColorPrevWeek { get; set; } = System.Drawing.Color.MediumPurple.Convert();
-
-    [Display(GroupName = "Colors ï¿½ By Period", Name = "Current Month", Order = 14)]
-    public CrossColor PeriodColorCurrentMonth { get; set; } = System.Drawing.Color.Teal.Convert();
-
-    [Display(GroupName = "Colors ï¿½ By Period", Name = "Previous Month", Order = 15)]
-    public CrossColor PeriodColorPrevMonth { get; set; } = System.Drawing.Color.DarkSlateGray.Convert();
-
-    [Display(GroupName = "Colors ï¿½ By Period", Name = "Contract", Order = 16)]
-    public CrossColor PeriodColorContract { get; set; } = System.Drawing.Color.DodgerBlue.Convert();
-
-    // --- Palette by LEVEL TYPE (used when ColorMode == ByLevel)
-    [Display(GroupName = "Colors ï¿½ By Level", Name = "Open", Order = 110)]
-    public CrossColor LevelColorOpen { get; set; } = System.Drawing.Color.Orange.Convert();
-
-    [Display(GroupName = "Colors ï¿½ By Level", Name = "High", Order = 120)]
-    public CrossColor LevelColorHigh { get; set; } = System.Drawing.Color.Green.Convert();
-
-    [Display(GroupName = "Colors ï¿½ By Level", Name = "Low", Order = 130)]
-    public CrossColor LevelColorLow { get; set; } = System.Drawing.Color.Red.Convert();
-
-    [Display(GroupName = "Colors ï¿½ By Level", Name = "Close", Order = 140)]
-    public CrossColor LevelColorClose { get; set; } = System.Drawing.Color.Gray.Convert();
-
-    [Display(GroupName = "Colors ï¿½ By Level", Name = "Equilibrium (EQ)", Order = 150)]
-    public CrossColor LevelColorEQ { get; set; } = System.Drawing.Color.Yellow.Convert();
-
-    [Display(GroupName = "Colors ï¿½ By Level", Name = "POC", Order = 160)]
-    public CrossColor LevelColorPOC { get; set; } = System.Drawing.Color.Orange.Convert();
-
-    [Display(GroupName = "Colors ï¿½ By Level", Name = "VWAP", Order = 170)]
-    public CrossColor LevelColorVWAP { get; set; } = System.Drawing.Color.SteelBlue.Convert();
-
-    [Display(GroupName = "Colors ï¿½ By Level", Name = "VAH", Order = 180)]
-    public CrossColor LevelColorVAH { get; set; } = System.Drawing.Color.Purple.Convert();
-
-    [Display(GroupName = "Colors ï¿½ By Level", Name = "VAL", Order = 190)]
-    public CrossColor LevelColorVAL { get; set; } = System.Drawing.Color.Purple.Convert();
     #endregion
 
     #region Color scheme

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -1042,53 +1042,53 @@ public class OHLCPlus : Indicator
     public ColorMode ColorMode { get; set; } = ColorMode.PerLineSettings;
 
     // --- Palette by PERIOD (used when ColorMode == ByPeriod)
-    [Display(GroupName = "Colors — By Period", Name = "Current Day", Order = 10)]
+    [Display(GroupName = "Colors - By Period", Name = "Current Day", Order = 10)]
     public CrossColor PeriodColorCurrentDay { get; set; } = System.Drawing.Color.OrangeRed.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Previous Day", Order = 11)]
+    [Display(GroupName = "Colors - By Period", Name = "Previous Day", Order = 11)]
     public CrossColor PeriodColorPrevDay { get; set; } = System.Drawing.Color.SaddleBrown.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Current Week", Order = 12)]
+    [Display(GroupName = "Colors - By Period", Name = "Current Week", Order = 12)]
     public CrossColor PeriodColorCurrentWeek { get; set; } = System.Drawing.Color.DeepSkyBlue.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Previous Week", Order = 13)]
+    [Display(GroupName = "Colors - By Period", Name = "Previous Week", Order = 13)]
     public CrossColor PeriodColorPrevWeek { get; set; } = System.Drawing.Color.DarkSlateBlue.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Current Month", Order = 14)]
+    [Display(GroupName = "Colors - By Period", Name = "Current Month", Order = 14)]
     public CrossColor PeriodColorCurrentMonth { get; set; } = System.Drawing.Color.MediumSeaGreen.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Previous Month", Order = 15)]
+    [Display(GroupName = "Colors - By Period", Name = "Previous Month", Order = 15)]
     public CrossColor PeriodColorPrevMonth { get; set; } = System.Drawing.Color.DarkOliveGreen.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Contract", Order = 16)]
+    [Display(GroupName = "Colors - By Period", Name = "Contract", Order = 16)]
     public CrossColor PeriodColorContract { get; set; } = System.Drawing.Color.Indigo.Convert();
 
     // --- Palette by LEVEL TYPE (used when ColorMode == ByLevel)
-    [Display(GroupName = "Colors — By Level", Name = "Open", Order = 110)]
+    [Display(GroupName = "Colors - By Level", Name = "Open", Order = 110)]
     public CrossColor LevelColorOpen { get; set; } = System.Drawing.Color.DarkGoldenrod.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "High", Order = 120)]
+    [Display(GroupName = "Colors - By Level", Name = "High", Order = 120)]
     public CrossColor LevelColorHigh { get; set; } = System.Drawing.Color.ForestGreen.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "Low", Order = 130)]
+    [Display(GroupName = "Colors - By Level", Name = "Low", Order = 130)]
     public CrossColor LevelColorLow { get; set; } = System.Drawing.Color.Firebrick.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "Close", Order = 140)]
+    [Display(GroupName = "Colors - By Level", Name = "Close", Order = 140)]
     public CrossColor LevelColorClose { get; set; } = System.Drawing.Color.DimGray.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "Equilibrium (EQ)", Order = 150)]
+    [Display(GroupName = "Colors - By Level", Name = "Equilibrium (EQ)", Order = 150)]
     public CrossColor LevelColorEQ { get; set; } = System.Drawing.Color.DarkKhaki.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "POC", Order = 160)]
+    [Display(GroupName = "Colors - By Level", Name = "POC", Order = 160)]
     public CrossColor LevelColorPOC { get; set; } = System.Drawing.Color.OrangeRed.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "VWAP", Order = 170)]
+    [Display(GroupName = "Colors - By Level", Name = "VWAP", Order = 170)]
     public CrossColor LevelColorVWAP { get; set; } = System.Drawing.Color.DodgerBlue.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "VAH", Order = 180)]
+    [Display(GroupName = "Colors - By Level", Name = "VAH", Order = 180)]
     public CrossColor LevelColorVAH { get; set; } = System.Drawing.Color.CornflowerBlue.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "VAL", Order = 190)]
+    [Display(GroupName = "Colors - By Level", Name = "VAL", Order = 190)]
     public CrossColor LevelColorVAL { get; set; } = System.Drawing.Color.RoyalBlue.Convert();
     #endregion
 
@@ -1680,7 +1680,7 @@ public class OHLCPlus : Indicator
             }
         }
 
-        // Visual-only changes → redraw
+        // Visual-only changes -> redraw
         if (e.PropertyName == nameof(LevelSettings.Color)
             || e.PropertyName == nameof(LevelSettings.OverrideColorInSchemes)
             || e.PropertyName == nameof(LevelSettings.LineStyle)

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -958,21 +958,54 @@ public class OHLCPlus : Indicator
 
     #endregion
 
+    #region Prefix Settings
+    // Display-only prefixes (do not affect storage keys)
+    [Display(GroupName = "Prefixes", Name = "Current Day", Order = 10)]
+    public string PrefixCurrentDay { get; set; } = "d";
+
+    [Display(GroupName = "Prefixes", Name = "Previous Day", Order = 20)]
+    public string PrefixPrevDay { get; set; } = "p";
+
+    [Display(GroupName = "Prefixes", Name = "Current Week", Order = 30)]
+    public string PrefixCurrentWeek { get; set; } = "w";
+
+    [Display(GroupName = "Prefixes", Name = "Previous Week", Order = 40)]
+    public string PrefixPrevWeek { get; set; } = "pw";
+
+    [Display(GroupName = "Prefixes", Name = "Current Month", Order = 50)]
+    public string PrefixCurrentMonth { get; set; } = "m";
+
+    [Display(GroupName = "Prefixes", Name = "Previous Month", Order = 60)]
+    public string PrefixPrevMonth { get; set; } = "pm";
+
+    [Display(GroupName = "Prefixes", Name = "Contract", Order = 70)]
+    public string PrefixContract { get; set; } = "c";
+    #endregion
+
     #region Labels Settings
 
     // Template supports {prefix} and {level}
-    [Display(Name = "Label template")]
+    [Display(GroupName = "Labels", Name = "Label template", Order = 10)]
     public string LabelTemplate { get; set; } = "{prefix}{level}";
 
-    [Display(Name = "Open label")] public string OpenLabel { get; set; } = "Open";
-    [Display(Name = "High label")] public string HighLabel { get; set; } = "High";
-    [Display(Name = "Low label")] public string LowLabel { get; set; } = "Low";
-    [Display(Name = "Close label")] public string CloseLabel { get; set; } = "Close";
-    [Display(Name = "Equilibrium label")] public string EqLabel { get; set; } = "EQ";
-    [Display(Name = "POC label")] public string POCLabel { get; set; } = "POC";
-    [Display(Name = "VWAP label")] public string VWAPLabel { get; set; } = "VWAP";
-    [Display(Name = "VAH label")] public string VAHLabel { get; set; } = "VAH";
-    [Display(Name = "VAL label")] public string VALLabel { get; set; } = "VAL";
+    [Display(GroupName = "Labels", Name = "Open", Order = 20)]
+    public string OpenLabel { get; set; } = "Open";
+    [Display(GroupName = "Labels", Name = "High", Order = 30)]
+    public string HighLabel { get; set; } = "High";
+    [Display(GroupName = "Labels", Name = "Low", Order = 40)]
+    public string LowLabel { get; set; } = "Low";
+    [Display(GroupName = "Labels", Name = "Close", Order = 50)]
+    public string CloseLabel { get; set; } = "Close";
+    [Display(GroupName = "Labels", Name = "Equilibrium", Order = 60)]
+    public string EqLabel { get; set; } = "EQ";
+    [Display(GroupName = "Labels", Name = "POC", Order = 70)]
+    public string POCLabel { get; set; } = "POC";
+    [Display(GroupName = "Labels", Name = "VWAP", Order = 80)]
+    public string VWAPLabel { get; set; } = "VWAP";
+    [Display(GroupName = "Labels", Name = "VAH", Order = 90)]
+    public string VAHLabel { get; set; } = "VAH";
+    [Display(GroupName = "Labels", Name = "VAL", Order = 100)]
+    public string VALLabel { get; set; } = "VAL";
 
     #endregion
 
@@ -1046,13 +1079,13 @@ public class OHLCPlus : Indicator
             return;
 
         // Render all levels in groups for better organization
-        RenderLevelGroup(context, "d", DayOpenLevel, DayHighLevel, DayLowLevel, DayCloseLevel, DayEquilibriumLevel, DayPOCLevel, DayVWAPLevel, DayVAHLevel, DayVALLevel);
-        RenderLevelGroup(context, "p", PrevDayOpenLevel, PrevDayHighLevel, PrevDayLowLevel, PrevDayCloseLevel, PrevDayEquilibriumLevel, PrevDayPOCLevel, PrevDayVWAPLevel, PrevDayVAHLevel, PrevDayVALLevel);
-        RenderLevelGroup(context, "w", WeekOpenLevel, WeekHighLevel, WeekLowLevel, WeekCloseLevel, WeekEquilibriumLevel, WeekPOCLevel, WeekVWAPLevel, WeekVAHLevel, WeekVALLevel);
-        RenderLevelGroup(context, "pw", PrevWeekOpenLevel, PrevWeekHighLevel, PrevWeekLowLevel, PrevWeekCloseLevel, PrevWeekEquilibriumLevel, PrevWeekPOCLevel, PrevWeekVWAPLevel, PrevWeekVAHLevel, PrevWeekVALLevel);
-        RenderLevelGroup(context, "m", MonthOpenLevel, MonthHighLevel, MonthLowLevel, MonthCloseLevel, MonthEquilibriumLevel, MonthPOCLevel, MonthVWAPLevel, MonthVAHLevel, MonthVALLevel);
-        RenderLevelGroup(context, "pm", PrevMonthOpenLevel, PrevMonthHighLevel, PrevMonthLowLevel, PrevMonthCloseLevel, PrevMonthEquilibriumLevel, PrevMonthPOCLevel, PrevMonthVWAPLevel, PrevMonthVAHLevel, PrevMonthVALLevel);
-        RenderLevelGroup(context, "c", ContractOpenLevel, ContractHighLevel, ContractLowLevel, ContractCloseLevel, ContractEquilibriumLevel, ContractPOCLevel, ContractVWAPLevel, ContractVAHLevel, ContractVALLevel);
+        RenderLevelGroup(context, storagePrefix: "d", displayPrefix: PrefixCurrentDay, DayOpenLevel, DayHighLevel, DayLowLevel, DayCloseLevel, DayEquilibriumLevel, DayPOCLevel, DayVWAPLevel, DayVAHLevel, DayVALLevel);
+        RenderLevelGroup(context, storagePrefix: "p", displayPrefix: PrefixPrevDay, PrevDayOpenLevel, PrevDayHighLevel, PrevDayLowLevel, PrevDayCloseLevel, PrevDayEquilibriumLevel, PrevDayPOCLevel, PrevDayVWAPLevel, PrevDayVAHLevel, PrevDayVALLevel);
+        RenderLevelGroup(context, storagePrefix: "w", displayPrefix: PrefixCurrentWeek, WeekOpenLevel, WeekHighLevel, WeekLowLevel, WeekCloseLevel, WeekEquilibriumLevel, WeekPOCLevel, WeekVWAPLevel, WeekVAHLevel, WeekVALLevel);
+        RenderLevelGroup(context, storagePrefix: "pw", displayPrefix: PrefixPrevWeek, PrevWeekOpenLevel, PrevWeekHighLevel, PrevWeekLowLevel, PrevWeekCloseLevel, PrevWeekEquilibriumLevel, PrevWeekPOCLevel, PrevWeekVWAPLevel, PrevWeekVAHLevel, PrevWeekVALLevel);
+        RenderLevelGroup(context, storagePrefix: "m", displayPrefix: PrefixCurrentMonth, MonthOpenLevel, MonthHighLevel, MonthLowLevel, MonthCloseLevel, MonthEquilibriumLevel, MonthPOCLevel, MonthVWAPLevel, MonthVAHLevel, MonthVALLevel);
+        RenderLevelGroup(context, storagePrefix: "pm", displayPrefix: PrefixPrevMonth, PrevMonthOpenLevel, PrevMonthHighLevel, PrevMonthLowLevel, PrevMonthCloseLevel, PrevMonthEquilibriumLevel, PrevMonthPOCLevel, PrevMonthVWAPLevel, PrevMonthVAHLevel, PrevMonthVALLevel);
+        RenderLevelGroup(context, storagePrefix: "c", displayPrefix: PrefixContract, ContractOpenLevel, ContractHighLevel, ContractLowLevel, ContractCloseLevel, ContractEquilibriumLevel, ContractPOCLevel, ContractVWAPLevel, ContractVAHLevel, ContractVALLevel);
     }
 
     #endregion
@@ -1244,6 +1277,20 @@ public class OHLCPlus : Indicator
         _ => FixedProfilePeriods.CurrentDay
     };
 
+    // Maps the canonical storage prefix ("d", "p", "w", "pw", "m", "pm", "c")
+    // to the user-configurable display prefix for visual labels.
+    private string DisplayPrefixFor(string storagePrefix) => storagePrefix switch
+    {
+        "d" => PrefixCurrentDay,
+        "p" => PrefixPrevDay,
+        "w" => PrefixCurrentWeek,
+        "pw" => PrefixPrevWeek,
+        "m" => PrefixCurrentMonth,
+        "pm" => PrefixPrevMonth,
+        "c" => PrefixContract,
+        _ => storagePrefix ?? string.Empty
+    };
+
     private void RenderLevel(RenderContext context, string levelKey, LevelSettings levelSettings)
     {
         if (!levelSettings.Enabled || !_levels.TryGetValue(levelKey, out var level) || !level.IsValid)
@@ -1252,7 +1299,7 @@ public class OHLCPlus : Indicator
         // --- Calculate actual label width for better positioning ---
         var (prefix, suffix) = SplitKey(levelKey);
         var levelText = ResolveLevelText(suffix, levelSettings);
-        var displayLabel = BuildDisplayLabel(prefix, levelText);
+        var displayLabel = BuildDisplayLabel(DisplayPrefixFor(prefix), levelText);
         // ----------------------------------------------------
 
         // Validate price is reasonable

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -126,6 +126,7 @@ public class LevelSettings : NotifiableObject
 
     private string _overrideLabel = string.Empty;
 
+    // If set, this replaces the ENTIRE visual label (ignores template/prefix/suffix)
     [Display(Name = "Override label (optional)")]
     public string OverrideLabel
     {
@@ -1311,10 +1312,20 @@ public class OHLCPlus : Indicator
         if (!levelSettings.Enabled || !_levels.TryGetValue(levelKey, out var level) || !level.IsValid)
             return;
 
-        // --- Calculate actual label width for better positioning ---
+        // --- Calculate actual label ---
+
         var (prefix, suffix) = SplitKey(levelKey);
-        var levelText = ResolveLevelText(suffix, levelSettings);
-        var displayLabel = BuildDisplayLabel(DisplayPrefixFor(prefix), levelText);
+        // If an override label is provided for this LevelSettings, use it as-is
+        string displayLabel;
+        if (!string.IsNullOrWhiteSpace(levelSettings.OverrideLabel))
+        {
+            displayLabel = levelSettings.OverrideLabel;
+        }
+        else
+        {
+            var levelText = ResolveLevelText(suffix);
+            displayLabel = BuildDisplayLabel(DisplayPrefixFor(prefix), levelText);
+        }
         // ----------------------------------------------------
 
         // Validate price is reasonable
@@ -1343,9 +1354,6 @@ public class OHLCPlus : Indicator
                 if (levelSettings.LabelPosition == LabelPosition.Bar)
                 {
                     // Calculate actual label width for better positioning
-                    var (prefix, suffix) = SplitKey(levelKey);
-                    var levelText = ResolveLevelText(suffix, levelSettings);
-                    var displayLabel = BuildDisplayLabel(prefix, levelText);
                     var labelSize = context.MeasureString(displayLabel, _font);
                     var labelStartX = currentBarRightX + 5;
                     var lineStartX = labelStartX + labelSize.Width + 4; // 4px padding
@@ -1567,11 +1575,8 @@ public class OHLCPlus : Indicator
         return ("", key);
     }
 
-    private string ResolveLevelText(string suffix, LevelSettings ls)
+    private string ResolveLevelText(string suffix)
     {
-        if (!string.IsNullOrWhiteSpace(ls?.OverrideLabel))
-            return ls.OverrideLabel;
-
         return suffix switch
         {
             "Open" => OpenLabel,

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -1374,20 +1374,18 @@ public class OHLCPlus : Indicator
     }
 
 
-// Resolve the color respecting the precedence (per-line override > scheme > per-line default)
-    private CrossColor ResolveColor(FixedProfilePeriods period, string suffix, LevelSettings ls)
+    // Resolve the color respecting the precedence (per-line override > scheme > per-line default)
+    private CrossColor ResolveColor(string storagePrefix, string suffix, LevelSettings ls)
     {
-        if (ls != null && ls.UsePerLineColor)
-            return ls.Color; // per-line override wins
-
-        switch (ColorMode) // TODO: enum you introduce for the color feature
+        switch (ColorMode)
         {
             case ColorMode.ByPeriod:
-                return ResolvePeriodPalette(period);
+                return ResolvePeriodPalette(storagePrefix);
             case ColorMode.ByLevel:
                 return ResolveLevelPalette(suffix);
+            case ColorMode.PerLineSettings:
             default:
-                return ls?.Color ?? CrossColors.White;
+                return ls?.Color ?? CrossColors.White; // color propio de la línea (comportamiento por defecto)
         }
     }
 
@@ -1396,33 +1394,31 @@ public class OHLCPlus : Indicator
         => new PenSettings { Color = color, Width = ls.Width, LineDashStyle = ls.LineStyle }.RenderObject;
 
     // Palette resolvers
-    private CrossColor ResolvePeriodPalette(FixedProfilePeriods period)
-        => period switch
-        {
-            FixedProfilePeriods.CurrentDay   => PeriodColorCurrentDay,
-            FixedProfilePeriods.LastDay      => PeriodColorPrevDay,
-            FixedProfilePeriods.CurrentWeek  => PeriodColorCurrentWeek,
-            FixedProfilePeriods.LastWeek     => PeriodColorPrevWeek,
-            FixedProfilePeriods.CurrentMonth => PeriodColorCurrentMonth,
-            FixedProfilePeriods.LastMonth    => PeriodColorPrevMonth,
-            FixedProfilePeriods.Contract     => PeriodColorContract,
-            _                                => CrossColors.White
-        };
+    private CrossColor ResolvePeriodPalette(string storagePrefix) => storagePrefix switch
+    {
+        "d" => PeriodColorCurrentDay,
+        "p" => PeriodColorPrevDay,
+        "w" => PeriodColorCurrentWeek,
+        "pw" => PeriodColorPrevWeek,
+        "m" => PeriodColorCurrentMonth,
+        "pm" => PeriodColorPrevMonth,
+        "c" => PeriodColorContract,
+        _ => CrossColors.White
+    };
 
-    private CrossColor ResolveLevelPalette(string suffix)
-        => suffix switch
-        {
-            "Open"  => LevelColorOpen,
-            "High"  => LevelColorHigh,
-            "Low"   => LevelColorLow,
-            "Close" => LevelColorClose,
-            "EQ"    => LevelColorEQ,
-            "POC"   => LevelColorPOC,
-            "VWAP"  => LevelColorVWAP,
-            "VAH"   => LevelColorVAH,
-            "VAL"   => LevelColorVAL,
-            _       => CrossColors.White
-        };
+    private CrossColor ResolveLevelPalette(string suffix) => suffix switch
+    {
+        "Open" => LevelColorOpen,
+        "High" => LevelColorHigh,
+        "Low" => LevelColorLow,
+        "Close" => LevelColorClose,
+        "EQ" => LevelColorEQ,
+        "POC" => LevelColorPOC,
+        "VWAP" => LevelColorVWAP,
+        "VAH" => LevelColorVAH,
+        "VAL" => LevelColorVAL,
+        _ => CrossColors.White
+    };
 
     private void RenderLevel(RenderContext context, string levelKey, LevelSettings levelSettings)
     {

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -233,6 +233,10 @@ public class OHLCPlus : Indicator
     private bool _needPrevMonth;
     private bool _needContract;
 
+    // Scoped display-prefix override for the current group render
+    private string? _scopedStoragePrefix = null;
+    private string? _scopedDisplayPrefix = null;
+
     #endregion
 
     #region Properties
@@ -1279,17 +1283,28 @@ public class OHLCPlus : Indicator
 
     // Maps the canonical storage prefix ("d", "p", "w", "pw", "m", "pm", "c")
     // to the user-configurable display prefix for visual labels.
-    private string DisplayPrefixFor(string storagePrefix) => storagePrefix switch
+    // NEW: respects a scoped override set by RenderLevelGroup.
+    private string DisplayPrefixFor(string storagePrefix)
     {
-        "d" => PrefixCurrentDay,
-        "p" => PrefixPrevDay,
-        "w" => PrefixCurrentWeek,
-        "pw" => PrefixPrevWeek,
-        "m" => PrefixCurrentMonth,
-        "pm" => PrefixPrevMonth,
-        "c" => PrefixContract,
-        _ => storagePrefix ?? string.Empty
-    };
+        // Scoped override: only applies while a group with this storagePrefix is rendering
+        if (!string.IsNullOrEmpty(_scopedStoragePrefix) &&
+            string.Equals(storagePrefix, _scopedStoragePrefix, StringComparison.Ordinal) &&
+            !string.IsNullOrEmpty(_scopedDisplayPrefix))
+            return _scopedDisplayPrefix!;
+
+        return storagePrefix switch
+        {
+            "d" => PrefixCurrentDay,
+            "p" => PrefixPrevDay,
+            "w" => PrefixCurrentWeek,
+            "pw" => PrefixPrevWeek,
+            "m" => PrefixCurrentMonth,
+            "pm" => PrefixPrevMonth,
+            "c" => PrefixContract,
+            _ => storagePrefix ?? string.Empty
+        };
+    }
+
 
     private void RenderLevel(RenderContext context, string levelKey, LevelSettings levelSettings)
     {
@@ -1427,22 +1442,38 @@ public class OHLCPlus : Indicator
         context.DrawString(text, _font, textColor, textRect, format);
     }
 
-    private void RenderLevelGroup(RenderContext context, string prefix,
-      LevelSettings openLevel, LevelSettings highLevel, LevelSettings lowLevel, LevelSettings closeLevel,
-      LevelSettings eqLevel, LevelSettings pocLevel, LevelSettings vwapLevel, LevelSettings vahLevel, LevelSettings valLevel)
+    private void RenderLevelGroup(RenderContext context, string storagePrefix, string displayPrefix, // NEW: user-configurable display prefix (UI)
+    LevelSettings openLevel, LevelSettings highLevel, LevelSettings lowLevel, LevelSettings closeLevel,
+    LevelSettings eqLevel, LevelSettings pocLevel, LevelSettings vwapLevel, LevelSettings vahLevel, LevelSettings valLevel)
     {
-        var keys = _keys[PeriodFromPrefix(prefix)];
-        // 0 Open, 1 High, 2 Low, 3 Close, 4 EQ, 5 POC, 6 VWAP, 7 VAH, 8 VAL
+        // Activate scoped override for this group render
+        _scopedStoragePrefix = storagePrefix;
+        _scopedDisplayPrefix = displayPrefix;
 
-        RenderLevel(context, keys[0], openLevel);
-        RenderLevel(context, keys[1], highLevel);
-        RenderLevel(context, keys[2], lowLevel);
-        RenderLevel(context, keys[3], closeLevel);
-        RenderLevel(context, keys[4], eqLevel);
-        RenderLevel(context, keys[5], pocLevel);
-        RenderLevel(context, keys[6], vwapLevel);
-        RenderLevel(context, keys[7], vahLevel);
-        RenderLevel(context, keys[8], valLevel);
+        try
+        {
+            var levels = new[]
+            {
+            ("Open", openLevel),
+            ("High", highLevel),
+            ("Low", lowLevel),
+            ("Close", closeLevel),
+            ("EQ", eqLevel),
+            ("POC", pocLevel),
+            ("VWAP", vwapLevel),
+            ("VAH", vahLevel),
+            ("VAL", valLevel)
+        };
+
+            foreach (var (suffix, levelSettings) in levels)
+                RenderLevel(context, $"{storagePrefix}{suffix}", levelSettings);
+        }
+        finally
+        {
+            // Always clear the override after finishing this group
+            _scopedStoragePrefix = null;
+            _scopedDisplayPrefix = null;
+        }
     }
 
     #endregion

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -261,6 +261,20 @@ public class OHLCPlus : Indicator
     private string? _scopedStoragePrefix = null;
     private string? _scopedDisplayPrefix = null;
 
+    // HVN prices by period
+    private readonly Dictionary<FixedProfilePeriods, List<HVNBand>> _hvnBands = new();
+
+    private static readonly FixedProfilePeriods[] _hvnPriorityOrder = new[]
+    {
+    FixedProfilePeriods.Contract,
+    FixedProfilePeriods.LastMonth,
+    FixedProfilePeriods.CurrentMonth,
+    FixedProfilePeriods.LastWeek,
+    FixedProfilePeriods.CurrentWeek,
+    FixedProfilePeriods.LastDay,
+    FixedProfilePeriods.CurrentDay
+    };
+
     #endregion
 
     #region Properties

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -1032,53 +1032,53 @@ public class OHLCPlus : Indicator
 
     // --- Palette by PERIOD (used when ColorMode == ByPeriod)
     [Display(GroupName = "Colors — By Period", Name = "Current Day", Order = 10)]
-    public CrossColor PeriodColorCurrentDay { get; set; } = System.Drawing.Color.Orange.Convert();
+    public CrossColor PeriodColorCurrentDay { get; set; } = System.Drawing.Color.OrangeRed.Convert();
 
     [Display(GroupName = "Colors — By Period", Name = "Previous Day", Order = 11)]
-    public CrossColor PeriodColorPrevDay { get; set; } = System.Drawing.Color.Gray.Convert();
+    public CrossColor PeriodColorPrevDay { get; set; } = System.Drawing.Color.SaddleBrown.Convert();
 
     [Display(GroupName = "Colors — By Period", Name = "Current Week", Order = 12)]
-    public CrossColor PeriodColorCurrentWeek { get; set; } = System.Drawing.Color.SteelBlue.Convert();
+    public CrossColor PeriodColorCurrentWeek { get; set; } = System.Drawing.Color.DeepSkyBlue.Convert();
 
     [Display(GroupName = "Colors — By Period", Name = "Previous Week", Order = 13)]
-    public CrossColor PeriodColorPrevWeek { get; set; } = System.Drawing.Color.MediumPurple.Convert();
+    public CrossColor PeriodColorPrevWeek { get; set; } = System.Drawing.Color.DarkSlateBlue.Convert();
 
     [Display(GroupName = "Colors — By Period", Name = "Current Month", Order = 14)]
-    public CrossColor PeriodColorCurrentMonth { get; set; } = System.Drawing.Color.Teal.Convert();
+    public CrossColor PeriodColorCurrentMonth { get; set; } = System.Drawing.Color.MediumSeaGreen.Convert();
 
     [Display(GroupName = "Colors — By Period", Name = "Previous Month", Order = 15)]
-    public CrossColor PeriodColorPrevMonth { get; set; } = System.Drawing.Color.DarkSlateGray.Convert();
+    public CrossColor PeriodColorPrevMonth { get; set; } = System.Drawing.Color.DarkOliveGreen.Convert();
 
     [Display(GroupName = "Colors — By Period", Name = "Contract", Order = 16)]
-    public CrossColor PeriodColorContract { get; set; } = System.Drawing.Color.DodgerBlue.Convert();
+    public CrossColor PeriodColorContract { get; set; } = System.Drawing.Color.Indigo.Convert();
 
     // --- Palette by LEVEL TYPE (used when ColorMode == ByLevel)
     [Display(GroupName = "Colors — By Level", Name = "Open", Order = 110)]
-    public CrossColor LevelColorOpen { get; set; } = System.Drawing.Color.Orange.Convert();
+    public CrossColor LevelColorOpen { get; set; } = System.Drawing.Color.DarkGoldenrod.Convert();
 
     [Display(GroupName = "Colors — By Level", Name = "High", Order = 120)]
-    public CrossColor LevelColorHigh { get; set; } = System.Drawing.Color.Green.Convert();
+    public CrossColor LevelColorHigh { get; set; } = System.Drawing.Color.ForestGreen.Convert();
 
     [Display(GroupName = "Colors — By Level", Name = "Low", Order = 130)]
-    public CrossColor LevelColorLow { get; set; } = System.Drawing.Color.Red.Convert();
+    public CrossColor LevelColorLow { get; set; } = System.Drawing.Color.Firebrick.Convert();
 
     [Display(GroupName = "Colors — By Level", Name = "Close", Order = 140)]
-    public CrossColor LevelColorClose { get; set; } = System.Drawing.Color.Gray.Convert();
+    public CrossColor LevelColorClose { get; set; } = System.Drawing.Color.DimGray.Convert();
 
     [Display(GroupName = "Colors — By Level", Name = "Equilibrium (EQ)", Order = 150)]
-    public CrossColor LevelColorEQ { get; set; } = System.Drawing.Color.Yellow.Convert();
+    public CrossColor LevelColorEQ { get; set; } = System.Drawing.Color.DarkKhaki.Convert();
 
     [Display(GroupName = "Colors — By Level", Name = "POC", Order = 160)]
-    public CrossColor LevelColorPOC { get; set; } = System.Drawing.Color.Orange.Convert();
+    public CrossColor LevelColorPOC { get; set; } = System.Drawing.Color.OrangeRed.Convert();
 
     [Display(GroupName = "Colors — By Level", Name = "VWAP", Order = 170)]
-    public CrossColor LevelColorVWAP { get; set; } = System.Drawing.Color.SteelBlue.Convert();
+    public CrossColor LevelColorVWAP { get; set; } = System.Drawing.Color.DodgerBlue.Convert();
 
     [Display(GroupName = "Colors — By Level", Name = "VAH", Order = 180)]
-    public CrossColor LevelColorVAH { get; set; } = System.Drawing.Color.Purple.Convert();
+    public CrossColor LevelColorVAH { get; set; } = System.Drawing.Color.CornflowerBlue.Convert();
 
     [Display(GroupName = "Colors — By Level", Name = "VAL", Order = 190)]
-    public CrossColor LevelColorVAL { get; set; } = System.Drawing.Color.Purple.Convert();
+    public CrossColor LevelColorVAL { get; set; } = System.Drawing.Color.RoyalBlue.Convert();
     #endregion
 
     #endregion

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -11,6 +11,7 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Drawing;
 using System.Runtime.CompilerServices;
+using System.Linq;
 
 public enum LabelPosition
 {
@@ -365,6 +366,12 @@ public class OHLCPlus : Indicator
         lineType: LineType.Bar
     );
 
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentDay), Name = "Enable HVN", Order = 90)]
+    public bool DayHVNEnabled { get; set; } = false;
+
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentDay), Name = "HVN Color", Order = 95)]
+    public CrossColor DayHVNColor { get; set; } = System.Drawing.Color.FromArgb(140, 30, 144, 255).Convert(); // semi-transparent blue/violet
+
     #endregion
 
     #region Prev.Day Settings
@@ -467,6 +474,12 @@ public class OHLCPlus : Indicator
         labelPosition: LabelPosition.Bar,
         lineType: LineType.Bar
     );
+
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousDay), Name = "Enable HVN", Order = 90)]
+    public bool PrevDayHVNEnabled { get; set; } = false;
+
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousDay), Name = "HVN Color", Order = 95)]
+    public CrossColor PrevDayHVNColor { get; set; } = System.Drawing.Color.FromArgb(140, 255, 140, 0).Convert(); // semi-transparent amber.
 
     #endregion
 
@@ -571,6 +584,11 @@ public class OHLCPlus : Indicator
         lineType: LineType.Bar
     );
 
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentWeek), Name = "Enable HVN", Order = 90)]
+    public bool WeekHVNEnabled { get; set; } = false;
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentWeek), Name = "HVN Color", Order = 95)]
+    public CrossColor WeekHVNColor { get; set; } = System.Drawing.Color.FromArgb(140, 70, 130, 180).Convert(); // steel-ish
+
     #endregion
 
     #region Prev.Week Settings
@@ -673,6 +691,11 @@ public class OHLCPlus : Indicator
         labelPosition: LabelPosition.Bar,
         lineType: LineType.Bar
     );
+
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousWeek), Name = "Enable HVN", Order = 90)]
+    public bool PrevWeekHVNEnabled { get; set; } = false;
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousWeek), Name = "HVN Color", Order = 95)]
+    public CrossColor PrevWeekHVNColor { get; set; } = System.Drawing.Color.FromArgb(140, 186, 85, 211).Convert(); // mediumPurple
 
     #endregion
 
@@ -777,6 +800,11 @@ public class OHLCPlus : Indicator
         lineType: LineType.Bar
     );
 
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentMonth), Name = "Enable HVN", Order = 90)]
+    public bool MonthHVNEnabled { get; set; } = false;
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentMonth), Name = "HVN Color", Order = 95)]
+    public CrossColor MonthHVNColor { get; set; } = System.Drawing.Color.FromArgb(140, 0, 128, 128).Convert(); // teal
+
     #endregion
 
     #region Prev.Month Settings
@@ -880,6 +908,11 @@ public class OHLCPlus : Indicator
         lineType: LineType.Bar
     );
 
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousMonth), Name = "Enable HVN", Order = 90)]
+    public bool PrevMonthHVNEnabled { get; set; } = false;
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousMonth), Name = "HVN Color", Order = 95)]
+    public CrossColor PrevMonthHVNColor { get; set; } = System.Drawing.Color.FromArgb(140, 47, 79, 79).Convert(); // darkslategray
+
     #endregion
 
     #region Contract Settings
@@ -982,6 +1015,27 @@ public class OHLCPlus : Indicator
         labelPosition: LabelPosition.Bar,
         lineType: LineType.Bar
     );
+
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Contract), Name = "Enable HVN", Order = 90)]
+    public bool ContractHVNEnabled { get; set; } = false;
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Contract), Name = "HVN Color", Order = 95)]
+    public CrossColor ContractHVNColor { get; set; } = System.Drawing.Color.FromArgb(140, 30, 144, 255).Convert(); // dodgerblue
+
+    #endregion
+
+    #region HVN Settings
+    [Display(GroupName = "HVN Settings", Name = "Threshold (% of POC volume)", Order = 10)]
+    [Range(1, 99)]
+    public int HVNThresholdPct { get; set; } = 80;
+
+    [Display(GroupName = "HVN Settings", Name = "Gap tolerance (ticks)", Order = 20)]
+    [Range(0, 10)]
+    public int HVNGapToleranceTicks { get; set; } = 1;
+
+    // Overlap tolerance in ticks: if a price falls within ±N ticks of another already drawn, it is hidden.
+    [Display(GroupName = "HVN Settings", Name = "Occlusion tolerance (ticks)", Order = 30)]
+    [Range(0, 10)]
+    public int HVNOcclusionTicks { get; set; } = 1;
 
     #endregion
 
@@ -1209,6 +1263,7 @@ public class OHLCPlus : Indicator
     {
         _profileCandles[period] = fixedProfileOriginScale;
         UpdateLevels(period, fixedProfileOriginScale);
+        UpdateHVNs(period, fixedProfileOriginScale);
         RedrawChart();
     }
 
@@ -1225,6 +1280,9 @@ public class OHLCPlus : Indicator
         RenderLevelGroup(context, storagePrefix: "m", displayPrefix: PrefixCurrentMonth, MonthOpenLevel, MonthHighLevel, MonthLowLevel, MonthCloseLevel, MonthEquilibriumLevel, MonthPOCLevel, MonthVWAPLevel, MonthVAHLevel, MonthVALLevel);
         RenderLevelGroup(context, storagePrefix: "pm", displayPrefix: PrefixPrevMonth, PrevMonthOpenLevel, PrevMonthHighLevel, PrevMonthLowLevel, PrevMonthCloseLevel, PrevMonthEquilibriumLevel, PrevMonthPOCLevel, PrevMonthVWAPLevel, PrevMonthVAHLevel, PrevMonthVALLevel);
         RenderLevelGroup(context, storagePrefix: "c", displayPrefix: PrefixContract, ContractOpenLevel, ContractHighLevel, ContractLowLevel, ContractCloseLevel, ContractEquilibriumLevel, ContractPOCLevel, ContractVWAPLevel, ContractVAHLevel, ContractVALLevel);
+
+        // HVN rects
+        RenderAllHVNsWithPriority(context);
     }
 
     #endregion
@@ -1316,43 +1374,43 @@ public class OHLCPlus : Indicator
     private bool NeedsDayData()
     {
         return DayOpenLevel.Enabled || DayHighLevel.Enabled || DayLowLevel.Enabled || DayCloseLevel.Enabled ||
-               DayEquilibriumLevel.Enabled || DayPOCLevel.Enabled || DayVWAPLevel.Enabled || DayVAHLevel.Enabled || DayVALLevel.Enabled;
+               DayEquilibriumLevel.Enabled || DayPOCLevel.Enabled || DayVWAPLevel.Enabled || DayVAHLevel.Enabled || DayVALLevel.Enabled || DayHVNEnabled;
     }
 
     private bool NeedsPrevDayData()
     {
         return PrevDayOpenLevel.Enabled || PrevDayHighLevel.Enabled || PrevDayLowLevel.Enabled || PrevDayCloseLevel.Enabled ||
-               PrevDayEquilibriumLevel.Enabled || PrevDayPOCLevel.Enabled || PrevDayVWAPLevel.Enabled || PrevDayVAHLevel.Enabled || PrevDayVALLevel.Enabled;
+               PrevDayEquilibriumLevel.Enabled || PrevDayPOCLevel.Enabled || PrevDayVWAPLevel.Enabled || PrevDayVAHLevel.Enabled || PrevDayVALLevel.Enabled || PrevDayHVNEnabled;
     }
 
     private bool NeedsWeekData()
     {
         return WeekOpenLevel.Enabled || WeekHighLevel.Enabled || WeekLowLevel.Enabled || WeekCloseLevel.Enabled ||
-               WeekEquilibriumLevel.Enabled || WeekPOCLevel.Enabled || WeekVWAPLevel.Enabled || WeekVAHLevel.Enabled || WeekVALLevel.Enabled;
+               WeekEquilibriumLevel.Enabled || WeekPOCLevel.Enabled || WeekVWAPLevel.Enabled || WeekVAHLevel.Enabled || WeekVALLevel.Enabled || WeekHVNEnabled;
     }
 
     private bool NeedsPrevWeekData()
     {
         return PrevWeekOpenLevel.Enabled || PrevWeekHighLevel.Enabled || PrevWeekLowLevel.Enabled || PrevWeekCloseLevel.Enabled ||
-               PrevWeekEquilibriumLevel.Enabled || PrevWeekPOCLevel.Enabled || PrevWeekVWAPLevel.Enabled || PrevWeekVAHLevel.Enabled || PrevWeekVALLevel.Enabled;
+               PrevWeekEquilibriumLevel.Enabled || PrevWeekPOCLevel.Enabled || PrevWeekVWAPLevel.Enabled || PrevWeekVAHLevel.Enabled || PrevWeekVALLevel.Enabled || PrevWeekHVNEnabled;
     }
 
     private bool NeedsMonthData()
     {
         return MonthOpenLevel.Enabled || MonthHighLevel.Enabled || MonthLowLevel.Enabled || MonthCloseLevel.Enabled ||
-               MonthEquilibriumLevel.Enabled || MonthPOCLevel.Enabled || MonthVWAPLevel.Enabled || MonthVAHLevel.Enabled || MonthVALLevel.Enabled;
+               MonthEquilibriumLevel.Enabled || MonthPOCLevel.Enabled || MonthVWAPLevel.Enabled || MonthVAHLevel.Enabled || MonthVALLevel.Enabled || MonthHVNEnabled;
     }
 
     private bool NeedsPrevMonthData()
     {
         return PrevMonthOpenLevel.Enabled || PrevMonthHighLevel.Enabled || PrevMonthLowLevel.Enabled || PrevMonthCloseLevel.Enabled ||
-               PrevMonthEquilibriumLevel.Enabled || PrevMonthPOCLevel.Enabled || PrevMonthVWAPLevel.Enabled || PrevMonthVAHLevel.Enabled || PrevMonthVALLevel.Enabled;
+               PrevMonthEquilibriumLevel.Enabled || PrevMonthPOCLevel.Enabled || PrevMonthVWAPLevel.Enabled || PrevMonthVAHLevel.Enabled || PrevMonthVALLevel.Enabled || PrevMonthHVNEnabled;
     }
 
     private bool NeedsContractData()
     {
         return ContractOpenLevel.Enabled || ContractHighLevel.Enabled || ContractLowLevel.Enabled || ContractCloseLevel.Enabled ||
-               ContractEquilibriumLevel.Enabled || ContractPOCLevel.Enabled || ContractVWAPLevel.Enabled || ContractVAHLevel.Enabled || ContractVALLevel.Enabled;
+               ContractEquilibriumLevel.Enabled || ContractPOCLevel.Enabled || ContractVWAPLevel.Enabled || ContractVAHLevel.Enabled || ContractVALLevel.Enabled || ContractHVNEnabled;
     }
 
     private void UpdateLevels(FixedProfilePeriods period, IndicatorCandle candle)
@@ -1797,7 +1855,244 @@ public class OHLCPlus : Indicator
                        .Replace("{level}", levelText ?? string.Empty);
     }
 
+    private void UpdateHVNs(FixedProfilePeriods period, IndicatorCandle candle)
+    {
+        if (candle == null)
+            return;
+
+        if (!_hvnBands.TryGetValue(period, out var bands))
+        {
+            bands = new List<HVNBand>();
+            _hvnBands[period] = bands;
+        }
+        else
+        {
+            bands.Clear();
+        }
+
+        var poc = candle.MaxVolumePriceInfo;
+        if (poc == null || poc.Volume <= 0)
+            return;
+
+        var cutoff = poc.Volume * (HVNThresholdPct / 100m);
+
+        // Materialize and sort by ascending price
+        var levelsEnum = candle.GetAllPriceLevels();
+        if (levelsEnum == null)
+            return;
+
+        var levels = levelsEnum.OrderBy(l => l.Price).ToList();
+        if (levels.Count == 0)
+            return;
+
+        var tick = InstrumentInfo.TickSize;
+        if (tick <= 0m)
+            return;
+
+        // Current run state (a "band" of contiguous HVN ticks allowing small gaps)
+        decimal? runStart = null;   // current band start (price)
+        decimal lastPriceInRun = 0; // last visited price
+        int gapLeft = 0;            // remaining tolerated gaps inside a band
+
+        bool IsNextTick(decimal prev, decimal next)
+            => Math.Abs(next - prev) <= tick * 1.0000001m; // tiny tolerance
+
+        for (int i = 0; i < levels.Count; i++)
+        {
+            var p = levels[i].Price;
+            var v = levels[i].Volume; // Si Volume no es decimal, castea a decimal
+
+            bool isHigh = v >= cutoff;
+
+            if (runStart == null)
+            {
+                // No open band: only start when level is above cutoff
+                if (isHigh)
+                {
+                    runStart = p;
+                    lastPriceInRun = p;
+                    gapLeft = HVNGapToleranceTicks;
+                }
+                continue;
+            }
+
+            // There is an open band: check contiguity by tick
+            bool contiguous = IsNextTick(lastPriceInRun, p);
+
+            if (!contiguous)
+            {
+                // We jumped several ticks -> close previous band
+                bands.Add(new HVNBand { Low = runStart.Value, High = lastPriceInRun });
+                runStart = null;
+
+                
+                if (isHigh)
+                {
+                    runStart = p;
+                    lastPriceInRun = p;
+                    gapLeft = HVNGapToleranceTicks; 
+                }
+                continue;
+            }
+
+            // Contiguous by tick
+            if (isHigh)
+            {
+                lastPriceInRun = p;
+                gapLeft = HVNGapToleranceTicks; // reset tolerance when back to "high" zone
+            }
+            else
+            {
+                if (gapLeft > 0)
+                {
+                    gapLeft--;
+                    lastPriceInRun = p; // keep band continuity
+                }
+                else
+                {
+                    // Tolerance exhausted: close band at last "high" tick
+                    var end = lastPriceInRun;
+
+                    // If previous tick was low, step back one tick
+                    if (i > 0 && levels[i - 1].Volume < cutoff)
+                        end -= tick;
+
+                    if (end >= runStart.Value)
+                        bands.Add(new HVNBand { Low = runStart.Value, High = end });
+
+                    runStart = null;
+
+                    // Start a new band with this point if it's high
+                    if (isHigh)
+                    {
+                        runStart = p;
+                        lastPriceInRun = p;
+                        gapLeft = HVNGapToleranceTicks;
+                    }
+                }
+            }
+        }
+
+        // Close trailing band if any
+        if (runStart != null && lastPriceInRun >= runStart.Value)
+            bands.Add(new HVNBand { Low = runStart.Value, High = lastPriceInRun });
+
+        // Optional: filter very small bands
+        // bands.RemoveAll(b => (b.High - b.Low) < tick);
+    }
+
+    private sealed class HVNBand
+    {
+        public decimal Low { get; init; }  
+        public decimal High { get; init; }
+    }
+
+    private void RenderAllHVNsWithPriority(RenderContext ctx)
+    {
+        var tick = InstrumentInfo?.TickSize ?? 0m;
+        if (tick <= 0) return;
+
+        // ranges already claimed by higher-priority periods (stored already expanded)
+        var claimed = new List<(decimal Lo, decimal Hi)>();
+
+        foreach (var period in _hvnPriorityOrder)
+        {
+            var (enabled, color) = period switch
+            {
+                FixedProfilePeriods.CurrentDay => (DayHVNEnabled, DayHVNColor),
+                FixedProfilePeriods.LastDay => (PrevDayHVNEnabled, PrevDayHVNColor),
+                FixedProfilePeriods.CurrentWeek => (WeekHVNEnabled, WeekHVNColor),
+                FixedProfilePeriods.LastWeek => (PrevWeekHVNEnabled, PrevWeekHVNColor),
+                FixedProfilePeriods.CurrentMonth => (MonthHVNEnabled, MonthHVNColor),
+                FixedProfilePeriods.LastMonth => (PrevMonthHVNEnabled, PrevMonthHVNColor),
+                FixedProfilePeriods.Contract => (ContractHVNEnabled, ContractHVNColor),
+                _ => (false, CrossColors.Transparent)
+            };
+
+            if (!enabled) continue;
+            if (!_hvnBands.TryGetValue(period, out var bands) || bands.Count == 0) continue;
+
+            foreach (var band in bands)
+            {
+                // compute the remaining (non-occluded) parts of this band
+                var leftovers = SubtractClaimed(band, claimed, tick);
+                foreach (var piece in leftovers)
+                {
+                    RenderBand(ctx, piece, color);
+                    // claim with occlusion tolerance
+                    claimed.Add((
+                        piece.Low - HVNOcclusionTicks * tick,
+                        piece.High + HVNOcclusionTicks * tick
+                    ));
+                }
+            }
+        }
+    }
+
+    private void RenderBand(RenderContext ctx, HVNBand band, CrossColor crossColor)
+    {
+        if (band.Low <= 0 || band.High <= 0) return;
+
+        var yHigh = ChartInfo.GetYByPrice(band.High, false);
+        var yLow = ChartInfo.GetYByPrice(band.Low, false);
+
+        var top = Math.Min(yHigh, yLow);
+        var bottom = Math.Max(yHigh, yLow);
+
+        // Only if visible
+        if (bottom < 0 || top > ChartInfo.PriceChartContainer.Region.Height)
+            return;
+
+        var w = ChartInfo.PriceChartContainer.Region.Width;
+        var drawTop = Math.Max(0, top);
+        var drawBot = Math.Min(ChartInfo.PriceChartContainer.Region.Height, bottom);
+        var drawH = Math.Max(1, drawBot - drawTop + 1);
+
+        var rect = new System.Drawing.Rectangle(0, drawTop, w, drawH);
+        ctx.FillRectangle(crossColor.Convert(), rect);
+    }
+
+    // Split a band by subtracting previously-claimed ranges (already expanded by occlusion tolerance).
+    // Returns the list of remaining sub-bands aligned to the tick grid.
+    private List<HVNBand> SubtractClaimed(HVNBand band, List<(decimal Lo, decimal Hi)> claimed, decimal tick)
+    {
+        // work list as simple (Lo, Hi) intervals
+        var segments = new List<(decimal Lo, decimal Hi)> { (band.Low, band.High) };
+
+        foreach (var r in claimed)
+        {
+            var next = new List<(decimal Lo, decimal Hi)>();
+
+            foreach (var s in segments)
+            {
+                // no overlap
+                if (r.Hi < s.Lo || r.Lo > s.Hi)
+                {
+                    next.Add(s);
+                    continue;
+                }
+
     #endregion
+                // overlap -> split into left/right remainders (if any), keeping tick alignment
+                if (r.Lo > s.Lo)
+                    next.Add((s.Lo, Math.Min(s.Hi, r.Lo - tick)));
+
+                if (r.Hi < s.Hi)
+                    next.Add((Math.Max(s.Lo, r.Hi + tick), s.Hi));
+            }
+
+            segments = next;
+            if (segments.Count == 0)
+                break;
+        }
+
+        return segments
+            .Where(seg => seg.Hi >= seg.Lo)
+            .Select(seg => new HVNBand { Low = seg.Lo, High = seg.Hi })
+            .ToList();
+    }
+
+
 
     #endregion
 }

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -1,4 +1,4 @@
-namespace ATAS.Indicators.Technical;
+ï»¿namespace ATAS.Indicators.Technical;
 
 using OFT.Localization;
 using OFT.Rendering.Context;
@@ -145,6 +145,16 @@ public class LevelSettings : NotifiableObject
         set => SetField(ref _overrideLabel, value);
     }
 
+    private bool _overrideColorInSchemes;
+
+    [Display(GroupName = "Colors", Name = "Override color in scheme modes")]
+    [Description("If enabled, this line will use its own Color even when ColorMode is ByPeriod or ByLevel.")]
+    public bool OverrideColorInSchemes
+    {
+        get => _overrideColorInSchemes;
+        set => SetField(ref _overrideColorInSchemes, value);
+    }
+
     [Browsable(false)]
     public RenderPen RenderPen => new PenSettings { Color = Color, Width = Width, LineDashStyle = LineStyle }.RenderObject;
 
@@ -170,6 +180,7 @@ public class LevelSettings : NotifiableObject
         ShowPrice = showPrice;
         LabelPosition = labelPosition;
         LineType = lineType;
+        OverrideColorInSchemes = false;
     }
 
     #endregion
@@ -1031,53 +1042,53 @@ public class OHLCPlus : Indicator
     public ColorMode ColorMode { get; set; } = ColorMode.PerLineSettings;
 
     // --- Palette by PERIOD (used when ColorMode == ByPeriod)
-    [Display(GroupName = "Colors — By Period", Name = "Current Day", Order = 10)]
+    [Display(GroupName = "Colors â€” By Period", Name = "Current Day", Order = 10)]
     public CrossColor PeriodColorCurrentDay { get; set; } = System.Drawing.Color.OrangeRed.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Previous Day", Order = 11)]
+    [Display(GroupName = "Colors â€” By Period", Name = "Previous Day", Order = 11)]
     public CrossColor PeriodColorPrevDay { get; set; } = System.Drawing.Color.SaddleBrown.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Current Week", Order = 12)]
+    [Display(GroupName = "Colors â€” By Period", Name = "Current Week", Order = 12)]
     public CrossColor PeriodColorCurrentWeek { get; set; } = System.Drawing.Color.DeepSkyBlue.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Previous Week", Order = 13)]
+    [Display(GroupName = "Colors â€” By Period", Name = "Previous Week", Order = 13)]
     public CrossColor PeriodColorPrevWeek { get; set; } = System.Drawing.Color.DarkSlateBlue.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Current Month", Order = 14)]
+    [Display(GroupName = "Colors â€” By Period", Name = "Current Month", Order = 14)]
     public CrossColor PeriodColorCurrentMonth { get; set; } = System.Drawing.Color.MediumSeaGreen.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Previous Month", Order = 15)]
+    [Display(GroupName = "Colors â€” By Period", Name = "Previous Month", Order = 15)]
     public CrossColor PeriodColorPrevMonth { get; set; } = System.Drawing.Color.DarkOliveGreen.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Contract", Order = 16)]
+    [Display(GroupName = "Colors â€” By Period", Name = "Contract", Order = 16)]
     public CrossColor PeriodColorContract { get; set; } = System.Drawing.Color.Indigo.Convert();
 
     // --- Palette by LEVEL TYPE (used when ColorMode == ByLevel)
-    [Display(GroupName = "Colors — By Level", Name = "Open", Order = 110)]
+    [Display(GroupName = "Colors â€” By Level", Name = "Open", Order = 110)]
     public CrossColor LevelColorOpen { get; set; } = System.Drawing.Color.DarkGoldenrod.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "High", Order = 120)]
+    [Display(GroupName = "Colors â€” By Level", Name = "High", Order = 120)]
     public CrossColor LevelColorHigh { get; set; } = System.Drawing.Color.ForestGreen.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "Low", Order = 130)]
+    [Display(GroupName = "Colors â€” By Level", Name = "Low", Order = 130)]
     public CrossColor LevelColorLow { get; set; } = System.Drawing.Color.Firebrick.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "Close", Order = 140)]
+    [Display(GroupName = "Colors â€” By Level", Name = "Close", Order = 140)]
     public CrossColor LevelColorClose { get; set; } = System.Drawing.Color.DimGray.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "Equilibrium (EQ)", Order = 150)]
+    [Display(GroupName = "Colors â€” By Level", Name = "Equilibrium (EQ)", Order = 150)]
     public CrossColor LevelColorEQ { get; set; } = System.Drawing.Color.DarkKhaki.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "POC", Order = 160)]
+    [Display(GroupName = "Colors â€” By Level", Name = "POC", Order = 160)]
     public CrossColor LevelColorPOC { get; set; } = System.Drawing.Color.OrangeRed.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "VWAP", Order = 170)]
+    [Display(GroupName = "Colors â€” By Level", Name = "VWAP", Order = 170)]
     public CrossColor LevelColorVWAP { get; set; } = System.Drawing.Color.DodgerBlue.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "VAH", Order = 180)]
+    [Display(GroupName = "Colors â€” By Level", Name = "VAH", Order = 180)]
     public CrossColor LevelColorVAH { get; set; } = System.Drawing.Color.CornflowerBlue.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "VAL", Order = 190)]
+    [Display(GroupName = "Colors â€” By Level", Name = "VAL", Order = 190)]
     public CrossColor LevelColorVAL { get; set; } = System.Drawing.Color.RoyalBlue.Convert();
     #endregion
 
@@ -1377,6 +1388,11 @@ public class OHLCPlus : Indicator
     // Resolve the color respecting the precedence (per-line override > scheme > per-line default)
     private CrossColor ResolveColor(string storagePrefix, string suffix, LevelSettings ls)
     {
+        // 1) Per-line hard override
+        if (ls?.OverrideColorInSchemes == true)
+            return ls.Color;
+
+        // 2) Scheme color (when active)
         switch (ColorMode)
         {
             case ColorMode.ByPeriod:
@@ -1385,7 +1401,7 @@ public class OHLCPlus : Indicator
                 return ResolveLevelPalette(suffix);
             case ColorMode.PerLineSettings:
             default:
-                return ls?.Color ?? CrossColors.White; // color propio de la línea (comportamiento por defecto)
+                return ls?.Color ?? CrossColors.White; // line's own color (default behavior)
         }
     }
 
@@ -1663,6 +1679,18 @@ public class OHLCPlus : Indicator
                     RedrawChart();
             }
         }
+
+        // Visual-only changes â†’ redraw
+        if (e.PropertyName == nameof(LevelSettings.Color)
+            || e.PropertyName == nameof(LevelSettings.OverrideColorInSchemes)
+            || e.PropertyName == nameof(LevelSettings.LineStyle)
+            || e.PropertyName == nameof(LevelSettings.Width)
+            || e.PropertyName == nameof(LevelSettings.LabelPosition)
+            || e.PropertyName == nameof(LevelSettings.ShowPrice)
+            || e.PropertyName == nameof(LevelSettings.OverrideLabel))
+        {
+            RedrawChart();
+        }
     }
 
     private bool IsNeeded(FixedProfilePeriods period)
@@ -1682,7 +1710,7 @@ public class OHLCPlus : Indicator
 
     private static (string Prefix, string Suffix) SplitKey(string key)
     {
-        // Sufijos conocidos ordenados por longitud para evitar colisiones
+        // Known suffixes ordered by length to avoid collisions
         foreach (var s in new[] { "Close", "Open", "High", "Low", "VWAP", "POC", "VAH", "VAL", "EQ" })
             if (key.EndsWith(s, StringComparison.Ordinal))
                 return (key.Substring(0, key.Length - s.Length), s);

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -39,6 +39,17 @@ public enum LineType
     Full = 2
 }
 
+// How colors are chosen at render time
+public enum ColorMode
+{
+    // Use the color in each LevelSettings (current behavior)
+    PerLineSettings = 0,
+    // Override by timeframe (Day/PrevDay/Week/...)
+    ByPeriod = 1,
+    // Override by level type (Open/High/Low/Close/EQ/POC/VWAP/VAH/VAL)
+    ByLevel = 2
+}
+
 public abstract class NotifiableObject : INotifyPropertyChanged
 {
     public event PropertyChangedEventHandler? PropertyChanged;
@@ -1014,6 +1025,62 @@ public class OHLCPlus : Indicator
 
     #endregion
 
+    #region Color scheme
+    // Strategy selector
+    [Display(GroupName = "Colors", Name = "Mode", Order = 5)]
+    public ColorMode ColorMode { get; set; } = ColorMode.PerLineSettings;
+
+    // --- Palette by PERIOD (used when ColorMode == ByPeriod)
+    [Display(GroupName = "Colors — By Period", Name = "Current Day", Order = 10)]
+    public CrossColor PeriodColorCurrentDay { get; set; } = System.Drawing.Color.Orange.Convert();
+
+    [Display(GroupName = "Colors — By Period", Name = "Previous Day", Order = 11)]
+    public CrossColor PeriodColorPrevDay { get; set; } = System.Drawing.Color.Gray.Convert();
+
+    [Display(GroupName = "Colors — By Period", Name = "Current Week", Order = 12)]
+    public CrossColor PeriodColorCurrentWeek { get; set; } = System.Drawing.Color.SteelBlue.Convert();
+
+    [Display(GroupName = "Colors — By Period", Name = "Previous Week", Order = 13)]
+    public CrossColor PeriodColorPrevWeek { get; set; } = System.Drawing.Color.MediumPurple.Convert();
+
+    [Display(GroupName = "Colors — By Period", Name = "Current Month", Order = 14)]
+    public CrossColor PeriodColorCurrentMonth { get; set; } = System.Drawing.Color.Teal.Convert();
+
+    [Display(GroupName = "Colors — By Period", Name = "Previous Month", Order = 15)]
+    public CrossColor PeriodColorPrevMonth { get; set; } = System.Drawing.Color.DarkSlateGray.Convert();
+
+    [Display(GroupName = "Colors — By Period", Name = "Contract", Order = 16)]
+    public CrossColor PeriodColorContract { get; set; } = System.Drawing.Color.DodgerBlue.Convert();
+
+    // --- Palette by LEVEL TYPE (used when ColorMode == ByLevel)
+    [Display(GroupName = "Colors — By Level", Name = "Open", Order = 110)]
+    public CrossColor LevelColorOpen { get; set; } = System.Drawing.Color.Orange.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "High", Order = 120)]
+    public CrossColor LevelColorHigh { get; set; } = System.Drawing.Color.Green.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "Low", Order = 130)]
+    public CrossColor LevelColorLow { get; set; } = System.Drawing.Color.Red.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "Close", Order = 140)]
+    public CrossColor LevelColorClose { get; set; } = System.Drawing.Color.Gray.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "Equilibrium (EQ)", Order = 150)]
+    public CrossColor LevelColorEQ { get; set; } = System.Drawing.Color.Yellow.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "POC", Order = 160)]
+    public CrossColor LevelColorPOC { get; set; } = System.Drawing.Color.Orange.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "VWAP", Order = 170)]
+    public CrossColor LevelColorVWAP { get; set; } = System.Drawing.Color.SteelBlue.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "VAH", Order = 180)]
+    public CrossColor LevelColorVAH { get; set; } = System.Drawing.Color.Purple.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "VAL", Order = 190)]
+    public CrossColor LevelColorVAL { get; set; } = System.Drawing.Color.Purple.Convert();
+    #endregion
+
     #endregion
 
     #region Constructor
@@ -1307,6 +1374,56 @@ public class OHLCPlus : Indicator
     }
 
 
+// Resolve the color respecting the precedence (per-line override > scheme > per-line default)
+    private CrossColor ResolveColor(FixedProfilePeriods period, string suffix, LevelSettings ls)
+    {
+        if (ls != null && ls.UsePerLineColor)
+            return ls.Color; // per-line override wins
+
+        switch (ColorMode) // TODO: enum you introduce for the color feature
+        {
+            case ColorMode.ByPeriod:
+                return ResolvePeriodPalette(period);
+            case ColorMode.ByLevel:
+                return ResolveLevelPalette(suffix);
+            default:
+                return ls?.Color ?? CrossColors.White;
+        }
+    }
+
+    // Build a pen using the resolved color (do not rely on ls.RenderPen anymore when schemes are active)
+    private RenderPen BuildPen(LevelSettings ls, CrossColor color)
+        => new PenSettings { Color = color, Width = ls.Width, LineDashStyle = ls.LineStyle }.RenderObject;
+
+    // Palette resolvers
+    private CrossColor ResolvePeriodPalette(FixedProfilePeriods period)
+        => period switch
+        {
+            FixedProfilePeriods.CurrentDay   => PeriodColorCurrentDay,
+            FixedProfilePeriods.LastDay      => PeriodColorPrevDay,
+            FixedProfilePeriods.CurrentWeek  => PeriodColorCurrentWeek,
+            FixedProfilePeriods.LastWeek     => PeriodColorPrevWeek,
+            FixedProfilePeriods.CurrentMonth => PeriodColorCurrentMonth,
+            FixedProfilePeriods.LastMonth    => PeriodColorPrevMonth,
+            FixedProfilePeriods.Contract     => PeriodColorContract,
+            _                                => CrossColors.White
+        };
+
+    private CrossColor ResolveLevelPalette(string suffix)
+        => suffix switch
+        {
+            "Open"  => LevelColorOpen,
+            "High"  => LevelColorHigh,
+            "Low"   => LevelColorLow,
+            "Close" => LevelColorClose,
+            "EQ"    => LevelColorEQ,
+            "POC"   => LevelColorPOC,
+            "VWAP"  => LevelColorVWAP,
+            "VAH"   => LevelColorVAH,
+            "VAL"   => LevelColorVAL,
+            _       => CrossColors.White
+        };
+
     private void RenderLevel(RenderContext context, string levelKey, LevelSettings levelSettings)
     {
         if (!levelSettings.Enabled || !_levels.TryGetValue(levelKey, out var level) || !level.IsValid)
@@ -1328,6 +1445,10 @@ public class OHLCPlus : Indicator
         }
         // ----------------------------------------------------
 
+        // NEW: resolve color & pen
+        var color = ResolveColor(prefix, suffix, levelSettings);
+        var renderPen = BuildPen(levelSettings, color);
+
         // Validate price is reasonable
         if (level.Price <= 0)
             return;
@@ -1343,8 +1464,6 @@ public class OHLCPlus : Indicator
         var barWidth = (int)ChartInfo.PriceChartContainer.BarsWidth;
         var currentBarRightX = currentBarX + barWidth;
 
-        // Get pen from LevelSettings
-        var renderPen = levelSettings.RenderPen;
 
         // Draw line first (if LineType != None)
         switch (levelSettings.LineType)
@@ -1376,7 +1495,7 @@ public class OHLCPlus : Indicator
         // Draw price label (if ShowPrice == true)
         if (levelSettings.ShowPrice)
         {
-            DrawPriceLabel(context, level.Price, y, renderPen, levelSettings);
+            DrawPriceLabel(context, level.Price, y, renderPen, color);
         }
 
         // Draw text label (if LabelPosition != None)
@@ -1400,12 +1519,11 @@ public class OHLCPlus : Indicator
         }
     }
 
-    private void DrawPriceLabel(RenderContext context, decimal price, int y, RenderPen pen, LevelSettings levelSettings)
+    private void DrawPriceLabel(RenderContext context, decimal price, int y, RenderPen pen, CrossColor backgroundColor)
     {
         var priceText = string.Format(ChartInfo.StringFormat, price);
 
         // Calculate contrasting text color based on background color
-        var backgroundColor = levelSettings.Color;
         var textColor = GetContrastingColor(backgroundColor);
 
         this.DrawLabelOnPriceAxis(context, priceText, y, _axisFont, backgroundColor.Convert(), textColor.Convert());

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -1280,6 +1280,11 @@ public class OHLCPlus : Indicator
                 // If label is at bar position, start line after the label to avoid overlap
                 if (levelSettings.LabelPosition == LabelPosition.Bar)
                 {
+                    // Calculate actual label width for better positioning
+                    var (prefix, suffix) = SplitKey(levelKey);
+                    var levelText = ResolveLevelText(suffix, levelSettings);
+                    var displayLabel = BuildDisplayLabel(prefix, levelText);
+                    var labelSize = context.MeasureString(displayLabel, _font);
                     var labelSize = context.MeasureString(displayLabel, _font);
                     var labelStartX = currentBarRightX + 5;
                     var lineStartX = labelStartX + labelSize.Width + 4; // 4px padding

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -124,6 +124,15 @@ public class LevelSettings : NotifiableObject
         set => SetField(ref _labelPosition, value);
     }
 
+    private string _overrideLabel = string.Empty;
+
+    [Display(Name = "Override label (optional)")]
+    public string OverrideLabel
+    {
+        get => _overrideLabel;
+        set => SetField(ref _overrideLabel, value);
+    }
+
     [Browsable(false)]
     public RenderPen RenderPen => new PenSettings { Color = Color, Width = Width, LineDashStyle = LineStyle }.RenderObject;
 
@@ -949,6 +958,24 @@ public class OHLCPlus : Indicator
 
     #endregion
 
+    #region Labels Settings
+
+    // Template supports {prefix} and {level}
+    [Display(Name = "Label template")]
+    public string LabelTemplate { get; set; } = "{prefix}{level}";
+
+    [Display(Name = "Open label")] public string OpenLabel { get; set; } = "Open";
+    [Display(Name = "High label")] public string HighLabel { get; set; } = "High";
+    [Display(Name = "Low label")] public string LowLabel { get; set; } = "Low";
+    [Display(Name = "Close label")] public string CloseLabel { get; set; } = "Close";
+    [Display(Name = "Equilibrium label")] public string EqLabel { get; set; } = "EQ";
+    [Display(Name = "POC label")] public string POCLabel { get; set; } = "POC";
+    [Display(Name = "VWAP label")] public string VWAPLabel { get; set; } = "VWAP";
+    [Display(Name = "VAH label")] public string VAHLabel { get; set; } = "VAH";
+    [Display(Name = "VAL label")] public string VALLabel { get; set; } = "VAL";
+
+    #endregion
+
     #endregion
 
     #region Constructor
@@ -1248,8 +1275,10 @@ public class OHLCPlus : Indicator
                 if (levelSettings.LabelPosition == LabelPosition.Bar)
                 {
                     // Calculate actual label width for better positioning
-                    var labelText = level.Label;
-                    var labelSize = context.MeasureString(labelText, _font);
+                    var (prefix, suffix) = SplitKey(levelKey);
+                    var levelText = ResolveLevelText(suffix, levelSettings);
+                    var displayLabel = BuildDisplayLabel(prefix, levelText);
+                    var labelSize = context.MeasureString(displayLabel, _font);
                     var labelStartX = currentBarRightX + 5;
                     var lineStartX = labelStartX + labelSize.Width + 4; // 4px padding
                     context.DrawLine(renderPen, lineStartX, y, chartWidth, y);
@@ -1279,15 +1308,15 @@ public class OHLCPlus : Indicator
         {
             case LabelPosition.Bar:
                 var barLabelX = currentBarRightX + 5;
-                DrawTextLabel(context, level.Label, barLabelX, y, renderPen, false);
+                DrawTextLabel(context, displayLabel, barLabelX, y, renderPen, false);
                 break;
             case LabelPosition.Right:
                 var rightLabelX = chartWidth - 5;
-                DrawTextLabel(context, level.Label, rightLabelX, y, renderPen, true);
+                DrawTextLabel(context, displayLabel, rightLabelX, y, renderPen, true);
                 break;
             case LabelPosition.Left:
                 var leftLabelX = 5;
-                DrawTextLabel(context, level.Label, leftLabelX, y, renderPen, false);
+                DrawTextLabel(context, displayLabel, leftLabelX, y, renderPen, false);
                 break;
             case LabelPosition.None:
                 // No text label to draw
@@ -1443,6 +1472,42 @@ public class OHLCPlus : Indicator
             FixedProfilePeriods.Contract => _needContract,
             _ => false
         };
+    }
+
+    private static (string Prefix, string Suffix) SplitKey(string key)
+    {
+        // Sufijos conocidos ordenados por longitud para evitar colisiones
+        foreach (var s in new[] { "Close", "Open", "High", "Low", "VWAP", "POC", "VAH", "VAL", "EQ" })
+            if (key.EndsWith(s, StringComparison.Ordinal))
+                return (key.Substring(0, key.Length - s.Length), s);
+        return ("", key);
+    }
+
+    private string ResolveLevelText(string suffix, LevelSettings ls)
+    {
+        if (!string.IsNullOrWhiteSpace(ls?.OverrideLabel))
+            return ls.OverrideLabel;
+
+        return suffix switch
+        {
+            "Open" => OpenLabel,
+            "High" => HighLabel,
+            "Low" => LowLabel,
+            "Close" => CloseLabel,
+            "EQ" => EqLabel,
+            "POC" => POCLabel,
+            "VWAP" => VWAPLabel,
+            "VAH" => VAHLabel,
+            "VAL" => VALLabel,
+            _ => suffix
+        };
+    }
+
+    private string BuildDisplayLabel(string prefix, string levelText)
+    {
+        var template = string.IsNullOrEmpty(LabelTemplate) ? "{prefix}{level}" : LabelTemplate;
+        return template.Replace("{prefix}", prefix ?? string.Empty)
+                       .Replace("{level}", levelText ?? string.Empty);
     }
 
     #endregion

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -1042,6 +1042,62 @@ public class OHLCPlus : Indicator
     public ColorMode ColorMode { get; set; } = ColorMode.PerLineSettings;
 
     // --- Palette by PERIOD (used when ColorMode == ByPeriod)
+    [Display(GroupName = "Colors � By Period", Name = "Current Day", Order = 10)]
+    public CrossColor PeriodColorCurrentDay { get; set; } = System.Drawing.Color.Orange.Convert();
+
+    [Display(GroupName = "Colors � By Period", Name = "Previous Day", Order = 11)]
+    public CrossColor PeriodColorPrevDay { get; set; } = System.Drawing.Color.Gray.Convert();
+
+    [Display(GroupName = "Colors � By Period", Name = "Current Week", Order = 12)]
+    public CrossColor PeriodColorCurrentWeek { get; set; } = System.Drawing.Color.SteelBlue.Convert();
+
+    [Display(GroupName = "Colors � By Period", Name = "Previous Week", Order = 13)]
+    public CrossColor PeriodColorPrevWeek { get; set; } = System.Drawing.Color.MediumPurple.Convert();
+
+    [Display(GroupName = "Colors � By Period", Name = "Current Month", Order = 14)]
+    public CrossColor PeriodColorCurrentMonth { get; set; } = System.Drawing.Color.Teal.Convert();
+
+    [Display(GroupName = "Colors � By Period", Name = "Previous Month", Order = 15)]
+    public CrossColor PeriodColorPrevMonth { get; set; } = System.Drawing.Color.DarkSlateGray.Convert();
+
+    [Display(GroupName = "Colors � By Period", Name = "Contract", Order = 16)]
+    public CrossColor PeriodColorContract { get; set; } = System.Drawing.Color.DodgerBlue.Convert();
+
+    // --- Palette by LEVEL TYPE (used when ColorMode == ByLevel)
+    [Display(GroupName = "Colors � By Level", Name = "Open", Order = 110)]
+    public CrossColor LevelColorOpen { get; set; } = System.Drawing.Color.Orange.Convert();
+
+    [Display(GroupName = "Colors � By Level", Name = "High", Order = 120)]
+    public CrossColor LevelColorHigh { get; set; } = System.Drawing.Color.Green.Convert();
+
+    [Display(GroupName = "Colors � By Level", Name = "Low", Order = 130)]
+    public CrossColor LevelColorLow { get; set; } = System.Drawing.Color.Red.Convert();
+
+    [Display(GroupName = "Colors � By Level", Name = "Close", Order = 140)]
+    public CrossColor LevelColorClose { get; set; } = System.Drawing.Color.Gray.Convert();
+
+    [Display(GroupName = "Colors � By Level", Name = "Equilibrium (EQ)", Order = 150)]
+    public CrossColor LevelColorEQ { get; set; } = System.Drawing.Color.Yellow.Convert();
+
+    [Display(GroupName = "Colors � By Level", Name = "POC", Order = 160)]
+    public CrossColor LevelColorPOC { get; set; } = System.Drawing.Color.Orange.Convert();
+
+    [Display(GroupName = "Colors � By Level", Name = "VWAP", Order = 170)]
+    public CrossColor LevelColorVWAP { get; set; } = System.Drawing.Color.SteelBlue.Convert();
+
+    [Display(GroupName = "Colors � By Level", Name = "VAH", Order = 180)]
+    public CrossColor LevelColorVAH { get; set; } = System.Drawing.Color.Purple.Convert();
+
+    [Display(GroupName = "Colors � By Level", Name = "VAL", Order = 190)]
+    public CrossColor LevelColorVAL { get; set; } = System.Drawing.Color.Purple.Convert();
+    #endregion
+
+    #region Color scheme
+    // Strategy selector
+    [Display(GroupName = "Colors", Name = "Mode", Order = 5)]
+    public ColorMode ColorMode { get; set; } = ColorMode.PerLineSettings;
+
+    // --- Palette by PERIOD (used when ColorMode == ByPeriod)
     [Display(GroupName = "Colors - By Period", Name = "Current Day", Order = 10)]
     public CrossColor PeriodColorCurrentDay { get; set; } = System.Drawing.Color.OrangeRed.Convert();
 

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -16,13 +16,13 @@ public enum LabelPosition
 {
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.None))]
     None = 0,
-    
+
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Bar))]
     Bar = 1,
-    
+
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Right))]
     Right = 2,
-    
+
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Left))]
     Left = 3
 }
@@ -31,10 +31,10 @@ public enum LineType
 {
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.None))]
     None = 0,
-    
+
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.TillBar))]
     Bar = 1,
-    
+
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.FullWidth))]
     Full = 2
 }
@@ -1332,7 +1332,6 @@ public class OHLCPlus : Indicator
                     var levelText = ResolveLevelText(suffix, levelSettings);
                     var displayLabel = BuildDisplayLabel(prefix, levelText);
                     var labelSize = context.MeasureString(displayLabel, _font);
-                    var labelSize = context.MeasureString(displayLabel, _font);
                     var labelStartX = currentBarRightX + 5;
                     var lineStartX = labelStartX + labelSize.Width + 4; // 4px padding
                     context.DrawLine(renderPen, lineStartX, y, chartWidth, y);
@@ -1381,20 +1380,20 @@ public class OHLCPlus : Indicator
     private void DrawPriceLabel(RenderContext context, decimal price, int y, RenderPen pen, LevelSettings levelSettings)
     {
         var priceText = string.Format(ChartInfo.StringFormat, price);
-        
+
         // Calculate contrasting text color based on background color
         var backgroundColor = levelSettings.Color;
         var textColor = GetContrastingColor(backgroundColor);
-        
+
         this.DrawLabelOnPriceAxis(context, priceText, y, _axisFont, backgroundColor.Convert(), textColor.Convert());
     }
-    
+
     private CrossColor GetContrastingColor(CrossColor backgroundColor)
     {
         // Calculate luminance using relative luminance formula
         // See: https://www.w3.org/TR/WCAG20/#relativeluminancedef
         double luminance = (0.299 * backgroundColor.R + 0.587 * backgroundColor.G + 0.114 * backgroundColor.B) / 255;
-        
+
         // If background is dark, use white text; if light, use black text
         if (luminance > 0.5)
         {
@@ -1412,16 +1411,16 @@ public class OHLCPlus : Indicator
     {
         var size = context.MeasureString(text, _font);
         var textColor = ChartInfo.ColorsStore.MouseTextColor;
-        
+
         // Calculate rectangle position based on alignment
         var rectX = alignRight ? x - size.Width : x;
         var rect = new Rectangle(rectX - 2, y - size.Height / 2 - 1, size.Width + 4, size.Height + 2);
-        
+
         // Draw background with border
         var backgroundColor = ChartInfo.ColorsStore.BaseBackgroundColor;
         context.FillRectangle(backgroundColor, rect);
         context.DrawRectangle(pen, rect);
-        
+
         // Draw text
         var textRect = new Rectangle(rectX, y - size.Height / 2, size.Width, size.Height);
         var format = alignRight ? _stringRightFormat : _stringLeftFormat;


### PR DESCRIPTION
# PR: OHLCPlus — HVN bands by period with priority, partial occlusion, and color schemes

## Summary
This PR upgrades **OHLCPlus** with robust High-Volume Node (HVN) *band* detection and drawing across all fixed-profile periods, adds a clear priority system, introduces partial occlusion (crop only overlaps), and provides flexible color schemes (by period / by level) with per-line overrides. It also consolidates rendering, improves axis label contrast, and fixes previous build issues.

## Motivation
- We needed consistent HVN visuals across Day/Week/Month/Contract.
- When bands overlap, fully hiding a band is too aggressive; cropping is clearer.


## What’s in this PR
- **HVN computation** for all periods from `IndicatorCandle.GetAllPriceLevels()`:
  - Band building with gap tolerance (`HVNGapToleranceTicks`) and volume cutoff as `% of POC`.
- **Drawing priority** (highest → lowest):
  `Contract > PrevMonth > CurrentMonth > PrevWeek > CurrentWeek > PrevDay > CurrentDay`.
- **Partial occlusion**:
  - `SubtractClaimed(...)` subtracts previously claimed ranges (already expanded by `HVNOcclusionTicks`) and returns leftover sub-bands to draw.
- **Rendering**:
  - `RenderAllHVNsWithPriority(...)` iterates by priority, crops overlaps, draws only visible pieces.
  - `RenderLevelGroup(...)` centralizes OHLC/POC/VWAP/VA* lines and labels.
  - Price-axis labels use automatic text color (black/white) for contrast.
- **Color strategies**:
  - `ColorMode`: `PerLineSettings` (default), `ByPeriod`, `ByLevel`.
  - `UsePerLineColor` on each `LevelSettings` overrides any global scheme.
- **Configuration**:
  - Display-only per-period prefixes and a `{prefix}{level}` label template.

## Screenshots
<img width="1491" height="961" alt="image" src="https://github.com/user-attachments/assets/f115520b-e236-4c8b-acf4-f5bed5c102e7" />
<p><em>In blue: CurrentDay HVN.<br>
In orange: Previous Day HVN.<br>
In purple: Previous week HVN.</em></p>

## Testing
Manual checks performed:
1. Toggle each period’s **Enable HVN** on/off and verify band presence.
2. Create overlaps (e.g., Current Day and Previous Day) and confirm only the overlapped *sub-range* is cropped on the lower-priority band.
3. Adjust `HVNThresholdPct`, `HVNGapToleranceTicks`, `HVNOcclusionTicks` and verify band generation/occlusion respond as expected.
4. Switch `ColorMode` between PerLine / ByPeriod / ByLevel; verify precedence of `UsePerLineColor`.
5. Confirm labels render with the configured prefix and template; axis label contrast remains readable.
6. Performance sanity check on dense profiles—no noticeable lag.

## Backwards compatibility
- Default behavior remains close to previous visuals unless new options are enabled.
- Storage keys for levels stay canonical (e.g., `dOpen`, `pPOC`, …).

## Known limitations / Future work
- Optional post-filter for “very thin” bands (1 tick) is present but commented.
- Potential future enhancement: user-configurable minimum band height.

## Checklist
- [x] Compiles and runs locally
- [x] No public API changes
- [x] Comments in English
- [x] Unit/visual manual checks
- [x] Changelog entry (if applicable)
