### PR TITLE
Feature/clusterstatistic peak delta per vol (stacked on 108)

### DIFF
--- a/Technical/ClusterStatistic.cs
+++ b/Technical/ClusterStatistic.cs
@@ -71,6 +71,7 @@ public class ClusterStatistic : Indicator
             Add(DataType.DeltaSecond, new RenderInfo(16));
             Add(DataType.PeakVolPerSec, new RenderInfo(17));
             Add(DataType.PeakDeltaPerSec, new RenderInfo(18));
+            Add(DataType.PeakDeltaPerVol, new RenderInfo(19));
         }
 
 		#endregion
@@ -170,6 +171,7 @@ public class ClusterStatistic : Indicator
 		public decimal MaxDeltaSec { get; set; }
         public decimal MaxPeakVolPerSec { get; set; }
         public decimal MaxPeakDeltaPerSec { get; set; }
+        public decimal MaxPeakDeltaPerVol { get; set; }
     }
 
 	public enum DataType
@@ -193,6 +195,7 @@ public class ClusterStatistic : Indicator
 		Duration,
         PeakVolPerSec,
         PeakDeltaPerSec,
+        PeakDeltaPerVol,
         None
 	}
 
@@ -223,6 +226,7 @@ public class ClusterStatistic : Indicator
     private readonly ValueDataSeries _peakDeltaPerSec = new("PeakDeltaPerSec");
     private readonly ValueDataSeries _peakVolAuto = new("MaxVol/sec AutoThr");
     private readonly ValueDataSeries _peakDeltaAuto = new("Delta@MaxVol AutoThr");
+    private readonly ValueDataSeries _peakDeltaPerVol = new("PeakDeltaPerVol");
 
 
     // --- SoT core state (historical + real-time) ---
@@ -547,6 +551,14 @@ public class ClusterStatistic : Indicator
     {
         get => RowsOrder.TryGetValue(DataType.PeakDeltaPerSec, out var ri) && ri.Enabled;
         set => RowsOrder.SetEnabled(DataType.PeakDeltaPerSec, value);
+    }
+
+    [DisplayName("Delta/Vol at Max vol/sec")]
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Rows), Order = 200)]
+    public bool ShowPeakDeltaPerVol
+    {
+        get => RowsOrder.TryGetValue(DataType.PeakDeltaPerVol, out var ri) && ri.Enabled;
+        set => RowsOrder.SetEnabled(DataType.PeakDeltaPerVol, value);
     }
 
     #endregion
@@ -1305,7 +1317,7 @@ public class ClusterStatistic : Indicator
             DataType.SessionDeltaVolume => Blend(_cDeltaPerVol[bar] > 0 ? AskColor : BidColor, BackGroundColor, rate),
 			DataType.SessionDelta => Blend(_cDelta[bar] > 0 ? AskColor : BidColor, BackGroundColor, rate),
 			DataType.DeltaChange => GetDeltaChangeBrush(candle, bar, rate),
-            DataType.PeakDeltaPerSec => Blend(_peakDeltaPerSec[bar] >= 0 ? AskColor : BidColor, BackGroundColor, rate),
+            DataType.PeakDeltaPerSec or DataType.PeakDeltaPerVol => Blend(_peakDeltaPerSec[bar] >= 0 ? AskColor : BidColor, BackGroundColor, rate),
             DataType.None => System.Drawing.Color.Transparent,
             _ => throw new ArgumentOutOfRangeException()
 		};
@@ -1329,6 +1341,14 @@ public class ClusterStatistic : Indicator
                 return GetRateByMean(v, _peakDeltaAuto[bar]);
             return GetRate(v, maxValues.MaxPeakDeltaPerSec);
         }
+
+        if (type == DataType.PeakDeltaPerVol)
+            {
+                var v = Math.Abs(_peakDeltaPerVol[bar]);
+                if (SotUseAutoFilter && _afCount > 0)
+                    return GetRateByMean(v, _peakDeltaAuto[bar] == 0m ? 0m : (_peakDeltaAuto[bar] / (_peakVolAuto[bar] == 0m ? 1m : _peakVolAuto[bar])));
+                return GetRate(v, maxValues.MaxPeakDeltaPerVol);
+            }
 
         return type switch
 		{
@@ -1376,6 +1396,7 @@ public class ClusterStatistic : Indicator
         decimal maxDeltaSec = 0m;
         decimal maxPeakVolPerSec = 0m;
         decimal maxPeakDeltaPerSec = 0m;
+        decimal maxPeakDeltaPerVol = 0m;
 
         if (VisibleProportion)
 		{
@@ -1402,6 +1423,7 @@ public class ClusterStatistic : Indicator
 
                 maxPeakVolPerSec = Math.Max(maxPeakVolPerSec, Math.Abs(_peakVolPerSec[i]));
                 maxPeakDeltaPerSec = Math.Max(maxPeakDeltaPerSec, Math.Abs(_peakDeltaPerSec[i]));
+                maxPeakDeltaPerVol = Math.Max(maxPeakDeltaPerVol, Math.Abs(_peakDeltaPerVol[i]));
 
                 if (i == 0)
 					continue;
@@ -1438,6 +1460,7 @@ public class ClusterStatistic : Indicator
                 maxDeltaSec = Math.Max(Math.Abs(_deltaPerSecond[i]), maxDeltaSec);
                 maxPeakVolPerSec = Math.Max(maxPeakVolPerSec, Math.Abs(_peakVolPerSec[i]));
                 maxPeakDeltaPerSec = Math.Max(maxPeakDeltaPerSec, Math.Abs(_peakDeltaPerSec[i]));
+                maxPeakDeltaPerVol = Math.Max(maxPeakDeltaPerVol, Math.Abs(_peakDeltaPerVol[i]));
             }
         }
 
@@ -1461,7 +1484,8 @@ public class ClusterStatistic : Indicator
 			MaxVolumeSec = maxVolumeSec,
             MaxDeltaSec = maxDeltaSec,
             MaxPeakVolPerSec = maxPeakVolPerSec,
-            MaxPeakDeltaPerSec = maxPeakDeltaPerSec
+            MaxPeakDeltaPerSec = maxPeakDeltaPerSec,
+            MaxPeakDeltaPerVol = maxPeakDeltaPerVol
         };
 	}
 
