### PR TITLE
Optimize fixed-profile requests by period (request previous* only once per rollover) (stacked on top of #103)

### DIFF
--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -38,6 +38,17 @@ public enum LineType
     Full = 2
 }
 
+// How colors are chosen at render time
+public enum ColorMode
+{
+    // Use the color in each LevelSettings (current behavior)
+    PerLineSettings = 0,
+    // Override by timeframe (Day/PrevDay/Week/...)
+    ByPeriod = 1,
+    // Override by level type (Open/High/Low/Close/EQ/POC/VWAP/VAH/VAL)
+    ByLevel = 2
+}
+
 public abstract class NotifiableObject : INotifyPropertyChanged
 {
     public event PropertyChangedEventHandler? PropertyChanged;
@@ -980,6 +991,62 @@ public class OHLCPlus : Indicator
 
     #endregion
 
+    #region Color scheme
+    // Strategy selector
+    [Display(GroupName = "Colors", Name = "Mode", Order = 5)]
+    public ColorMode ColorMode { get; set; } = ColorMode.PerLineSettings;
+
+    // --- Palette by PERIOD (used when ColorMode == ByPeriod)
+    [Display(GroupName = "Colors — By Period", Name = "Current Day", Order = 10)]
+    public CrossColor PeriodColorCurrentDay { get; set; } = System.Drawing.Color.Orange.Convert();
+
+    [Display(GroupName = "Colors — By Period", Name = "Previous Day", Order = 11)]
+    public CrossColor PeriodColorPrevDay { get; set; } = System.Drawing.Color.Gray.Convert();
+
+    [Display(GroupName = "Colors — By Period", Name = "Current Week", Order = 12)]
+    public CrossColor PeriodColorCurrentWeek { get; set; } = System.Drawing.Color.SteelBlue.Convert();
+
+    [Display(GroupName = "Colors — By Period", Name = "Previous Week", Order = 13)]
+    public CrossColor PeriodColorPrevWeek { get; set; } = System.Drawing.Color.MediumPurple.Convert();
+
+    [Display(GroupName = "Colors — By Period", Name = "Current Month", Order = 14)]
+    public CrossColor PeriodColorCurrentMonth { get; set; } = System.Drawing.Color.Teal.Convert();
+
+    [Display(GroupName = "Colors — By Period", Name = "Previous Month", Order = 15)]
+    public CrossColor PeriodColorPrevMonth { get; set; } = System.Drawing.Color.DarkSlateGray.Convert();
+
+    [Display(GroupName = "Colors — By Period", Name = "Contract", Order = 16)]
+    public CrossColor PeriodColorContract { get; set; } = System.Drawing.Color.DodgerBlue.Convert();
+
+    // --- Palette by LEVEL TYPE (used when ColorMode == ByLevel)
+    [Display(GroupName = "Colors — By Level", Name = "Open", Order = 110)]
+    public CrossColor LevelColorOpen { get; set; } = System.Drawing.Color.Orange.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "High", Order = 120)]
+    public CrossColor LevelColorHigh { get; set; } = System.Drawing.Color.Green.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "Low", Order = 130)]
+    public CrossColor LevelColorLow { get; set; } = System.Drawing.Color.Red.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "Close", Order = 140)]
+    public CrossColor LevelColorClose { get; set; } = System.Drawing.Color.Gray.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "Equilibrium (EQ)", Order = 150)]
+    public CrossColor LevelColorEQ { get; set; } = System.Drawing.Color.Yellow.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "POC", Order = 160)]
+    public CrossColor LevelColorPOC { get; set; } = System.Drawing.Color.Orange.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "VWAP", Order = 170)]
+    public CrossColor LevelColorVWAP { get; set; } = System.Drawing.Color.SteelBlue.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "VAH", Order = 180)]
+    public CrossColor LevelColorVAH { get; set; } = System.Drawing.Color.Purple.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "VAL", Order = 190)]
+    public CrossColor LevelColorVAL { get; set; } = System.Drawing.Color.Purple.Convert();
+    #endregion
+
     #endregion
 
     #region Constructor
@@ -1207,6 +1274,56 @@ public class OHLCPlus : Indicator
     }
 
 
+// Resolve the color respecting the precedence (per-line override > scheme > per-line default)
+    private CrossColor ResolveColor(FixedProfilePeriods period, string suffix, LevelSettings ls)
+    {
+        if (ls != null && ls.UsePerLineColor)
+            return ls.Color; // per-line override wins
+
+        switch (ColorMode) // TODO: enum you introduce for the color feature
+        {
+            case ColorMode.ByPeriod:
+                return ResolvePeriodPalette(period);
+            case ColorMode.ByLevel:
+                return ResolveLevelPalette(suffix);
+            default:
+                return ls?.Color ?? CrossColors.White;
+        }
+    }
+
+    // Build a pen using the resolved color (do not rely on ls.RenderPen anymore when schemes are active)
+    private RenderPen BuildPen(LevelSettings ls, CrossColor color)
+        => new PenSettings { Color = color, Width = ls.Width, LineDashStyle = ls.LineStyle }.RenderObject;
+
+    // Palette resolvers
+    private CrossColor ResolvePeriodPalette(FixedProfilePeriods period)
+        => period switch
+        {
+            FixedProfilePeriods.CurrentDay   => PeriodColorCurrentDay,
+            FixedProfilePeriods.LastDay      => PeriodColorPrevDay,
+            FixedProfilePeriods.CurrentWeek  => PeriodColorCurrentWeek,
+            FixedProfilePeriods.LastWeek     => PeriodColorPrevWeek,
+            FixedProfilePeriods.CurrentMonth => PeriodColorCurrentMonth,
+            FixedProfilePeriods.LastMonth    => PeriodColorPrevMonth,
+            FixedProfilePeriods.Contract     => PeriodColorContract,
+            _                                => CrossColors.White
+        };
+
+    private CrossColor ResolveLevelPalette(string suffix)
+        => suffix switch
+        {
+            "Open"  => LevelColorOpen,
+            "High"  => LevelColorHigh,
+            "Low"   => LevelColorLow,
+            "Close" => LevelColorClose,
+            "EQ"    => LevelColorEQ,
+            "POC"   => LevelColorPOC,
+            "VWAP"  => LevelColorVWAP,
+            "VAH"   => LevelColorVAH,
+            "VAL"   => LevelColorVAL,
+            _       => CrossColors.White
+        };
+
     private void RenderLevel(RenderContext context, string levelKey, LevelSettings levelSettings)
     {
         if (!levelSettings.Enabled || !_levels.TryGetValue(levelKey, out var level) || !level.IsValid)
@@ -1217,6 +1334,10 @@ public class OHLCPlus : Indicator
         var levelText = ResolveLevelText(suffix, levelSettings);
         var displayLabel = BuildDisplayLabel(DisplayPrefixFor(prefix), levelText);
         // ----------------------------------------------------
+
+        // NEW: resolve color & pen
+        var color = ResolveColor(prefix, suffix, levelSettings);
+        var renderPen = BuildPen(levelSettings, color);
 
         // Validate price is reasonable
         if (level.Price <= 0)
@@ -1233,8 +1354,6 @@ public class OHLCPlus : Indicator
         var barWidth = (int)ChartInfo.PriceChartContainer.BarsWidth;
         var currentBarRightX = currentBarX + barWidth;
 
-        // Get pen from LevelSettings
-        var renderPen = levelSettings.RenderPen;
 
         // Draw line first (if LineType != None)
         switch (levelSettings.LineType)
@@ -1266,7 +1385,7 @@ public class OHLCPlus : Indicator
         // Draw price label (if ShowPrice == true)
         if (levelSettings.ShowPrice)
         {
-            DrawPriceLabel(context, level.Price, y, renderPen, levelSettings);
+            DrawPriceLabel(context, level.Price, y, renderPen, color);
         }
 
         // Draw text label (if LabelPosition != None)
@@ -1290,12 +1409,11 @@ public class OHLCPlus : Indicator
         }
     }
 
-    private void DrawPriceLabel(RenderContext context, decimal price, int y, RenderPen pen, LevelSettings levelSettings)
+    private void DrawPriceLabel(RenderContext context, decimal price, int y, RenderPen pen, CrossColor backgroundColor)
     {
         var priceText = string.Format(ChartInfo.StringFormat, price);
 
         // Calculate contrasting text color based on background color
-        var backgroundColor = levelSettings.Color;
         var textColor = GetContrastingColor(backgroundColor);
 
         this.DrawLabelOnPriceAxis(context, priceText, y, _axisFont, backgroundColor.Convert(), textColor.Convert());

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -123,6 +123,15 @@ public class LevelSettings : NotifiableObject
         set => SetField(ref _labelPosition, value);
     }
 
