### PR TITLE
fix(ClusterStatistic): correct Bid maxima and Delta/Volume maxima accumulation

### DIFF
--- a/Technical/ClusterStatistic.cs
+++ b/Technical/ClusterStatistic.cs
@@ -783,7 +783,7 @@ public class ClusterStatistic : Indicator
 		_maxSessionDelta = Math.Max(Math.Abs(_cDelta[bar]), _maxSessionDelta);
 
 		_maxAsk = Math.Max(candle.Ask, _maxAsk);
-		_maxBid = Math.Max(candle.Ask, _maxBid);
+		_maxBid = Math.Max(candle.Bid, _maxBid);
 
 		_maxDeltaChange = Math.Max(Math.Abs(candle.Delta - prevCandle.Delta), _maxDeltaChange);
 
@@ -798,7 +798,7 @@ public class ClusterStatistic : Indicator
 
 		_maxDeltaPerVolume = candle.Volume is 0
 			? 0
-			: Math.Max(Math.Abs(100 * candle.Delta / candle.Volume), _minDelta);
+			: Math.Max(Math.Abs(100 * candle.Delta / candle.Volume), _maxDeltaPerVolume);
 
 		var candleHeight = candle.High - candle.Low;
 		_maxHeight = Math.Max(candleHeight, _maxHeight);
@@ -1245,7 +1245,7 @@ public class ClusterStatistic : Indicator
 				maxVolume = Math.Max(candle.Volume, maxVolume);
 				minDelta = Math.Min(candle.MinDelta, minDelta);
 				maxAsk = Math.Max(candle.Ask, maxAsk);
-				maxBid = Math.Max(candle.Ask, maxBid);
+				maxBid = Math.Max(candle.Bid, maxBid);
 				maxMaxDelta = Math.Max(Math.Abs(candle.MaxDelta), maxMaxDelta);
 				maxMinDelta = Math.Max(Math.Abs(candle.MinDelta), maxMinDelta);
 				maxSessionDelta = Math.Max(Math.Abs(_cDelta[i]), maxSessionDelta);


### PR DESCRIPTION
### 🛠️ What
Fixes two logical errors in `ClusterStatistic`:
1. `_maxBid` was being updated with `Ask` instead of `Bid` in two locations.
2. `_maxDeltaPerVolume` was compared against `_minDelta` instead of its own previous maximum.

### 💡 Why
These fixes ensure correct accumulation of:
- **Bid maxima** during candle updates.
- **Delta/Volume% maxima** across bars.

Without these corrections, both bid extremes and delta/volume ratios could be understated or overstated.

### 🔍 Scope
- Minimal, isolated bugfix.
- No new parameters, enums, or UI changes.
- No behavioral side effects outside the intended corrections.

### ⚙️ Compatibility
- Fully backward-compatible.
- No impact on saved layouts or series names.

### 🧪 Testing
Verified in replay and live data:
- `maxBid` now tracks actual bid highs.
- `maxDeltaPerVolume` correctly reflects the historical maximum delta/volume ratio.

### 🔗 Reference
See previous commit for context:  
https://github.com/AtasPlatform/Indicators/pull/80/commits/9ee3626d24a1d21e0b4fc78cba92b88574a7749a