@@ -1488,6 +1512,7 @@ public class ClusterStatistic : Indicator
             DataType.DeltaSecond => ChartInfo.TryGetMinimizedVolumeString(_deltaPerSecond[bar]),
             DataType.PeakVolPerSec => ChartInfo.TryGetMinimizedVolumeString(_peakVolPerSec[bar]),
             DataType.PeakDeltaPerSec => ChartInfo.TryGetMinimizedVolumeString(_peakDeltaPerSec[bar]),
+            DataType.PeakDeltaPerVol => _peakDeltaPerVol[bar].ToString("+#0.00;-#0.00;0.00", CultureInfo.InvariantCulture),
             DataType.None => string.Empty,
 			_ => throw new ArgumentOutOfRangeException()
 		};
@@ -1578,6 +1603,7 @@ public class ClusterStatistic : Indicator
             DataType.DeltaSecond => "Delta/sec",
             DataType.PeakVolPerSec => "Max Vol/sec",
             DataType.PeakDeltaPerSec => "Delta at Max vol/sec",
+            DataType.PeakDeltaPerVol => "Delta/Vol Max vol/sec",
             DataType.None => string.Empty,
 
 			_ => throw new ArgumentOutOfRangeException()
@@ -1718,6 +1744,11 @@ public class ClusterStatistic : Indicator
             // Store peak-of-bar values (0 if no window met the minimum)
             _peakVolPerSec[bar] = Math.Round(peakTradesPerSec, 0);
             _peakDeltaPerSec[bar] = Math.Round(peakDeltaPerSec, 0);
+
+            _peakDeltaPerVol[bar] = _peakVolPerSec[bar] == 0m
+				? 0m
+				: (_peakDeltaPerSec[bar] / _peakVolPerSec[bar]);
+
             UpdateAutoFilterWithClosedBar(bar);
         }
     }
@@ -1765,6 +1796,10 @@ public class ClusterStatistic : Indicator
         // Write to Peak* series (rounded to int-like display like your UI)
         _peakVolPerSec[bar] = Math.Round(_rtPeakTradesPerSec, 0);
         _peakDeltaPerSec[bar] = Math.Round(_rtPeakDeltaPerSec, 0);
+
+        _peakDeltaPerVol[bar] = _peakVolPerSec[bar] == 0m
+			? 0m
+			: (_peakDeltaPerSec[bar] / _peakVolPerSec[bar]);
 
         // If bar changes, reset RT peaks for the next bar
         if (_lastBar != bar)

--- a/Technical/ClusterStatistic.cs
+++ b/Technical/ClusterStatistic.cs
@@ -783,7 +783,7 @@ public class ClusterStatistic : Indicator
 		_maxSessionDelta = Math.Max(Math.Abs(_cDelta[bar]), _maxSessionDelta);
 
 		_maxAsk = Math.Max(candle.Ask, _maxAsk);
-		_maxBid = Math.Max(candle.Ask, _maxBid);
+		_maxBid = Math.Max(candle.Bid, _maxBid);
 
 		_maxDeltaChange = Math.Max(Math.Abs(candle.Delta - prevCandle.Delta), _maxDeltaChange);
 
@@ -798,7 +798,7 @@ public class ClusterStatistic : Indicator
 
 		_maxDeltaPerVolume = candle.Volume is 0
 			? 0
-			: Math.Max(Math.Abs(100 * candle.Delta / candle.Volume), _minDelta);
+			: Math.Max(Math.Abs(100 * candle.Delta / candle.Volume), _maxDeltaPerVolume);
 
 		var candleHeight = candle.High - candle.Low;
 		_maxHeight = Math.Max(candleHeight, _maxHeight);
@@ -1245,7 +1245,7 @@ public class ClusterStatistic : Indicator
 				maxVolume = Math.Max(candle.Volume, maxVolume);
 				minDelta = Math.Min(candle.MinDelta, minDelta);
 				maxAsk = Math.Max(candle.Ask, maxAsk);
-				maxBid = Math.Max(candle.Ask, maxBid);
+				maxBid = Math.Max(candle.Bid, maxBid);
 				maxMaxDelta = Math.Max(Math.Abs(candle.MaxDelta), maxMaxDelta);
 				maxMinDelta = Math.Max(Math.Abs(candle.MinDelta), maxMinDelta);
 				maxSessionDelta = Math.Max(Math.Abs(_cDelta[i]), maxSessionDelta);

--- a/Technical/ClusterStatistic.cs
+++ b/Technical/ClusterStatistic.cs
@@ -68,7 +68,8 @@ public class ClusterStatistic : Indicator
 			Add(DataType.Height, new RenderInfo(13));
 			Add(DataType.Time, new RenderInfo(14));
 			Add(DataType.Duration, new RenderInfo(15));
-		}
+            Add(DataType.DeltaSecond, new RenderInfo(16));
+        }
 
 		#endregion
 
@@ -164,7 +165,8 @@ public class ClusterStatistic : Indicator
 		public decimal MaxHeight { get; set; }
 
 		public decimal MaxVolumeSec { get; set; }