+    private string _overrideLabel = string.Empty;
+
+    [Display(Name = "Override label (optional)")]
+    public string OverrideLabel
+    {
+        get => _overrideLabel;
+        set => SetField(ref _overrideLabel, value);
+    }
+
     [Browsable(false)]
     public RenderPen RenderPen => new PenSettings { Color = Color, Width = Width, LineDashStyle = LineStyle }.RenderObject;
 
@@ -916,6 +925,24 @@ public class OHLCPlus : Indicator
 
     #endregion
 
+    #region Labels Settings
+
+    // Template supports {prefix} and {level}
+    [Display(Name = "Label template")]
+    public string LabelTemplate { get; set; } = "{prefix}{level}";
+
+    [Display(Name = "Open label")] public string OpenLabel { get; set; } = "Open";
+    [Display(Name = "High label")] public string HighLabel { get; set; } = "High";
+    [Display(Name = "Low label")] public string LowLabel { get; set; } = "Low";
+    [Display(Name = "Close label")] public string CloseLabel { get; set; } = "Close";
+    [Display(Name = "Equilibrium label")] public string EqLabel { get; set; } = "EQ";
+    [Display(Name = "POC label")] public string POCLabel { get; set; } = "POC";
+    [Display(Name = "VWAP label")] public string VWAPLabel { get; set; } = "VWAP";
+    [Display(Name = "VAH label")] public string VAHLabel { get; set; } = "VAH";
+    [Display(Name = "VAL label")] public string VALLabel { get; set; } = "VAL";
+
+    #endregion
+
     #endregion
 
     #region Constructor
@@ -1149,8 +1176,10 @@ public class OHLCPlus : Indicator
                 if (levelSettings.LabelPosition == LabelPosition.Bar)
                 {
                     // Calculate actual label width for better positioning
-                    var labelText = level.Label;
-                    var labelSize = context.MeasureString(labelText, _font);
+                    var (prefix, suffix) = SplitKey(levelKey);
+                    var levelText = ResolveLevelText(suffix, levelSettings);
+                    var displayLabel = BuildDisplayLabel(prefix, levelText);
+                    var labelSize = context.MeasureString(displayLabel, _font);
                     var labelStartX = currentBarRightX + 5;
                     var lineStartX = labelStartX + labelSize.Width + 4; // 4px padding
                     context.DrawLine(renderPen, lineStartX, y, chartWidth, y);
@@ -1180,15 +1209,15 @@ public class OHLCPlus : Indicator
         {
             case LabelPosition.Bar:
                 var barLabelX = currentBarRightX + 5;
-                DrawTextLabel(context, level.Label, barLabelX, y, renderPen, false);
+                DrawTextLabel(context, displayLabel, barLabelX, y, renderPen, false);
                 break;
             case LabelPosition.Right:
                 var rightLabelX = chartWidth - 5;
-                DrawTextLabel(context, level.Label, rightLabelX, y, renderPen, true);
+                DrawTextLabel(context, displayLabel, rightLabelX, y, renderPen, true);
                 break;
             case LabelPosition.Left:
                 var leftLabelX = 5;
-                DrawTextLabel(context, level.Label, leftLabelX, y, renderPen, false);
+                DrawTextLabel(context, displayLabel, leftLabelX, y, renderPen, false);
                 break;
             case LabelPosition.None:
                 // No text label to draw
@@ -1313,6 +1342,42 @@ public class OHLCPlus : Indicator
             RedrawChart();
             return;
         }
+    }
+
+    private static (string Prefix, string Suffix) SplitKey(string key)
+    {
+        // Sufijos conocidos ordenados por longitud para evitar colisiones
+        foreach (var s in new[] { "Close", "Open", "High", "Low", "VWAP", "POC", "VAH", "VAL", "EQ" })
+            if (key.EndsWith(s, StringComparison.Ordinal))
+                return (key.Substring(0, key.Length - s.Length), s);
+        return ("", key);
+    }
+
+    private string ResolveLevelText(string suffix, LevelSettings ls)
+    {
+        if (!string.IsNullOrWhiteSpace(ls?.OverrideLabel))
+            return ls.OverrideLabel;
+
+        return suffix switch
+        {
+            "Open" => OpenLabel,
+            "High" => HighLabel,
+            "Low" => LowLabel,
+            "Close" => CloseLabel,
+            "EQ" => EqLabel,
+            "POC" => POCLabel,
+            "VWAP" => VWAPLabel,
+            "VAH" => VAHLabel,
+            "VAL" => VALLabel,
+            _ => suffix
+        };
+    }
+
+    private string BuildDisplayLabel(string prefix, string levelText)
+    {
+        var template = string.IsNullOrEmpty(LabelTemplate) ? "{prefix}{level}" : LabelTemplate;
+        return template.Replace("{prefix}", prefix ?? string.Empty)
+                       .Replace("{level}", levelText ?? string.Empty);
     }
 
     #endregion

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -925,21 +925,54 @@ public class OHLCPlus : Indicator
 
     #endregion
 
+    #region Prefix Settings
+    // Display-only prefixes (do not affect storage keys)
+    [Display(GroupName = "Prefixes", Name = "Current Day", Order = 10)]
+    public string PrefixCurrentDay { get; set; } = "d";
+
+    [Display(GroupName = "Prefixes", Name = "Previous Day", Order = 20)]
+    public string PrefixPrevDay { get; set; } = "p";
+
+    [Display(GroupName = "Prefixes", Name = "Current Week", Order = 30)]
+    public string PrefixCurrentWeek { get; set; } = "w";
+
+    [Display(GroupName = "Prefixes", Name = "Previous Week", Order = 40)]
+    public string PrefixPrevWeek { get; set; } = "pw";
+
+    [Display(GroupName = "Prefixes", Name = "Current Month", Order = 50)]
+    public string PrefixCurrentMonth { get; set; } = "m";
+
+    [Display(GroupName = "Prefixes", Name = "Previous Month", Order = 60)]
+    public string PrefixPrevMonth { get; set; } = "pm";
+
+    [Display(GroupName = "Prefixes", Name = "Contract", Order = 70)]
+    public string PrefixContract { get; set; } = "c";
+    #endregion
+
     #region Labels Settings
 
     // Template supports {prefix} and {level}
-    [Display(Name = "Label template")]
+    [Display(GroupName = "Labels", Name = "Label template", Order = 10)]
     public string LabelTemplate { get; set; } = "{prefix}{level}";
 
-    [Display(Name = "Open label")] public string OpenLabel { get; set; } = "Open";
-    [Display(Name = "High label")] public string HighLabel { get; set; } = "High";
-    [Display(Name = "Low label")] public string LowLabel { get; set; } = "Low";
-    [Display(Name = "Close label")] public string CloseLabel { get; set; } = "Close";
-    [Display(Name = "Equilibrium label")] public string EqLabel { get; set; } = "EQ";
-    [Display(Name = "POC label")] public string POCLabel { get; set; } = "POC";
-    [Display(Name = "VWAP label")] public string VWAPLabel { get; set; } = "VWAP";
-    [Display(Name = "VAH label")] public string VAHLabel { get; set; } = "VAH";
-    [Display(Name = "VAL label")] public string VALLabel { get; set; } = "VAL";
+    [Display(GroupName = "Labels", Name = "Open", Order = 20)]
+    public string OpenLabel { get; set; } = "Open";
+    [Display(GroupName = "Labels", Name = "High", Order = 30)]
+    public string HighLabel { get; set; } = "High";
+    [Display(GroupName = "Labels", Name = "Low", Order = 40)]
+    public string LowLabel { get; set; } = "Low";
+    [Display(GroupName = "Labels", Name = "Close", Order = 50)]
+    public string CloseLabel { get; set; } = "Close";
+    [Display(GroupName = "Labels", Name = "Equilibrium", Order = 60)]
+    public string EqLabel { get; set; } = "EQ";
+    [Display(GroupName = "Labels", Name = "POC", Order = 70)]
+    public string POCLabel { get; set; } = "POC";
+    [Display(GroupName = "Labels", Name = "VWAP", Order = 80)]
+    public string VWAPLabel { get; set; } = "VWAP";
+    [Display(GroupName = "Labels", Name = "VAH", Order = 90)]
+    public string VAHLabel { get; set; } = "VAH";
+    [Display(GroupName = "Labels", Name = "VAL", Order = 100)]
+    public string VALLabel { get; set; } = "VAL";
 
     #endregion
 
@@ -1002,13 +1035,13 @@ public class OHLCPlus : Indicator
             return;
 
         // Render all levels in groups for better organization