-	}
+		public decimal MaxDeltaSec { get; set; }
+    }
 
 	public enum DataType
 	{
@@ -179,7 +181,8 @@ public class ClusterStatistic : Indicator
 		DeltaChange,
 		Volume,
 		VolumeSecond,
-		SessionVolume,
+        DeltaSecond,
+        SessionVolume,
 		Trades,
 		Height,
 		Time,
@@ -209,8 +212,9 @@ public class ClusterStatistic : Indicator
 	private readonly ValueDataSeries _cDeltaPerVol = new("DeltaPerVol");
 	private readonly ValueDataSeries _cVolume = new("cVolume");
 	private readonly ValueDataSeries _deltaPerVol = new("BarDeltaPerVol");
+    private readonly ValueDataSeries _deltaPerSecond = new("Delta/sec");
 
-	private readonly RenderStringFormat _stringLeftFormat = new()
+    private readonly RenderStringFormat _stringLeftFormat = new()
 	{
 		Alignment = StringAlignment.Near,
 		LineAlignment = StringAlignment.Center,
@@ -277,7 +281,8 @@ public class ClusterStatistic : Indicator
 	private bool _showTime;
 	private bool _showVolume;
 	private bool _showVolumePerSecond;
-	private System.Drawing.Color _textColor;
+    private bool _showDeltaPerSecond;
+    private System.Drawing.Color _textColor;
 	private string _tipText;
 
 	[Browsable(false)]
@@ -483,6 +488,19 @@ public class ClusterStatistic : Indicator
         {
             _showDuration = value;
             RowsOrder.SetEnabled(DataType.Duration, value);
+        }
+    }
+
+    [DisplayName("Delta/sec")]
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Rows),
+     Description = "Show Delta per second", Order = 197)]
+    public bool ShowDeltaPerSecond
+    {
+        get => _showDeltaPerSecond;
+        set
+        {
+            _showDeltaPerSecond = value;
+            RowsOrder.SetEnabled(DataType.DeltaSecond, value);
         }
     }
 
@@ -742,8 +760,9 @@ public class ClusterStatistic : Indicator
 			candleSeconds = 1;
 
 		_volPerSecond[bar] = candle.Volume / candleSeconds;
+        _deltaPerSecond[bar] = candle.Delta / candleSeconds;
 
-		if (bar == 0)
+        if (bar == 0)
 		{
 			_cumVolume = 0;
 			_maxVolume = 0;
@@ -1176,7 +1195,7 @@ public class ClusterStatistic : Indicator
 	{
 		return type switch
 		{
-			DataType.Ask or DataType.Bid or DataType.Delta or DataType.DeltaVolume =>
+			DataType.Ask or DataType.Bid or DataType.Delta or DataType.DeltaVolume or DataType.DeltaSecond =>
 				Blend(candle.Delta > 0 ? AskColor : BidColor, BackGroundColor, rate),
 
 			DataType.Volume or DataType.VolumeSecond or DataType.SessionVolume or
@@ -1206,7 +1225,8 @@ public class ClusterStatistic : Indicator
 			DataType.DeltaChange => GetRate(Math.Abs(candle.Delta - GetCandle(Math.Max(bar - 1, 0)).Delta), maxValues.MaxDeltaChange),
 			DataType.Volume => GetRate(candle.Volume, maxValues.MaxVolume),
 			DataType.VolumeSecond => GetRate(_volPerSecond[bar], maxValues.MaxVolumeSec),
-			DataType.SessionVolume => GetRate(_cVolume[bar], maxValues.CumVolume),
+            DataType.DeltaSecond => GetRate(Math.Abs(_deltaPerSecond[bar]), maxValues.MaxDeltaSec),
+            DataType.SessionVolume => GetRate(_cVolume[bar], maxValues.CumVolume),
 			DataType.Trades => GetRate(candle.Ticks, maxValues.MaxTicks),
 			DataType.Height => GetRate(_candleHeights[bar], maxValues.MaxHeight),
 			DataType.Time => GetRate(_cVolume[bar], maxValues.CumVolume),
@@ -1235,8 +1255,9 @@ public class ClusterStatistic : Indicator
 		var maxHeight = 0m;
 		var maxTicks = 0m;
 		var maxDuration = 0m;
+        decimal maxDeltaSec = 0m;
 
-		if (VisibleProportion)
+        if (VisibleProportion)
 		{
 			for (var i = FirstVisibleBarNumber; i <= LastVisibleBarNumber; i++)
 			{
@@ -1256,7 +1277,10 @@ public class ClusterStatistic : Indicator
 				maxSessionDeltaPerVolume = Math.Max(Math.Abs(_cDeltaPerVol[i]), maxSessionDeltaPerVolume);
 				cumVolume += candle.Volume;
 
-				if (i == 0)
+                // Absolute peak for Delta/sec over the visible range
+                maxDeltaSec = Math.Max(Math.Abs(_deltaPerSecond[i]), maxDeltaSec);
+
+                if (i == 0)
 					continue;
 
 				var prevCandle = GetCandle(i - 1);
@@ -1286,7 +1310,9 @@ public class ClusterStatistic : Indicator
 			maxDeltaChange = _maxDeltaChange;
 			maxHeight = _maxHeight;
 			maxVolumeSec = _volPerSecond.MAX(CurrentBar - 1, CurrentBar - 1);
-		}
+            for (int i = 0; i <= CurrentBar - 1; i++)
+                maxDeltaSec = Math.Max(Math.Abs(_deltaPerSecond[i]), maxDeltaSec);
+        }
 
 		return new MaxValues
 		{
@@ -1305,8 +1331,9 @@ public class ClusterStatistic : Indicator
 			CumVolume = cumVolume,
 			MaxDeltaChange = maxDeltaChange,
 			MaxHeight = maxHeight,
-			MaxVolumeSec = maxVolumeSec
-		};
+			MaxVolumeSec = maxVolumeSec,
+            MaxDeltaSec = maxDeltaSec
+        };
 	}
 
 	private string GetValueText(DataType type, IndicatorCandle candle, int bar)
@@ -1329,7 +1356,8 @@ public class ClusterStatistic : Indicator
 			DataType.Height => _candleHeights[bar].ToString(CultureInfo.InvariantCulture),
 			DataType.Time => candle.Time.AddHours(InstrumentInfo.TimeZone).ToString("HH:mm:ss"),
 			DataType.Duration => ((int)(candle.LastTime - candle.Time).TotalSeconds).ToString(),
-			DataType.None => string.Empty,
+            DataType.DeltaSecond => ChartInfo.TryGetMinimizedVolumeString(_deltaPerSecond[bar]),
+            DataType.None => string.Empty,
 			_ => throw new ArgumentOutOfRangeException()
 		};
 	}
@@ -1416,7 +1444,8 @@ public class ClusterStatistic : Indicator
 			DataType.Height => "Height",
 			DataType.Time => "Time",
 			DataType.Duration => "Duration",
-			DataType.None => string.Empty,
+            DataType.DeltaSecond => "Delta/sec",
+            DataType.None => string.Empty,
 
 			_ => throw new ArgumentOutOfRangeException()
 		};

--- a/Technical/ClusterStatistic.cs
+++ b/Technical/ClusterStatistic.cs
@@ -69,6 +69,8 @@ public class ClusterStatistic : Indicator
 			Add(DataType.Time, new RenderInfo(14));
 			Add(DataType.Duration, new RenderInfo(15));
             Add(DataType.DeltaSecond, new RenderInfo(16));
+            Add(DataType.PeakVolPerSec, new RenderInfo(17));
+            Add(DataType.PeakDeltaPerSec, new RenderInfo(18));
         }
 
 		#endregion
@@ -166,6 +168,8 @@ public class ClusterStatistic : Indicator
 
 		public decimal MaxVolumeSec { get; set; }
 		public decimal MaxDeltaSec { get; set; }
+        public decimal MaxPeakVolPerSec { get; set; }
+        public decimal MaxPeakDeltaPerSec { get; set; }
     }
 
 	public enum DataType
@@ -187,7 +191,9 @@ public class ClusterStatistic : Indicator
 		Height,
 		Time,
 		Duration,
-		None
+        PeakVolPerSec,
+        PeakDeltaPerSec,
+        None
 	}
 
 	#endregion
@@ -213,6 +219,8 @@ public class ClusterStatistic : Indicator
 	private readonly ValueDataSeries _cVolume = new("cVolume");
 	private readonly ValueDataSeries _deltaPerVol = new("BarDeltaPerVol");
     private readonly ValueDataSeries _deltaPerSecond = new("Delta/sec");
+    private readonly ValueDataSeries _peakVolPerSec = new("PeakVolPerSec");
+    private readonly ValueDataSeries _peakDeltaPerSec = new("PeakDeltaPerSec");
 
     private readonly RenderStringFormat _stringLeftFormat = new()
 	{
@@ -502,6 +510,22 @@ public class ClusterStatistic : Indicator
             _showDeltaPerSecond = value;
             RowsOrder.SetEnabled(DataType.DeltaSecond, value);
         }
+    }
+
+    [DisplayName("Max Vol/sec (peak)")]
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Rows), Order = 198)]
+    public bool ShowPeakVolPerSec
+    {
+        get => RowsOrder.TryGetValue(DataType.PeakVolPerSec, out var ri) && ri.Enabled;
+        set => RowsOrder.SetEnabled(DataType.PeakVolPerSec, value);
+    }
+
+    [DisplayName("Delta at Max vol/sec")]
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Rows), Order = 199)]
+    public bool ShowPeakDeltaPerSec
+    {
+        get => RowsOrder.TryGetValue(DataType.PeakDeltaPerSec, out var ri) && ri.Enabled;
+        set => RowsOrder.SetEnabled(DataType.PeakDeltaPerSec, value);
     }
 
     #endregion
@@ -1199,14 +1223,15 @@ public class ClusterStatistic : Indicator
 				Blend(candle.Delta > 0 ? AskColor : BidColor, BackGroundColor, rate),
 
 			DataType.Volume or DataType.VolumeSecond or DataType.SessionVolume or
-				DataType.Trades or DataType.Height or DataType.Time or DataType.Duration => Blend(VolumeColor, BackGroundColor, rate),
+				DataType.Trades or DataType.Height or DataType.Time or DataType.Duration or DataType.PeakVolPerSec => Blend(VolumeColor, BackGroundColor, rate),
 			DataType.MaxDelta => Blend(candle.MaxDelta > 0 ?  AskColor : BidColor, BackGroundColor, rate),
 			DataType.MinDelta => Blend(candle.MinDelta > 0 ?  AskColor : BidColor, BackGroundColor, rate),
             DataType.SessionDeltaVolume => Blend(_cDeltaPerVol[bar] > 0 ? AskColor : BidColor, BackGroundColor, rate),
 			DataType.SessionDelta => Blend(_cDelta[bar] > 0 ? AskColor : BidColor, BackGroundColor, rate),
 			DataType.DeltaChange => GetDeltaChangeBrush(candle, bar, rate),
-			DataType.None => System.Drawing.Color.Transparent,
-			_ => throw new ArgumentOutOfRangeException()
+            DataType.PeakDeltaPerSec => Blend(_peakDeltaPerSec[bar] >= 0 ? AskColor : BidColor, BackGroundColor, rate),
+            DataType.None => System.Drawing.Color.Transparent,
+            _ => throw new ArgumentOutOfRangeException()
 		};
 	}
 
@@ -1231,7 +1256,9 @@ public class ClusterStatistic : Indicator
 			DataType.Height => GetRate(_candleHeights[bar], maxValues.MaxHeight),
 			DataType.Time => GetRate(_cVolume[bar], maxValues.CumVolume),
 			DataType.Duration => GetRate(_candleDurations[bar], maxValues.MaxDuration),
-			DataType.None => 0,
+            DataType.PeakVolPerSec => GetRate(_peakVolPerSec[bar], maxValues.MaxPeakVolPerSec),
+            DataType.PeakDeltaPerSec => GetRate(Math.Abs(_peakDeltaPerSec[bar]), maxValues.MaxPeakDeltaPerSec),
+            DataType.None => 0,
 
 			_ => throw new ArgumentOutOfRangeException()
 		};
@@ -1256,6 +1283,8 @@ public class ClusterStatistic : Indicator
 		var maxTicks = 0m;
 		var maxDuration = 0m;
         decimal maxDeltaSec = 0m;
+        decimal maxPeakVolPerSec = 0m;
+        decimal maxPeakDeltaPerSec = 0m;
 
         if (VisibleProportion)
 		{
@@ -1279,6 +1308,9 @@ public class ClusterStatistic : Indicator
 
                 // Absolute peak for Delta/sec over the visible range
                 maxDeltaSec = Math.Max(Math.Abs(_deltaPerSecond[i]), maxDeltaSec);
+
+                maxPeakVolPerSec = Math.Max(maxPeakVolPerSec, Math.Abs(_peakVolPerSec[i]));
+                maxPeakDeltaPerSec = Math.Max(maxPeakDeltaPerSec, Math.Abs(_peakDeltaPerSec[i]));
 
                 if (i == 0)
 					continue;
@@ -1311,7 +1343,11 @@ public class ClusterStatistic : Indicator
 			maxHeight = _maxHeight;
 			maxVolumeSec = _volPerSecond.MAX(CurrentBar - 1, CurrentBar - 1);
             for (int i = 0; i <= CurrentBar - 1; i++)
+			{
                 maxDeltaSec = Math.Max(Math.Abs(_deltaPerSecond[i]), maxDeltaSec);
+                maxPeakVolPerSec = Math.Max(maxPeakVolPerSec, Math.Abs(_peakVolPerSec[i]));
+                maxPeakDeltaPerSec = Math.Max(maxPeakDeltaPerSec, Math.Abs(_peakDeltaPerSec[i]));
+            }
         }
 
 		return new MaxValues