-        RenderLevelGroup(context, "d", DayOpenLevel, DayHighLevel, DayLowLevel, DayCloseLevel, DayEquilibriumLevel, DayPOCLevel, DayVWAPLevel, DayVAHLevel, DayVALLevel);
-        RenderLevelGroup(context, "p", PrevDayOpenLevel, PrevDayHighLevel, PrevDayLowLevel, PrevDayCloseLevel, PrevDayEquilibriumLevel, PrevDayPOCLevel, PrevDayVWAPLevel, PrevDayVAHLevel, PrevDayVALLevel);
-        RenderLevelGroup(context, "w", WeekOpenLevel, WeekHighLevel, WeekLowLevel, WeekCloseLevel, WeekEquilibriumLevel, WeekPOCLevel, WeekVWAPLevel, WeekVAHLevel, WeekVALLevel);
-        RenderLevelGroup(context, "pw", PrevWeekOpenLevel, PrevWeekHighLevel, PrevWeekLowLevel, PrevWeekCloseLevel, PrevWeekEquilibriumLevel, PrevWeekPOCLevel, PrevWeekVWAPLevel, PrevWeekVAHLevel, PrevWeekVALLevel);
-        RenderLevelGroup(context, "m", MonthOpenLevel, MonthHighLevel, MonthLowLevel, MonthCloseLevel, MonthEquilibriumLevel, MonthPOCLevel, MonthVWAPLevel, MonthVAHLevel, MonthVALLevel);
-        RenderLevelGroup(context, "pm", PrevMonthOpenLevel, PrevMonthHighLevel, PrevMonthLowLevel, PrevMonthCloseLevel, PrevMonthEquilibriumLevel, PrevMonthPOCLevel, PrevMonthVWAPLevel, PrevMonthVAHLevel, PrevMonthVALLevel);
-        RenderLevelGroup(context, "c", ContractOpenLevel, ContractHighLevel, ContractLowLevel, ContractCloseLevel, ContractEquilibriumLevel, ContractPOCLevel, ContractVWAPLevel, ContractVAHLevel, ContractVALLevel);
+        RenderLevelGroup(context, storagePrefix: "d", displayPrefix: PrefixCurrentDay, DayOpenLevel, DayHighLevel, DayLowLevel, DayCloseLevel, DayEquilibriumLevel, DayPOCLevel, DayVWAPLevel, DayVAHLevel, DayVALLevel);
+        RenderLevelGroup(context, storagePrefix: "p", displayPrefix: PrefixPrevDay, PrevDayOpenLevel, PrevDayHighLevel, PrevDayLowLevel, PrevDayCloseLevel, PrevDayEquilibriumLevel, PrevDayPOCLevel, PrevDayVWAPLevel, PrevDayVAHLevel, PrevDayVALLevel);
+        RenderLevelGroup(context, storagePrefix: "w", displayPrefix: PrefixCurrentWeek, WeekOpenLevel, WeekHighLevel, WeekLowLevel, WeekCloseLevel, WeekEquilibriumLevel, WeekPOCLevel, WeekVWAPLevel, WeekVAHLevel, WeekVALLevel);
+        RenderLevelGroup(context, storagePrefix: "pw", displayPrefix: PrefixPrevWeek, PrevWeekOpenLevel, PrevWeekHighLevel, PrevWeekLowLevel, PrevWeekCloseLevel, PrevWeekEquilibriumLevel, PrevWeekPOCLevel, PrevWeekVWAPLevel, PrevWeekVAHLevel, PrevWeekVALLevel);
+        RenderLevelGroup(context, storagePrefix: "m", displayPrefix: PrefixCurrentMonth, MonthOpenLevel, MonthHighLevel, MonthLowLevel, MonthCloseLevel, MonthEquilibriumLevel, MonthPOCLevel, MonthVWAPLevel, MonthVAHLevel, MonthVALLevel);
+        RenderLevelGroup(context, storagePrefix: "pm", displayPrefix: PrefixPrevMonth, PrevMonthOpenLevel, PrevMonthHighLevel, PrevMonthLowLevel, PrevMonthCloseLevel, PrevMonthEquilibriumLevel, PrevMonthPOCLevel, PrevMonthVWAPLevel, PrevMonthVAHLevel, PrevMonthVALLevel);
+        RenderLevelGroup(context, storagePrefix: "c", displayPrefix: PrefixContract, ContractOpenLevel, ContractHighLevel, ContractLowLevel, ContractCloseLevel, ContractEquilibriumLevel, ContractPOCLevel, ContractVWAPLevel, ContractVAHLevel, ContractVALLevel);
     }
 
     #endregion
@@ -1145,6 +1178,20 @@ public class OHLCPlus : Indicator
         };
     }
 
+    // Maps the canonical storage prefix ("d", "p", "w", "pw", "m", "pm", "c")
+    // to the user-configurable display prefix for visual labels.
+    private string DisplayPrefixFor(string storagePrefix) => storagePrefix switch
+    {
+        "d" => PrefixCurrentDay,
+        "p" => PrefixPrevDay,
+        "w" => PrefixCurrentWeek,
+        "pw" => PrefixPrevWeek,
+        "m" => PrefixCurrentMonth,
+        "pm" => PrefixPrevMonth,
+        "c" => PrefixContract,
+        _ => storagePrefix ?? string.Empty
+    };
+
     private void RenderLevel(RenderContext context, string levelKey, LevelSettings levelSettings)
     {
         if (!levelSettings.Enabled || !_levels.TryGetValue(levelKey, out var level) || !level.IsValid)
@@ -1153,7 +1200,7 @@ public class OHLCPlus : Indicator
         // --- Calculate actual label width for better positioning ---
         var (prefix, suffix) = SplitKey(levelKey);
         var levelText = ResolveLevelText(suffix, levelSettings);
-        var displayLabel = BuildDisplayLabel(prefix, levelText);
+        var displayLabel = BuildDisplayLabel(DisplayPrefixFor(prefix), levelText);
         // ----------------------------------------------------
 
         // Validate price is reasonable

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -1274,20 +1274,18 @@ public class OHLCPlus : Indicator
     }
 
 
-// Resolve the color respecting the precedence (per-line override > scheme > per-line default)
-    private CrossColor ResolveColor(FixedProfilePeriods period, string suffix, LevelSettings ls)
+    // Resolve the color respecting the precedence (per-line override > scheme > per-line default)
+    private CrossColor ResolveColor(string storagePrefix, string suffix, LevelSettings ls)
     {
-        if (ls != null && ls.UsePerLineColor)
-            return ls.Color; // per-line override wins
-
-        switch (ColorMode) // TODO: enum you introduce for the color feature
+        switch (ColorMode)
         {
             case ColorMode.ByPeriod:
-                return ResolvePeriodPalette(period);
+                return ResolvePeriodPalette(storagePrefix);
             case ColorMode.ByLevel:
                 return ResolveLevelPalette(suffix);
+            case ColorMode.PerLineSettings:
             default:
-                return ls?.Color ?? CrossColors.White;
+                return ls?.Color ?? CrossColors.White; // color propio de la línea (comportamiento por defecto)
         }
     }
 
@@ -1296,33 +1294,31 @@ public class OHLCPlus : Indicator
         => new PenSettings { Color = color, Width = ls.Width, LineDashStyle = ls.LineStyle }.RenderObject;
 
     // Palette resolvers
-    private CrossColor ResolvePeriodPalette(FixedProfilePeriods period)
-        => period switch
-        {
-            FixedProfilePeriods.CurrentDay   => PeriodColorCurrentDay,
-            FixedProfilePeriods.LastDay      => PeriodColorPrevDay,
-            FixedProfilePeriods.CurrentWeek  => PeriodColorCurrentWeek,
-            FixedProfilePeriods.LastWeek     => PeriodColorPrevWeek,
-            FixedProfilePeriods.CurrentMonth => PeriodColorCurrentMonth,
-            FixedProfilePeriods.LastMonth    => PeriodColorPrevMonth,
-            FixedProfilePeriods.Contract     => PeriodColorContract,
-            _                                => CrossColors.White
-        };
+    private CrossColor ResolvePeriodPalette(string storagePrefix) => storagePrefix switch
+    {
+        "d" => PeriodColorCurrentDay,
+        "p" => PeriodColorPrevDay,
+        "w" => PeriodColorCurrentWeek,
+        "pw" => PeriodColorPrevWeek,
+        "m" => PeriodColorCurrentMonth,
+        "pm" => PeriodColorPrevMonth,
+        "c" => PeriodColorContract,
+        _ => CrossColors.White
+    };
 