@@ -1332,7 +1368,9 @@ public class ClusterStatistic : Indicator
 			MaxDeltaChange = maxDeltaChange,
 			MaxHeight = maxHeight,
 			MaxVolumeSec = maxVolumeSec,
-            MaxDeltaSec = maxDeltaSec
+            MaxDeltaSec = maxDeltaSec,
+            MaxPeakVolPerSec = maxPeakVolPerSec,
+            MaxPeakDeltaPerSec = maxPeakDeltaPerSec
         };
 	}
 
@@ -1357,6 +1395,8 @@ public class ClusterStatistic : Indicator
 			DataType.Time => candle.Time.AddHours(InstrumentInfo.TimeZone).ToString("HH:mm:ss"),
 			DataType.Duration => ((int)(candle.LastTime - candle.Time).TotalSeconds).ToString(),
             DataType.DeltaSecond => ChartInfo.TryGetMinimizedVolumeString(_deltaPerSecond[bar]),
+            DataType.PeakVolPerSec => ChartInfo.TryGetMinimizedVolumeString(_peakVolPerSec[bar]),
+            DataType.PeakDeltaPerSec => ChartInfo.TryGetMinimizedVolumeString(_peakDeltaPerSec[bar]),
             DataType.None => string.Empty,
 			_ => throw new ArgumentOutOfRangeException()
 		};
@@ -1445,6 +1485,8 @@ public class ClusterStatistic : Indicator
 			DataType.Time => "Time",
 			DataType.Duration => "Duration",
             DataType.DeltaSecond => "Delta/sec",
+            DataType.PeakVolPerSec => "Max Vol/sec",
+            DataType.PeakDeltaPerSec => "Delta at Max vol/sec",
             DataType.None => string.Empty,
 
 			_ => throw new ArgumentOutOfRangeException()

--- a/Technical/ClusterStatistic.cs
+++ b/Technical/ClusterStatistic.cs
@@ -221,6 +221,9 @@ public class ClusterStatistic : Indicator
     private readonly ValueDataSeries _deltaPerSecond = new("Delta/sec");
     private readonly ValueDataSeries _peakVolPerSec = new("PeakVolPerSec");
     private readonly ValueDataSeries _peakDeltaPerSec = new("PeakDeltaPerSec");
+    private readonly ValueDataSeries _peakVolAuto = new("MaxVol/sec AutoThr");
+    private readonly ValueDataSeries _peakDeltaAuto = new("Delta@MaxVol AutoThr");
+
 
     // --- SoT core state (historical + real-time) ---
     private List<CumulativeTrade> _allCumulativeTrades;     // historical storage
@@ -233,6 +236,12 @@ public class ClusterStatistic : Indicator
     // Per-live-bar peaks while the bar is forming
     private decimal _rtPeakTradesPerSec;    // trades/sec peak for the current live bar
     private decimal _rtPeakDeltaPerSec;     // delta/sec at the same window as trades/sec peak