-    private CrossColor ResolveLevelPalette(string suffix)
-        => suffix switch
-        {
-            "Open"  => LevelColorOpen,
-            "High"  => LevelColorHigh,
-            "Low"   => LevelColorLow,
-            "Close" => LevelColorClose,
-            "EQ"    => LevelColorEQ,
-            "POC"   => LevelColorPOC,
-            "VWAP"  => LevelColorVWAP,
-            "VAH"   => LevelColorVAH,
-            "VAL"   => LevelColorVAL,
-            _       => CrossColors.White
-        };
+    private CrossColor ResolveLevelPalette(string suffix) => suffix switch
+    {
+        "Open" => LevelColorOpen,
+        "High" => LevelColorHigh,
+        "Low" => LevelColorLow,
+        "Close" => LevelColorClose,
+        "EQ" => LevelColorEQ,
+        "POC" => LevelColorPOC,
+        "VWAP" => LevelColorVWAP,
+        "VAH" => LevelColorVAH,
+        "VAL" => LevelColorVAL,
+        _ => CrossColors.White
+    };
 
     private void RenderLevel(RenderContext context, string levelKey, LevelSettings levelSettings)
     {

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -15,13 +15,13 @@ public enum LabelPosition
 {
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.None))]
     None = 0,
-    
+
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Bar))]
     Bar = 1,
-    
+
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Right))]
     Right = 2,
-    
+
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Left))]
     Left = 3
 }
@@ -30,10 +30,10 @@ public enum LineType
 {
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.None))]
     None = 0,
-    
+
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.TillBar))]
     Bar = 1,
-    
+
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.FullWidth))]
     Full = 2
 }
@@ -191,7 +191,7 @@ public class OHLCPlus : Indicator
         Trimming = StringTrimming.EllipsisCharacter,
         FormatFlags = StringFormatFlags.NoWrap
     };
-    
+
     private RenderStringFormat _stringLeftFormat = new()
     {
         Alignment = StringAlignment.Near,
@@ -199,7 +199,7 @@ public class OHLCPlus : Indicator
         Trimming = StringTrimming.EllipsisCharacter,
         FormatFlags = StringFormatFlags.NoWrap
     };
-    
+
     #endregion
 
     #region Properties
@@ -1143,8 +1143,8 @@ public class OHLCPlus : Indicator
             UpdateLevel($"{prefix}VWAP", candle.VWAP);
 
         // Safe ValueArea access with validation
-        if (candle.ValueArea != null && 
-            candle.ValueArea.ValueAreaHigh > 0 && 
+        if (candle.ValueArea != null &&
+            candle.ValueArea.ValueAreaHigh > 0 &&
             candle.ValueArea.ValueAreaLow > 0 &&
             candle.ValueArea.ValueAreaHigh >= candle.ValueArea.ValueAreaLow)
         {
@@ -1228,6 +1228,7 @@ public class OHLCPlus : Indicator
                 // If label is at bar position, start line after the label to avoid overlap
                 if (levelSettings.LabelPosition == LabelPosition.Bar)
                 {
+                    // Calculate actual label width for better positioning
                     var labelSize = context.MeasureString(displayLabel, _font);
                     var labelStartX = currentBarRightX + 5;
                     var lineStartX = labelStartX + labelSize.Width + 4; // 4px padding
@@ -1277,20 +1278,20 @@ public class OHLCPlus : Indicator
     private void DrawPriceLabel(RenderContext context, decimal price, int y, RenderPen pen, LevelSettings levelSettings)
     {
         var priceText = string.Format(ChartInfo.StringFormat, price);
-        
+
         // Calculate contrasting text color based on background color
         var backgroundColor = levelSettings.Color;
         var textColor = GetContrastingColor(backgroundColor);
-        
+
         this.DrawLabelOnPriceAxis(context, priceText, y, _axisFont, backgroundColor.Convert(), textColor.Convert());
     }
-    
+
     private CrossColor GetContrastingColor(CrossColor backgroundColor)
     {
         // Calculate luminance using relative luminance formula
         // See: https://www.w3.org/TR/WCAG20/#relativeluminancedef
         double luminance = (0.299 * backgroundColor.R + 0.587 * backgroundColor.G + 0.114 * backgroundColor.B) / 255;
-        
+
         // If background is dark, use white text; if light, use black text
         if (luminance > 0.5)
         {
@@ -1308,16 +1309,16 @@ public class OHLCPlus : Indicator
     {
         var size = context.MeasureString(text, _font);
         var textColor = ChartInfo.ColorsStore.MouseTextColor;
-        
+
         // Calculate rectangle position based on alignment
         var rectX = alignRight ? x - size.Width : x;
         var rect = new Rectangle(rectX - 2, y - size.Height / 2 - 1, size.Width + 4, size.Height + 2);
-        
+
         // Draw background with border
         var backgroundColor = ChartInfo.ColorsStore.BaseBackgroundColor;
         context.FillRectangle(backgroundColor, rect);
         context.DrawRectangle(pen, rect);
-        
+
         // Draw text
         var textRect = new Rectangle(rectX, y - size.Height / 2, size.Width, size.Height);
         var format = alignRight ? _stringRightFormat : _stringLeftFormat;

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -216,6 +216,20 @@ public class OHLCPlus : Indicator
     private string? _scopedStoragePrefix = null;
     private string? _scopedDisplayPrefix = null;
 
+    // HVN prices by period
+    private readonly Dictionary<FixedProfilePeriods, List<HVNBand>> _hvnBands = new();
+
+    private static readonly FixedProfilePeriods[] _hvnPriorityOrder = new[]
+    {
+    FixedProfilePeriods.Contract,
+    FixedProfilePeriods.LastMonth,
+    FixedProfilePeriods.CurrentMonth,
+    FixedProfilePeriods.LastWeek,
+    FixedProfilePeriods.CurrentWeek,
+    FixedProfilePeriods.LastDay,
+    FixedProfilePeriods.CurrentDay
+    };
+
     #endregion
 
     #region Properties

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -1149,17 +1149,23 @@ public class OHLCPlus : Indicator
     {
         if (!levelSettings.Enabled || !_levels.TryGetValue(levelKey, out var level) || !level.IsValid)
             return;
-            
+
+        // --- Calculate actual label width for better positioning ---
+        var (prefix, suffix) = SplitKey(levelKey);
+        var levelText = ResolveLevelText(suffix, levelSettings);
+        var displayLabel = BuildDisplayLabel(prefix, levelText);
+        // ----------------------------------------------------
+
         // Validate price is reasonable
         if (level.Price <= 0)
             return;
 
         var y = ChartInfo.GetYByPrice(level.Price, false);
-        
+
         // Check if price is visible on chart
         if (y < 0 || y > ChartInfo.PriceChartContainer.Region.Height)
             return;
-            
+
         var chartWidth = ChartInfo.PriceChartContainer.Region.Width;
         var currentBarX = ChartInfo.GetXByBar(CurrentBar - 1);
         var barWidth = (int)ChartInfo.PriceChartContainer.BarsWidth;
@@ -1175,10 +1181,6 @@ public class OHLCPlus : Indicator
                 // If label is at bar position, start line after the label to avoid overlap
                 if (levelSettings.LabelPosition == LabelPosition.Bar)
                 {
-                    // Calculate actual label width for better positioning
-                    var (prefix, suffix) = SplitKey(levelKey);
-                    var levelText = ResolveLevelText(suffix, levelSettings);
-                    var displayLabel = BuildDisplayLabel(prefix, levelText);
                     var labelSize = context.MeasureString(displayLabel, _font);
                     var labelStartX = currentBarRightX + 5;
                     var lineStartX = labelStartX + labelSize.Width + 4; // 4px padding

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -1005,7 +1005,7 @@ public class OHLCPlus : Indicator
     [Range(0, 10)]
     public int HVNGapToleranceTicks { get; set; } = 1;
 
-    // Overlap tolerance in ticks: if a price falls within ±N ticks of another already drawn, it is hidden.
+    // Overlap tolerance in ticks: if a price falls within �N ticks of another already drawn, it is hidden.
     [Display(GroupName = "HVN Settings", Name = "Occlusion tolerance (ticks)", Order = 30)]
     [Range(0, 10)]
     public int HVNOcclusionTicks { get; set; } = 1;
@@ -1375,7 +1375,7 @@ public class OHLCPlus : Indicator
                 return ResolveLevelPalette(suffix);
             case ColorMode.PerLineSettings:
             default:
-                return ls?.Color ?? CrossColors.White; // color propio de la línea (comportamiento por defecto)
+                return ls?.Color ?? CrossColors.White; // color propio de la l�nea (comportamiento por defecto)
         }
     }
 

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -1,4 +1,4 @@
-namespace ATAS.Indicators.Technical;
+ï»¿namespace ATAS.Indicators.Technical;
 
 using OFT.Localization;
 using OFT.Rendering.Context;
@@ -194,6 +194,10 @@ public class OHLCPlus : Indicator
 
     private readonly Dictionary<FixedProfilePeriods, IndicatorCandle> _profileCandles = new();
     private readonly Dictionary<string, LevelData> _levels = new();
+
+    // Tracks which "static" profiles (previous*) have already been requested
+    private readonly HashSet<FixedProfilePeriods> _requestedStatic = new();
+
     private RenderFont _font = new("Arial", 10);
     private RenderFont _axisFont = new("Arial", 11);
     private RenderStringFormat _stringRightFormat = new()
@@ -1001,7 +1005,7 @@ public class OHLCPlus : Indicator
     [Range(0, 10)]
     public int HVNGapToleranceTicks { get; set; } = 1;
 
-    // Overlap tolerance in ticks: if a price falls within ±N ticks of another already drawn, it is hidden.
+    // Overlap tolerance in ticks: if a price falls within Â±N ticks of another already drawn, it is hidden.
     [Display(GroupName = "HVN Settings", Name = "Occlusion tolerance (ticks)", Order = 30)]
     [Range(0, 10)]
     public int HVNOcclusionTicks { get; set; } = 1;
@@ -1065,53 +1069,53 @@ public class OHLCPlus : Indicator
     public ColorMode ColorMode { get; set; } = ColorMode.PerLineSettings;
 
     // --- Palette by PERIOD (used when ColorMode == ByPeriod)
-    [Display(GroupName = "Colors — By Period", Name = "Current Day", Order = 10)]
+    [Display(GroupName = "Colors â€” By Period", Name = "Current Day", Order = 10)]
     public CrossColor PeriodColorCurrentDay { get; set; } = System.Drawing.Color.Orange.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Previous Day", Order = 11)]
+    [Display(GroupName = "Colors â€” By Period", Name = "Previous Day", Order = 11)]
     public CrossColor PeriodColorPrevDay { get; set; } = System.Drawing.Color.Gray.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Current Week", Order = 12)]
+    [Display(GroupName = "Colors â€” By Period", Name = "Current Week", Order = 12)]
     public CrossColor PeriodColorCurrentWeek { get; set; } = System.Drawing.Color.SteelBlue.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Previous Week", Order = 13)]
+    [Display(GroupName = "Colors â€” By Period", Name = "Previous Week", Order = 13)]
     public CrossColor PeriodColorPrevWeek { get; set; } = System.Drawing.Color.MediumPurple.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Current Month", Order = 14)]
+    [Display(GroupName = "Colors â€” By Period", Name = "Current Month", Order = 14)]
     public CrossColor PeriodColorCurrentMonth { get; set; } = System.Drawing.Color.Teal.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Previous Month", Order = 15)]
+    [Display(GroupName = "Colors â€” By Period", Name = "Previous Month", Order = 15)]
     public CrossColor PeriodColorPrevMonth { get; set; } = System.Drawing.Color.DarkSlateGray.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Contract", Order = 16)]
+    [Display(GroupName = "Colors â€” By Period", Name = "Contract", Order = 16)]
     public CrossColor PeriodColorContract { get; set; } = System.Drawing.Color.DodgerBlue.Convert();
 
     // --- Palette by LEVEL TYPE (used when ColorMode == ByLevel)
-    [Display(GroupName = "Colors — By Level", Name = "Open", Order = 110)]
+    [Display(GroupName = "Colors â€” By Level", Name = "Open", Order = 110)]
     public CrossColor LevelColorOpen { get; set; } = System.Drawing.Color.Orange.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "High", Order = 120)]
+    [Display(GroupName = "Colors â€” By Level", Name = "High", Order = 120)]
     public CrossColor LevelColorHigh { get; set; } = System.Drawing.Color.Green.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "Low", Order = 130)]
+    [Display(GroupName = "Colors â€” By Level", Name = "Low", Order = 130)]
     public CrossColor LevelColorLow { get; set; } = System.Drawing.Color.Red.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "Close", Order = 140)]
+    [Display(GroupName = "Colors â€” By Level", Name = "Close", Order = 140)]
     public CrossColor LevelColorClose { get; set; } = System.Drawing.Color.Gray.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "Equilibrium (EQ)", Order = 150)]
+    [Display(GroupName = "Colors â€” By Level", Name = "Equilibrium (EQ)", Order = 150)]
     public CrossColor LevelColorEQ { get; set; } = System.Drawing.Color.Yellow.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "POC", Order = 160)]
+    [Display(GroupName = "Colors â€” By Level", Name = "POC", Order = 160)]
     public CrossColor LevelColorPOC { get; set; } = System.Drawing.Color.Orange.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "VWAP", Order = 170)]
+    [Display(GroupName = "Colors â€” By Level", Name = "VWAP", Order = 170)]
     public CrossColor LevelColorVWAP { get; set; } = System.Drawing.Color.SteelBlue.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "VAH", Order = 180)]
+    [Display(GroupName = "Colors â€” By Level", Name = "VAH", Order = 180)]
     public CrossColor LevelColorVAH { get; set; } = System.Drawing.Color.Purple.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "VAL", Order = 190)]
+    [Display(GroupName = "Colors â€” By Level", Name = "VAL", Order = 190)]
     public CrossColor LevelColorVAL { get; set; } = System.Drawing.Color.Purple.Convert();
     #endregion
 
@@ -1152,12 +1156,26 @@ public class OHLCPlus : Indicator
         {
             _profileCandles.Clear();
             _levels.Clear();
+            _requestedStatic.Clear(); // reset static cache at first bar
         }
 
+        // Detect period rollovers (sessionâ‰ˆday, week, month)
+        bool newDay = IsNewSession(bar);
+        bool newWeek = IsNewWeek(bar);
+        bool newMonth = IsNewMonth(bar);
+
+        // Invalidate only what must be refreshed on next RequestProfiles
+        if (newDay)
+            _requestedStatic.Remove(FixedProfilePeriods.LastDay);
+        if (newWeek)
+            _requestedStatic.Remove(FixedProfilePeriods.LastWeek);
+        if (newMonth)
+            _requestedStatic.Remove(FixedProfilePeriods.LastMonth);
+
+        // We only fetch when the last bar is being calculated
         if (bar != CurrentBar - 1)
             return;
 
-        // Request all needed profiles
         RequestProfiles();
     }
 
@@ -1193,33 +1211,33 @@ public class OHLCPlus : Indicator
 
     private void RequestProfiles()
     {
-        // Request current day profile
+        // Dynamic (Current*) profiles: always request when needed
         if (NeedsDayData())
             GetFixedProfile(new FixedProfileRequest(FixedProfilePeriods.CurrentDay));
 
-        // Request previous day profile
-        if (NeedsPrevDayData())
-            GetFixedProfile(new FixedProfileRequest(FixedProfilePeriods.LastDay));
-
-        // Request current week profile
         if (NeedsWeekData())
             GetFixedProfile(new FixedProfileRequest(FixedProfilePeriods.CurrentWeek));
 
-        // Request previous week profile
-        if (NeedsPrevWeekData())
-            GetFixedProfile(new FixedProfileRequest(FixedProfilePeriods.LastWeek));
-
-        // Request current month profile
         if (NeedsMonthData())
             GetFixedProfile(new FixedProfileRequest(FixedProfilePeriods.CurrentMonth));
 
-        // Request previous month profile
-        if (NeedsPrevMonthData())
-            GetFixedProfile(new FixedProfileRequest(FixedProfilePeriods.LastMonth));
-
-        // Request contract profile
         if (NeedsContractData())
             GetFixedProfile(new FixedProfileRequest(FixedProfilePeriods.Contract));
+
+        // Static (Previous*) profiles: request once until invalidated
+        RequestStaticOnce(FixedProfilePeriods.LastDay, NeedsPrevDayData());
+        RequestStaticOnce(FixedProfilePeriods.LastWeek, NeedsPrevWeekData());
+        RequestStaticOnce(FixedProfilePeriods.LastMonth, NeedsPrevMonthData());
+    }
+
+    // Request static profile only once per period rollover
+    private void RequestStaticOnce(FixedProfilePeriods period, bool needed)
+    {
+        if (!needed) return;
+        if (_requestedStatic.Contains(period)) return;
+
+        GetFixedProfile(new FixedProfileRequest(period));
+        _requestedStatic.Add(period);
     }
 
     private bool NeedsDayData()