+
+    // AutoFilter state
+    private int _afCount;
+    private decimal _afVol, _afDelta, _afVolEma, _afDeltaEma;
+    private readonly Queue<decimal> _afVolSma = new();
+    private readonly Queue<decimal> _afDeltaSma = new();
 
     private readonly RenderStringFormat _stringLeftFormat = new()
 	{
@@ -551,6 +560,49 @@ public class ClusterStatistic : Indicator
     [Display(Name = "Min Trades per Window", GroupName = "Max vol/sec", Order = 202)]
     [Range(1, 100000)]
     public int SotMinTrades { get; set; } = 150;
+
+    private bool _sotUseAutoFilter = true;
+    [Display(Name = "Use Auto Filter", GroupName = "Max vol/sec", Order = 203)]
+    public bool SotUseAutoFilter
+    {
+        get => _sotUseAutoFilter;
+        set
+        {
+            if (_sotUseAutoFilter == value) return;
+            _sotUseAutoFilter = value;
+            ResetAutoFilter();
+            RebuildHistoricalSoT();
+        }
+    }
+
+    private int _sotAutoFilterPeriod = 3;
+    [Display(Name = "Auto Filter Period", GroupName = "Max vol/sec", Order = 204)]
+    [Range(1, 200)]
+    public int SotAutoFilterPeriod
+    {
+        get => _sotAutoFilterPeriod;
+        set
+        {
+            _sotAutoFilterPeriod = value;
+            ResetAutoFilter();
+            RebuildHistoricalSoT();
+        }
+    }
+
+    private bool _sotAutoFilterUseEma = true;
+    [Display(Name = "Auto Filter = EMA (off=SMA)", GroupName = "Max vol/sec", Order = 205)]
+    public bool SotAutoFilterUseEma
+    {
+        get => _sotAutoFilterUseEma;
+        set
+        {
+            if (_sotAutoFilterUseEma == value) return;
+            _sotAutoFilterUseEma = value;
+            ResetAutoFilter();
+            RebuildHistoricalSoT();
+        }
+    }
+
 
     #endregion
 
@@ -1261,7 +1313,24 @@ public class ClusterStatistic : Indicator
 
 	private decimal GetRate(MaxValues maxValues, DataType type, IndicatorCandle candle, int bar)
 	{
-		return type switch
+
+        if (type == DataType.PeakVolPerSec)
+        {
+            var v = Math.Abs(_peakVolPerSec[bar]);
+            if (SotUseAutoFilter && _afCount > 0)
+                return GetRateByMean(v, _peakVolAuto[bar]); // v vs threshold
+            return GetRate(v, maxValues.MaxPeakVolPerSec); // fallback: visible max scaling
+        }
+
+        if (type == DataType.PeakDeltaPerSec)
+        {
+            var v = Math.Abs(_peakDeltaPerSec[bar]);
+            if (SotUseAutoFilter && _afCount > 0)
+                return GetRateByMean(v, _peakDeltaAuto[bar]);
+            return GetRate(v, maxValues.MaxPeakDeltaPerSec);
+        }
+
+        return type switch
 		{
 			DataType.Ask => GetRate(candle.Ask, maxValues.MaxAsk),
 			DataType.Bid => GetRate(candle.Bid, maxValues.MaxBid),
@@ -1280,8 +1349,6 @@ public class ClusterStatistic : Indicator
 			DataType.Height => GetRate(_candleHeights[bar], maxValues.MaxHeight),
 			DataType.Time => GetRate(_cVolume[bar], maxValues.CumVolume),
 			DataType.Duration => GetRate(_candleDurations[bar], maxValues.MaxDuration),
-            DataType.PeakVolPerSec => GetRate(_peakVolPerSec[bar], maxValues.MaxPeakVolPerSec),
-            DataType.PeakDeltaPerSec => GetRate(Math.Abs(_peakDeltaPerSec[bar]), maxValues.MaxPeakDeltaPerSec),
             DataType.None => 0,
 
 			_ => throw new ArgumentOutOfRangeException()
@@ -1540,9 +1607,11 @@ public class ClusterStatistic : Indicator
 		var b = (byte)(color.B + (backColor.B - color.B) * (1 - amount * 0.01m));
 		return System.Drawing.Color.FromArgb(_bgAlpha, r, g, b);
 	}
-
+    #region Peak Vol/sec helpers
     protected override void OnFinishRecalculate()
     {
+        ResetAutoFilter();
+
         // Clear RT window state when a full recalc completes
         _liveQueue.Clear();
         _winTrades = 0;
@@ -1564,6 +1633,8 @@ public class ClusterStatistic : Indicator
 
     protected override void OnCumulativeTradesResponse(CumulativeTradesRequest request, IEnumerable<CumulativeTrade> cumulativeTrades)
     {
+        ResetAutoFilter();
+
         // Store and rebuild the SoT peaks over history
         _allCumulativeTrades = cumulativeTrades?.ToList() ?? new List<CumulativeTrade>();
         RebuildHistoricalSoT();
@@ -1647,6 +1718,7 @@ public class ClusterStatistic : Indicator
             // Store peak-of-bar values (0 if no window met the minimum)
             _peakVolPerSec[bar] = Math.Round(peakTradesPerSec, 0);
             _peakDeltaPerSec[bar] = Math.Round(peakDeltaPerSec, 0);
+            UpdateAutoFilterWithClosedBar(bar);
         }
     }
 
@@ -1706,6 +1778,71 @@ public class ClusterStatistic : Indicator
 
         _lastBar = bar;
     }
+    #endregion
+
+    #region AutoFilter helpers
+    private void UpdateAutoFilterWithClosedBar(int bar)
+    {
+        if (!SotUseAutoFilter) return;
+
+        var vAbs = Math.Abs(_peakVolPerSec[bar]);
+        var dAbs = Math.Abs(_peakDeltaPerSec[bar]);
+
+        if (SotAutoFilterUseEma)
+        {
+            var p = Math.Max(1, SotAutoFilterPeriod);
+            var alpha = 2m / (p + 1m);
+            _afVolEma = _afCount == 0 ? vAbs : (alpha * vAbs + (1m - alpha) * _afVolEma);
+            _afDeltaEma = _afCount == 0 ? dAbs : (alpha * dAbs + (1m - alpha) * _afDeltaEma);
+            _afVol = _afVolEma;
+            _afDelta = _afDeltaEma;
+        }
+        else
+        {
+            var p = Math.Max(1, SotAutoFilterPeriod);
+            _afVolSma.Enqueue(vAbs);
+            _afDeltaSma.Enqueue(dAbs);
+            if (_afVolSma.Count > p) _afVolSma.Dequeue();
+            if (_afDeltaSma.Count > p) _afDeltaSma.Dequeue();
+
+            _afVol = _afVolSma.Average();
+            _afDelta = _afDeltaSma.Average();
+        }
+
+        _afCount++;
+        _peakVolAuto[bar] = _afVol;
+        _peakDeltaAuto[bar] = _afDelta;
+    }
+
+    private void ResetAutoFilter()
+    {
+        _afCount = 0;
+        _afVol = _afDelta = _afVolEma = _afDeltaEma = 0m;
+        _afVolSma.Clear();
+        _afDeltaSma.Clear();
+        for (int i = 0; i < CurrentBar; i++)
+        {
+            _peakVolAuto[i] = 0m;
+            _peakDeltaAuto[i] = 0m;
+        }
+    }
+
+    // Escalado 10..100 usando "cuánto por encima/debajo" de la media está el valor
+    private decimal GetRateByMean(decimal value, decimal mean)
+    {
+        if (mean <= 0m) return 10m;
+        var r = value / mean;              // >= 0
+        var gamma = 1.35m;                 // >1: enfatiza valores altos
+        r = (decimal)Math.Pow((double)r, (double)gamma);
+
+        const decimal lo = 0.85m, hi = 1.35m;
+        if (r <= lo) return 10m;
+        if (r >= hi) return 100m;
+        return 10m + (r - lo) * (90m / (hi - lo));
+    }
+
+    #endregion
+
 
 
 

--- a/Technical/ClusterStatistic.cs
+++ b/Technical/ClusterStatistic.cs
@@ -222,6 +222,18 @@ public class ClusterStatistic : Indicator
     private readonly ValueDataSeries _peakVolPerSec = new("PeakVolPerSec");
     private readonly ValueDataSeries _peakDeltaPerSec = new("PeakDeltaPerSec");
 
+    // --- SoT core state (historical + real-time) ---
+    private List<CumulativeTrade> _allCumulativeTrades;     // historical storage
+    private readonly Queue<CumulativeTrade> _liveQueue = new(); // sliding RT window
+
+    // Sliding-window aggregates for RT
+    private int _winTrades;                 // number of executions (sum of Ticks.Count)
+    private decimal _winDelta;              // signed delta (buy vol - sell vol)
+
+    // Per-live-bar peaks while the bar is forming
+    private decimal _rtPeakTradesPerSec;    // trades/sec peak for the current live bar
+    private decimal _rtPeakDeltaPerSec;     // delta/sec at the same window as trades/sec peak
+
     private readonly RenderStringFormat _stringLeftFormat = new()
 	{
 		Alignment = StringAlignment.Near,
@@ -527,6 +539,18 @@ public class ClusterStatistic : Indicator
         get => RowsOrder.TryGetValue(DataType.PeakDeltaPerSec, out var ri) && ri.Enabled;
         set => RowsOrder.SetEnabled(DataType.PeakDeltaPerSec, value);
     }
+
+    #endregion
+
+    #region Max vol/sec settings
+
+    [Display(Name = "Time Window (sec)", GroupName = "Max vol/sec", Order = 201)]
+    [Range(1, 600)]
+    public int SotTimeWindowSec { get; set; } = 5;
+
+    [Display(Name = "Min Trades per Window", GroupName = "Max vol/sec", Order = 202)]
+    [Range(1, 100000)]
+    public int SotMinTrades { get; set; } = 150;
 
     #endregion
 
@@ -1517,5 +1541,173 @@ public class ClusterStatistic : Indicator
 		return System.Drawing.Color.FromArgb(_bgAlpha, r, g, b);
 	}
 