@@ -1357,7 +1375,7 @@ public class OHLCPlus : Indicator
                 return ResolveLevelPalette(suffix);
             case ColorMode.PerLineSettings:
             default:
-                return ls?.Color ?? CrossColors.White; // color propio de la línea (comportamiento por defecto)
+                return ls?.Color ?? CrossColors.White; // color propio de la lÃ­nea (comportamiento por defecto)
         }
     }
 

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -10,6 +10,7 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Drawing;
 using System.Runtime.CompilerServices;
+using System.Linq;
 
 public enum LabelPosition
 {
@@ -320,6 +321,12 @@ public class OHLCPlus : Indicator
         lineType: LineType.Bar
     );
 
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentDay), Name = "Enable HVN", Order = 90)]
+    public bool DayHVNEnabled { get; set; } = false;
+
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentDay), Name = "HVN Color", Order = 95)]
+    public CrossColor DayHVNColor { get; set; } = System.Drawing.Color.FromArgb(140, 30, 144, 255).Convert(); // semi-transparent blue/violet
+
     #endregion
 
     #region Prev.Day Settings
@@ -422,6 +429,12 @@ public class OHLCPlus : Indicator
         labelPosition: LabelPosition.Bar,
         lineType: LineType.Bar
     );
+
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousDay), Name = "Enable HVN", Order = 90)]
+    public bool PrevDayHVNEnabled { get; set; } = false;
+
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousDay), Name = "HVN Color", Order = 95)]
+    public CrossColor PrevDayHVNColor { get; set; } = System.Drawing.Color.FromArgb(140, 255, 140, 0).Convert(); // semi-transparent amber.
 
     #endregion
 
@@ -526,6 +539,11 @@ public class OHLCPlus : Indicator
         lineType: LineType.Bar
     );
 
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentWeek), Name = "Enable HVN", Order = 90)]
+    public bool WeekHVNEnabled { get; set; } = false;
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentWeek), Name = "HVN Color", Order = 95)]
+    public CrossColor WeekHVNColor { get; set; } = System.Drawing.Color.FromArgb(140, 70, 130, 180).Convert(); // steel-ish
+
     #endregion
 
     #region Prev.Week Settings
@@ -628,6 +646,11 @@ public class OHLCPlus : Indicator
         labelPosition: LabelPosition.Bar,
         lineType: LineType.Bar
     );
+
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousWeek), Name = "Enable HVN", Order = 90)]
+    public bool PrevWeekHVNEnabled { get; set; } = false;
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousWeek), Name = "HVN Color", Order = 95)]
+    public CrossColor PrevWeekHVNColor { get; set; } = System.Drawing.Color.FromArgb(140, 186, 85, 211).Convert(); // mediumPurple
 
     #endregion
 
@@ -732,6 +755,11 @@ public class OHLCPlus : Indicator
         lineType: LineType.Bar
     );
 
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentMonth), Name = "Enable HVN", Order = 90)]
+    public bool MonthHVNEnabled { get; set; } = false;
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentMonth), Name = "HVN Color", Order = 95)]
+    public CrossColor MonthHVNColor { get; set; } = System.Drawing.Color.FromArgb(140, 0, 128, 128).Convert(); // teal
+
     #endregion
 
     #region Prev.Month Settings
@@ -835,6 +863,11 @@ public class OHLCPlus : Indicator
         lineType: LineType.Bar
     );
 
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousMonth), Name = "Enable HVN", Order = 90)]
+    public bool PrevMonthHVNEnabled { get; set; } = false;
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousMonth), Name = "HVN Color", Order = 95)]
+    public CrossColor PrevMonthHVNColor { get; set; } = System.Drawing.Color.FromArgb(140, 47, 79, 79).Convert(); // darkslategray
+
     #endregion
 
     #region Contract Settings
@@ -937,6 +970,27 @@ public class OHLCPlus : Indicator
         labelPosition: LabelPosition.Bar,
         lineType: LineType.Bar
     );
+
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Contract), Name = "Enable HVN", Order = 90)]
+    public bool ContractHVNEnabled { get; set; } = false;
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Contract), Name = "HVN Color", Order = 95)]
+    public CrossColor ContractHVNColor { get; set; } = System.Drawing.Color.FromArgb(140, 30, 144, 255).Convert(); // dodgerblue
+
+    #endregion
+
+    #region HVN Settings
+    [Display(GroupName = "HVN Settings", Name = "Threshold (% of POC volume)", Order = 10)]
+    [Range(1, 99)]
+    public int HVNThresholdPct { get; set; } = 80;
+
+    [Display(GroupName = "HVN Settings", Name = "Gap tolerance (ticks)", Order = 20)]
+    [Range(0, 10)]
+    public int HVNGapToleranceTicks { get; set; } = 1;
+
+    // Overlap tolerance in ticks: if a price falls within ±N ticks of another already drawn, it is hidden.
+    [Display(GroupName = "HVN Settings", Name = "Occlusion tolerance (ticks)", Order = 30)]
+    [Range(0, 10)]
+    public int HVNOcclusionTicks { get; set; } = 1;
 
     #endregion
 
@@ -1097,6 +1151,7 @@ public class OHLCPlus : Indicator
     {
         _profileCandles[period] = fixedProfileOriginScale;
         UpdateLevels(period, fixedProfileOriginScale);
+        UpdateHVNs(period, fixedProfileOriginScale);
         RedrawChart();
     }
 
@@ -1113,6 +1168,9 @@ public class OHLCPlus : Indicator
         RenderLevelGroup(context, storagePrefix: "m", displayPrefix: PrefixCurrentMonth, MonthOpenLevel, MonthHighLevel, MonthLowLevel, MonthCloseLevel, MonthEquilibriumLevel, MonthPOCLevel, MonthVWAPLevel, MonthVAHLevel, MonthVALLevel);
         RenderLevelGroup(context, storagePrefix: "pm", displayPrefix: PrefixPrevMonth, PrevMonthOpenLevel, PrevMonthHighLevel, PrevMonthLowLevel, PrevMonthCloseLevel, PrevMonthEquilibriumLevel, PrevMonthPOCLevel, PrevMonthVWAPLevel, PrevMonthVAHLevel, PrevMonthVALLevel);
         RenderLevelGroup(context, storagePrefix: "c", displayPrefix: PrefixContract, ContractOpenLevel, ContractHighLevel, ContractLowLevel, ContractCloseLevel, ContractEquilibriumLevel, ContractPOCLevel, ContractVWAPLevel, ContractVAHLevel, ContractVALLevel);
+
+        // HVN rects
+        RenderAllHVNsWithPriority(context);
     }
 
     #endregion
@@ -1153,43 +1211,43 @@ public class OHLCPlus : Indicator
     private bool NeedsDayData()
     {
         return DayOpenLevel.Enabled || DayHighLevel.Enabled || DayLowLevel.Enabled || DayCloseLevel.Enabled ||
-               DayEquilibriumLevel.Enabled || DayPOCLevel.Enabled || DayVWAPLevel.Enabled || DayVAHLevel.Enabled || DayVALLevel.Enabled;
+               DayEquilibriumLevel.Enabled || DayPOCLevel.Enabled || DayVWAPLevel.Enabled || DayVAHLevel.Enabled || DayVALLevel.Enabled || DayHVNEnabled;
     }
 
     private bool NeedsPrevDayData()
     {
         return PrevDayOpenLevel.Enabled || PrevDayHighLevel.Enabled || PrevDayLowLevel.Enabled || PrevDayCloseLevel.Enabled ||
-               PrevDayEquilibriumLevel.Enabled || PrevDayPOCLevel.Enabled || PrevDayVWAPLevel.Enabled || PrevDayVAHLevel.Enabled || PrevDayVALLevel.Enabled;
+               PrevDayEquilibriumLevel.Enabled || PrevDayPOCLevel.Enabled || PrevDayVWAPLevel.Enabled || PrevDayVAHLevel.Enabled || PrevDayVALLevel.Enabled || PrevDayHVNEnabled;
     }
 
     private bool NeedsWeekData()
     {
         return WeekOpenLevel.Enabled || WeekHighLevel.Enabled || WeekLowLevel.Enabled || WeekCloseLevel.Enabled ||
-               WeekEquilibriumLevel.Enabled || WeekPOCLevel.Enabled || WeekVWAPLevel.Enabled || WeekVAHLevel.Enabled || WeekVALLevel.Enabled;
+               WeekEquilibriumLevel.Enabled || WeekPOCLevel.Enabled || WeekVWAPLevel.Enabled || WeekVAHLevel.Enabled || WeekVALLevel.Enabled || WeekHVNEnabled;
     }
 
     private bool NeedsPrevWeekData()
     {
         return PrevWeekOpenLevel.Enabled || PrevWeekHighLevel.Enabled || PrevWeekLowLevel.Enabled || PrevWeekCloseLevel.Enabled ||
-               PrevWeekEquilibriumLevel.Enabled || PrevWeekPOCLevel.Enabled || PrevWeekVWAPLevel.Enabled || PrevWeekVAHLevel.Enabled || PrevWeekVALLevel.Enabled;
+               PrevWeekEquilibriumLevel.Enabled || PrevWeekPOCLevel.Enabled || PrevWeekVWAPLevel.Enabled || PrevWeekVAHLevel.Enabled || PrevWeekVALLevel.Enabled || PrevWeekHVNEnabled;
     }
 
     private bool NeedsMonthData()
     {
         return MonthOpenLevel.Enabled || MonthHighLevel.Enabled || MonthLowLevel.Enabled || MonthCloseLevel.Enabled ||
-               MonthEquilibriumLevel.Enabled || MonthPOCLevel.Enabled || MonthVWAPLevel.Enabled || MonthVAHLevel.Enabled || MonthVALLevel.Enabled;
+               MonthEquilibriumLevel.Enabled || MonthPOCLevel.Enabled || MonthVWAPLevel.Enabled || MonthVAHLevel.Enabled || MonthVALLevel.Enabled || MonthHVNEnabled;
     }
 
     private bool NeedsPrevMonthData()
     {
         return PrevMonthOpenLevel.Enabled || PrevMonthHighLevel.Enabled || PrevMonthLowLevel.Enabled || PrevMonthCloseLevel.Enabled ||
-               PrevMonthEquilibriumLevel.Enabled || PrevMonthPOCLevel.Enabled || PrevMonthVWAPLevel.Enabled || PrevMonthVAHLevel.Enabled || PrevMonthVALLevel.Enabled;
+               PrevMonthEquilibriumLevel.Enabled || PrevMonthPOCLevel.Enabled || PrevMonthVWAPLevel.Enabled || PrevMonthVAHLevel.Enabled || PrevMonthVALLevel.Enabled || PrevMonthHVNEnabled;
     }
 
     private bool NeedsContractData()
     {
         return ContractOpenLevel.Enabled || ContractHighLevel.Enabled || ContractLowLevel.Enabled || ContractCloseLevel.Enabled ||
-               ContractEquilibriumLevel.Enabled || ContractPOCLevel.Enabled || ContractVWAPLevel.Enabled || ContractVAHLevel.Enabled || ContractVALLevel.Enabled;
+               ContractEquilibriumLevel.Enabled || ContractPOCLevel.Enabled || ContractVWAPLevel.Enabled || ContractVAHLevel.Enabled || ContractVALLevel.Enabled || ContractHVNEnabled;
     }
 
     private void UpdateLevels(FixedProfilePeriods period, IndicatorCandle candle)
@@ -1581,7 +1639,244 @@ public class OHLCPlus : Indicator
                        .Replace("{level}", levelText ?? string.Empty);
     }
 
+    private void UpdateHVNs(FixedProfilePeriods period, IndicatorCandle candle)
+    {
+        if (candle == null)
+            return;
+
+        if (!_hvnBands.TryGetValue(period, out var bands))
+        {
+            bands = new List<HVNBand>();
+            _hvnBands[period] = bands;
+        }
+        else
+        {
+            bands.Clear();
+        }
+
+        var poc = candle.MaxVolumePriceInfo;
+        if (poc == null || poc.Volume <= 0)
+            return;
+
+        var cutoff = poc.Volume * (HVNThresholdPct / 100m);
+
+        // Materialize and sort by ascending price
+        var levelsEnum = candle.GetAllPriceLevels();
+        if (levelsEnum == null)
+            return;
+
+        var levels = levelsEnum.OrderBy(l => l.Price).ToList();
+        if (levels.Count == 0)
+            return;
+
+        var tick = InstrumentInfo.TickSize;
+        if (tick <= 0m)
+            return;
+
+        // Current run state (a "band" of contiguous HVN ticks allowing small gaps)
+        decimal? runStart = null;   // current band start (price)
+        decimal lastPriceInRun = 0; // last visited price
+        int gapLeft = 0;            // remaining tolerated gaps inside a band
+
+        bool IsNextTick(decimal prev, decimal next)
+            => Math.Abs(next - prev) <= tick * 1.0000001m; // tiny tolerance
+
+        for (int i = 0; i < levels.Count; i++)
+        {
+            var p = levels[i].Price;
+            var v = levels[i].Volume; // Si Volume no es decimal, castea a decimal
+
+            bool isHigh = v >= cutoff;
+
+            if (runStart == null)
+            {
+                // No open band: only start when level is above cutoff
+                if (isHigh)
+                {
+                    runStart = p;
+                    lastPriceInRun = p;
+                    gapLeft = HVNGapToleranceTicks;
+                }
+                continue;
+            }
+
+            // There is an open band: check contiguity by tick
+            bool contiguous = IsNextTick(lastPriceInRun, p);
+
+            if (!contiguous)
+            {
+                // We jumped several ticks -> close previous band
+                bands.Add(new HVNBand { Low = runStart.Value, High = lastPriceInRun });
+                runStart = null;
+
+                
+                if (isHigh)
+                {
+                    runStart = p;
+                    lastPriceInRun = p;
+                    gapLeft = HVNGapToleranceTicks; 
+                }
+                continue;
+            }
+
+            // Contiguous by tick
+            if (isHigh)
+            {
+                lastPriceInRun = p;
+                gapLeft = HVNGapToleranceTicks; // reset tolerance when back to "high" zone
+            }
+            else
+            {
+                if (gapLeft > 0)
+                {
+                    gapLeft--;
+                    lastPriceInRun = p; // keep band continuity
+                }
+                else
+                {
+                    // Tolerance exhausted: close band at last "high" tick
+                    var end = lastPriceInRun;
+
+                    // If previous tick was low, step back one tick
+                    if (i > 0 && levels[i - 1].Volume < cutoff)
+                        end -= tick;
+
+                    if (end >= runStart.Value)
+                        bands.Add(new HVNBand { Low = runStart.Value, High = end });
+
+                    runStart = null;
+
+                    // Start a new band with this point if it's high
+                    if (isHigh)
+                    {
+                        runStart = p;
+                        lastPriceInRun = p;
+                        gapLeft = HVNGapToleranceTicks;
+                    }
+                }
+            }
+        }
+
+        // Close trailing band if any
+        if (runStart != null && lastPriceInRun >= runStart.Value)
+            bands.Add(new HVNBand { Low = runStart.Value, High = lastPriceInRun });
+
+        // Optional: filter very small bands
+        // bands.RemoveAll(b => (b.High - b.Low) < tick);
+    }
+
+    private sealed class HVNBand
+    {
+        public decimal Low { get; init; }  
+        public decimal High { get; init; }
+    }
+
+    private void RenderAllHVNsWithPriority(RenderContext ctx)
+    {
+        var tick = InstrumentInfo?.TickSize ?? 0m;
+        if (tick <= 0) return;
+
+        // ranges already claimed by higher-priority periods (stored already expanded)
+        var claimed = new List<(decimal Lo, decimal Hi)>();
+
+        foreach (var period in _hvnPriorityOrder)
+        {
+            var (enabled, color) = period switch
+            {
+                FixedProfilePeriods.CurrentDay => (DayHVNEnabled, DayHVNColor),
+                FixedProfilePeriods.LastDay => (PrevDayHVNEnabled, PrevDayHVNColor),
+                FixedProfilePeriods.CurrentWeek => (WeekHVNEnabled, WeekHVNColor),
+                FixedProfilePeriods.LastWeek => (PrevWeekHVNEnabled, PrevWeekHVNColor),
+                FixedProfilePeriods.CurrentMonth => (MonthHVNEnabled, MonthHVNColor),
+                FixedProfilePeriods.LastMonth => (PrevMonthHVNEnabled, PrevMonthHVNColor),
+                FixedProfilePeriods.Contract => (ContractHVNEnabled, ContractHVNColor),
+                _ => (false, CrossColors.Transparent)
+            };
+
+            if (!enabled) continue;
+            if (!_hvnBands.TryGetValue(period, out var bands) || bands.Count == 0) continue;
+
+            foreach (var band in bands)
+            {
+                // compute the remaining (non-occluded) parts of this band
+                var leftovers = SubtractClaimed(band, claimed, tick);
+                foreach (var piece in leftovers)
+                {
+                    RenderBand(ctx, piece, color);
+                    // claim with occlusion tolerance
+                    claimed.Add((
+                        piece.Low - HVNOcclusionTicks * tick,
+                        piece.High + HVNOcclusionTicks * tick
+                    ));
+                }
+            }
+        }
+    }
+
+    private void RenderBand(RenderContext ctx, HVNBand band, CrossColor crossColor)
+    {
+        if (band.Low <= 0 || band.High <= 0) return;
+
+        var yHigh = ChartInfo.GetYByPrice(band.High, false);
+        var yLow = ChartInfo.GetYByPrice(band.Low, false);
+
+        var top = Math.Min(yHigh, yLow);
+        var bottom = Math.Max(yHigh, yLow);
+
+        // Only if visible
+        if (bottom < 0 || top > ChartInfo.PriceChartContainer.Region.Height)
+            return;
+
+        var w = ChartInfo.PriceChartContainer.Region.Width;
+        var drawTop = Math.Max(0, top);
+        var drawBot = Math.Min(ChartInfo.PriceChartContainer.Region.Height, bottom);
+        var drawH = Math.Max(1, drawBot - drawTop + 1);
+
+        var rect = new System.Drawing.Rectangle(0, drawTop, w, drawH);
+        ctx.FillRectangle(crossColor.Convert(), rect);
+    }
+
+    // Split a band by subtracting previously-claimed ranges (already expanded by occlusion tolerance).
+    // Returns the list of remaining sub-bands aligned to the tick grid.
+    private List<HVNBand> SubtractClaimed(HVNBand band, List<(decimal Lo, decimal Hi)> claimed, decimal tick)
+    {
+        // work list as simple (Lo, Hi) intervals
+        var segments = new List<(decimal Lo, decimal Hi)> { (band.Low, band.High) };
+
+        foreach (var r in claimed)
+        {
+            var next = new List<(decimal Lo, decimal Hi)>();
+
+            foreach (var s in segments)
+            {
+                // no overlap
+                if (r.Hi < s.Lo || r.Lo > s.Hi)
+                {
+                    next.Add(s);
+                    continue;
+                }
+
     #endregion
+                // overlap -> split into left/right remainders (if any), keeping tick alignment
+                if (r.Lo > s.Lo)
+                    next.Add((s.Lo, Math.Min(s.Hi, r.Lo - tick)));
+
+                if (r.Hi < s.Hi)
+                    next.Add((Math.Max(s.Lo, r.Hi + tick), s.Hi));
+            }
+
+            segments = next;
+            if (segments.Count == 0)
+                break;
+        }
+
+        return segments
+            .Where(seg => seg.Hi >= seg.Lo)
+            .Select(seg => new HVNBand { Low = seg.Lo, High = seg.Hi })
+            .ToList();
+    }
+
+
 
     #endregion
 }

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -200,6 +200,10 @@ public class OHLCPlus : Indicator
         FormatFlags = StringFormatFlags.NoWrap
     };
 