-	#endregion
+    protected override void OnFinishRecalculate()
+    {
+        // Clear RT window state when a full recalc completes
+        _liveQueue.Clear();
+        _winTrades = 0;
+        _winDelta = 0m;
+        _rtPeakTradesPerSec = 0m;
+        _rtPeakDeltaPerSec = 0m;
+
+        if (CurrentBar <= 0)
+            return;
+
+        // Request historical cumulative trades for the loaded range
+        var startTime = GetCandle(0).Time;
+        var endTime = GetCandle(CurrentBar - 1).LastTime;
+
+        // 0,0 means "no size filter" — ask for all trades
+        var request = new CumulativeTradesRequest(startTime, endTime, 0, 0);
+        RequestForCumulativeTrades(request);
+    }
+
+    protected override void OnCumulativeTradesResponse(CumulativeTradesRequest request, IEnumerable<CumulativeTrade> cumulativeTrades)
+    {
+        // Store and rebuild the SoT peaks over history
+        _allCumulativeTrades = cumulativeTrades?.ToList() ?? new List<CumulativeTrade>();
+        RebuildHistoricalSoT();
+    }
+
+    // Recompute SoT peaks (trades/sec peak inside each bar and its delta/sec) using historical cumulative trades
+    private void RebuildHistoricalSoT()
+    {
+        if (_allCumulativeTrades == null || _allCumulativeTrades.Count == 0 || CurrentBar <= 0)
+            return;
+
+        // Optional: clear Peak* series before full rebuild
+        for (int i = 0; i < CurrentBar; i++)
+        {
+            _peakVolPerSec[i] = 0m;
+            _peakDeltaPerSec[i] = 0m;
+        }
+
+        var q = new Queue<CumulativeTrade>();
+        int tradeIdx = 0;
+
+        // Sliding-window aggregates
+        int winTrades = 0;
+        decimal winDelta = 0m;
+
+        // Iterate bars chronologically
+        for (int bar = 0; bar < CurrentBar; bar++)
+        {
+            var c = GetCandle(bar);
+            var barStart = c.Time;
+            var barEnd = c.LastTime;
+
+            // Reset per-bar peaks
+            decimal peakTradesPerSec = 0m;
+            decimal peakDeltaPerSec = 0m;
+
+            // Move cursor to this bar's start
+            while (tradeIdx < _allCumulativeTrades.Count && _allCumulativeTrades[tradeIdx].Time < barStart)
+                tradeIdx++;
+
+            int j = tradeIdx;
+
+            // Walk through trades within this bar's time
+            while (j < _allCumulativeTrades.Count && _allCumulativeTrades[j].Time <= barEnd)
+            {
+                var t = _allCumulativeTrades[j++];
+                q.Enqueue(t);
+
+                // Count number of executions in this bundle; fallback to 1 if null
+                int ticksCount = (t.Ticks != null ? t.Ticks.Count : 1);
+                winTrades += ticksCount;
+
+                // Signed delta using Direction
+                winDelta += (t.Direction == TradeDirection.Buy ? t.Volume : -t.Volume);
+
+                // Slide the window: drop trades older than T seconds from current trade time
+                var cutoff = t.Time.AddSeconds(-SotTimeWindowSec);
+                while (q.Count > 0 && q.Peek().Time <= cutoff)
+                {
+                    var u = q.Dequeue();
+                    int uTicks = (u.Ticks != null ? u.Ticks.Count : 1);
+                    winTrades -= uTicks;
+                    winDelta -= (u.Direction == TradeDirection.Buy ? u.Volume : -u.Volume);
+                }
+
+                // Evaluate if window meets the minimum trade count
+                if (winTrades >= SotMinTrades)
+                {
+                    var tradesPerSec = (decimal)winTrades / SotTimeWindowSec; // SoT Vol/sec
+                    var deltaPerSec = winDelta / SotTimeWindowSec;            // SoT Delta/sec (same window)
+
+                    // Keep delta/sec from the window with the greatest trades/sec (break ties by higher vol/sec)
+                    if (tradesPerSec > peakTradesPerSec)
+                    {
+                        peakTradesPerSec = tradesPerSec;
+                        peakDeltaPerSec = deltaPerSec;
+                    }
+                }
+            }
+
+            // Store peak-of-bar values (0 if no window met the minimum)
+            _peakVolPerSec[bar] = Math.Round(peakTradesPerSec, 0);
+            _peakDeltaPerSec[bar] = Math.Round(peakDeltaPerSec, 0);
+        }
+    }
+
+    // Called by the platform for each incoming cumulative trade in real-time
+    protected override void OnCumulativeTrade(CumulativeTrade trade)
+    {
+        if (trade == null || trade.Volume <= 0)
+            return;
+
+        var bar = CurrentBar - 1;
+        if (bar < 0)
+            return;
+
+        // Maintain a sliding window of last SotTimeWindowSec seconds
+        _liveQueue.Enqueue(trade);
+
+        int ticksCount = (trade.Ticks != null ? trade.Ticks.Count : 1);
+        _winTrades += ticksCount;
+        _winDelta += (trade.Direction == TradeDirection.Buy ? trade.Volume : -trade.Volume);
+
+        // Remove outdated trades (older than T seconds from current trade time)
+        var cutoff = trade.Time.AddSeconds(-SotTimeWindowSec);
+        while (_liveQueue.Count > 0 && _liveQueue.Peek().Time <= cutoff)
+        {
+            var old = _liveQueue.Dequeue();
+            int oldTicks = (old.Ticks != null ? old.Ticks.Count : 1);
+            _winTrades -= oldTicks;
+            _winDelta -= (old.Direction == TradeDirection.Buy ? old.Volume : -old.Volume);
+        }
+
+        // Only compute/update peaks if the window meets the minimum trades
+        if (_winTrades >= SotMinTrades)
+        {
+            var tradesPerSec = (decimal)_winTrades / SotTimeWindowSec;
+            var deltaPerSec = _winDelta / SotTimeWindowSec;
+
+            if (tradesPerSec > _rtPeakTradesPerSec)
+            {
+                _rtPeakTradesPerSec = tradesPerSec;
+                _rtPeakDeltaPerSec = deltaPerSec;
+            }
+        }
+
+        // Write to Peak* series (rounded to int-like display like your UI)
+        _peakVolPerSec[bar] = Math.Round(_rtPeakTradesPerSec, 0);
+        _peakDeltaPerSec[bar] = Math.Round(_rtPeakDeltaPerSec, 0);
+
+        // If bar changes, reset RT peaks for the next bar
+        if (_lastBar != bar)
+        {
+            _rtPeakTradesPerSec = 0m;
+            _rtPeakDeltaPerSec = 0m;
+            _winTrades = 0;
+            _winDelta = 0m;
+            _liveQueue.Clear();
+        }
+
+        _lastBar = bar;
+    }
+
+
+
+    #endregion
 }