+    // Scoped display-prefix override for the current group render
+    private string? _scopedStoragePrefix = null;
+    private string? _scopedDisplayPrefix = null;
+
     #endregion
 
     #region Properties
@@ -1180,17 +1184,28 @@ public class OHLCPlus : Indicator
 
     // Maps the canonical storage prefix ("d", "p", "w", "pw", "m", "pm", "c")
     // to the user-configurable display prefix for visual labels.
-    private string DisplayPrefixFor(string storagePrefix) => storagePrefix switch
+    // NEW: respects a scoped override set by RenderLevelGroup.
+    private string DisplayPrefixFor(string storagePrefix)
     {
-        "d" => PrefixCurrentDay,
-        "p" => PrefixPrevDay,
-        "w" => PrefixCurrentWeek,
-        "pw" => PrefixPrevWeek,
-        "m" => PrefixCurrentMonth,
-        "pm" => PrefixPrevMonth,
-        "c" => PrefixContract,
-        _ => storagePrefix ?? string.Empty
-    };
+        // Scoped override: only applies while a group with this storagePrefix is rendering
+        if (!string.IsNullOrEmpty(_scopedStoragePrefix) &&
+            string.Equals(storagePrefix, _scopedStoragePrefix, StringComparison.Ordinal) &&
+            !string.IsNullOrEmpty(_scopedDisplayPrefix))
+            return _scopedDisplayPrefix!;
+
+        return storagePrefix switch
+        {
+            "d" => PrefixCurrentDay,
+            "p" => PrefixPrevDay,
+            "w" => PrefixCurrentWeek,
+            "pw" => PrefixPrevWeek,
+            "m" => PrefixCurrentMonth,
+            "pm" => PrefixPrevMonth,
+            "c" => PrefixContract,
+            _ => storagePrefix ?? string.Empty
+        };
+    }
+
 
     private void RenderLevel(RenderContext context, string levelKey, LevelSettings levelSettings)
     {
@@ -1325,14 +1340,30 @@ public class OHLCPlus : Indicator
         context.DrawString(text, _font, textColor, textRect, format);
     }
 
-    private void RenderLevelGroup(RenderContext context, string prefix, 
-        LevelSettings openLevel, LevelSettings highLevel, LevelSettings lowLevel, LevelSettings closeLevel,
-        LevelSettings eqLevel, LevelSettings pocLevel, LevelSettings vwapLevel, LevelSettings vahLevel, LevelSettings valLevel)
+    private void RenderLevelGroup(
+    RenderContext context,
+    string storagePrefix,
+    string displayPrefix, // NEW: user-configurable display prefix (UI)
+    LevelSettings openLevel,
+    LevelSettings highLevel,
+    LevelSettings lowLevel,
+    LevelSettings closeLevel,
+    LevelSettings eqLevel,
+    LevelSettings pocLevel,
+    LevelSettings vwapLevel,
+    LevelSettings vahLevel,
+    LevelSettings valLevel)
     {
-        var levels = new[]
+        // Activate scoped override for this group render
+        _scopedStoragePrefix = storagePrefix;
+        _scopedDisplayPrefix = displayPrefix;
+
+        try
         {
+            var levels = new[]
+            {
             ("Open", openLevel),
-            ("High", highLevel), 
+            ("High", highLevel),
             ("Low", lowLevel),
             ("Close", closeLevel),
             ("EQ", eqLevel),
@@ -1341,12 +1372,18 @@ public class OHLCPlus : Indicator
             ("VAH", vahLevel),
             ("VAL", valLevel)
         };
-        
-        foreach (var (suffix, levelSettings) in levels)
+
+            foreach (var (suffix, levelSettings) in levels)
+                RenderLevel(context, $"{storagePrefix}{suffix}", levelSettings);
+        }
+        finally
         {
-            RenderLevel(context, $"{prefix}{suffix}", levelSettings);
+            // Always clear the override after finishing this group
+            _scopedStoragePrefix = null;
+            _scopedDisplayPrefix = null;
         }
     }
+
 
     #region SubscribeAllLevels
 


### PR DESCRIPTION
# PR: Optimize fixed-profile requests by period (request previous* only once per rollover)

## Why
Reduce redundant `GetFixedProfile` calls:
- **Dynamic** profiles (`CurrentDay/Week/Month/Contract`) should still be requested whenever needed.
- **Static** profiles (`LastDay/LastWeek/LastMonth`) should be requested **once** and reused until the corresponding day/week/month rolls over.

## What
- Add a `_requestedStatic` cache to remember which *previous* profiles have already been fetched.
- Invalidate only the relevant cached entries on period rollovers detected in `OnCalculate`:
  - New session/day → invalidate `LastDay`
  - New ISO week → invalidate `LastWeek`
  - New month → invalidate `LastMonth`
- Introduce `RequestStaticOnce(...)` to request each *previous* profile exactly once per period.
- No changes to rendering logic, level structures, or UI behavior.

## Impact
- Fewer `GetFixedProfile` calls (notably during live trading and replay).
- No visible UI/UX changes.
- Maintains correctness across day/week/month boundaries.

## How it works
1. **Always** request needed dynamic profiles (`Current*`, `Contract`).
2. For *previous* profiles, call `RequestStaticOnce(period, needed)`; it invokes `GetFixedProfile` only if the period isn’t cached.
3. On rollover, remove only the affected period from `_requestedStatic` so it will be refreshed automatically on the next cycle.

## Tests
- Enable any *previous* level (e.g., `PrevDayPOCLevel.Enabled = true`):
  - `LastDay` is fetched once and fetched again only after a new session/day begins.
- Toggle *current* levels:
  - Requests proceed as before (no caching).
- Run in replay/live:
  - Observe a drop in `GetFixedProfile` calls for `Last*` periods while dynamic periods remain unchanged.