### PR DESCRIPTION
# feat(ClusterStatistic): add PeakDeltaPerVol (Delta/Vol at max vol/sec) with optional mean-based scaling

## Summary
This PR introduces **PeakDeltaPerVol** — the ratio `Delta/Vol` computed **at the same window** where `PeakVolPerSec` (max trades/sec) is found.  
It complements the existing peak rows and supports **mean-based scaling** (EMA/SMA) through the auto-filter added in PR #108.

---

## What’s included
- **New data row & series**
  - `DataType.PeakDeltaPerVol` (appended at the end; no reorder)
  - Backing series `_peakDeltaPerVol`
- **Calculation**
  - Per bar: `PeakDeltaPerVol = PeakDeltaPerSec / PeakVolPerSec` (0 when denominator is 0)
  - Updated in both:
    - Historical rebuild (`RebuildHistoricalSoT`)
    - Real-time (`OnCumulativeTrade`)
- **Rendering**
  - Header: **"Delta/Vol Max vol/sec"**
  - Value format: `+#0.00;-#0.00;0.00`
  - Coloring: AskColor when `>= 0`; BidColor when `< 0` (same convention as `PeakDeltaPerSec`)
  - Scaling:
    - If `SotUseAutoFilter` is ON and baselines exist, use mean-based scaling:
      - `GetRateByMean(value, meanDeltaPerVol)` where `meanDeltaPerVol = peakDeltaMean / max(1, peakVolMean)`
    - Else, fall back to max-based scaling (`MaxPeakDeltaPerVol`)
- **Max trackers**
  - `MaxPeakDeltaPerVol` added to the `MaxValues` struct and populated in `CreateMaxValues`

---

## Motivation
Traders often want the **efficiency** of a burst, not only its raw speed.  
`PeakDeltaPerVol` shows **how directional** the burst was *relative to its size*, within the micro-window that defines the bar’s maximum tape velocity.

---

## Backward compatibility
- ✅ **No breaking changes**: row is appended; existing indices remain intact
- ✅ Defaults OFF; visuals unchanged unless the new row is enabled

---

## Performance
- Minimal overhead: the ratio is computed when peaks are updated
- Reuses existing SoT peak detection and auto-filter baselines (PR #107 / PR #108)

---

## How to use
1. Enable **Max Vol/sec (peak)** and **Delta at Max vol/sec**.
2. Enable **Delta/Vol Max vol/sec** (this new row).
3. In *Max vol/sec* settings:
   - Toggle **Use Auto Filter** to normalize by recent means (EMA/SMA)  
     or disable it to scale by maxima.

---

## Testing steps
1. With active data, enable the three rows: PeakVolPerSec, PeakDeltaPerSec, PeakDeltaPerVol.
2. Verify:
   - `PeakDeltaPerVol ≈ PeakDeltaPerSec / PeakVolPerSec` (0 if `PeakVolPerSec == 0`).
   - Coloring sign matches `PeakDeltaPerSec`.
3. Toggle **Use Auto Filter** on/off and compare the heat scaling behavior.
4. Change period/type (EMA vs. SMA) and confirm stability vs. responsiveness.

---

## Implementation notes
- Enum: `DataType.PeakDeltaPerVol`
- Series: `_peakDeltaPerVol`
- RenderOrder: appended at the end
- `GetHeader`: `"Delta/Vol Max vol/sec"`
- `GetValueText`: signed decimal (two decimals)
- `GetBrush`: Ask/Bid by sign of `PeakDeltaPerSec`
- `GetRate`:
  - Mean scaling via `GetRateByMean(value, peakDeltaMean / max(1, peakVolMean))` when auto-filter is ON
  - Otherwise, `GetRate(value, MaxPeakDeltaPerVol)`

---

## Screenshot

<img width="866" height="207" alt="image" src="https://github.com/user-attachments/assets/2813040d-65a5-4235-ae98-21edaadbf459" />

