### PR TITLE
Feature/cluster statistic: basic footprint imbalances (buy/sell/net) + optional Net alert (on top #118)

### DIFF
--- a/Technical/ClusterStatistic.cs
+++ b/Technical/ClusterStatistic.cs
@@ -72,6 +72,9 @@ public class ClusterStatistic : Indicator
             Add(DataType.PeakVolPerSec, new RenderInfo(17));
             Add(DataType.PeakDeltaPerSec, new RenderInfo(18));
             Add(DataType.PeakDeltaPerVol, new RenderInfo(19));
+            Add(DataType.BuyImbalance, new RenderInfo(20));
+            Add(DataType.SellImbalance, new RenderInfo(21));
+            Add(DataType.NetImbalance, new RenderInfo(22));
         }
 
 		#endregion
@@ -172,6 +175,9 @@ public class ClusterStatistic : Indicator
         public decimal MaxPeakVolPerSec { get; set; }
         public decimal MaxPeakDeltaPerSec { get; set; }
         public decimal MaxPeakDeltaPerVol { get; set; }
+        public int MaxBuyImb { get; set; }
+        public int MaxSellImb { get; set; }
+        public int MaxNetImb { get; set; }
     }
 
 	public enum DataType
@@ -196,6 +202,9 @@ public class ClusterStatistic : Indicator
         PeakVolPerSec,
         PeakDeltaPerSec,
         PeakDeltaPerVol,
+        BuyImbalance,
+        SellImbalance,
+        NetImbalance,
         None
 	}
 
@@ -227,6 +236,9 @@ public class ClusterStatistic : Indicator
     private readonly ValueDataSeries _peakDeltaPerVol = new("Delta/Vol at Max vol/sec");
     private readonly ValueDataSeries _peakVolAuto = new("MaxVol/sec AutoThr");
     private readonly ValueDataSeries _peakDeltaAuto = new("Delta@MaxVol AutoThr");
+    private readonly ValueDataSeries _buyImbalance = new("BuyImbalance");
+    private readonly ValueDataSeries _sellImbalance = new("SellImbalance");
+    private readonly ValueDataSeries _netImbalance = new("NetImbalance");
 
     // --- SoT core state (historical) ---
     private List<CumulativeTrade> _allCumulativeTrades;
@@ -263,6 +275,9 @@ public class ClusterStatistic : Indicator
     private decimal _afVol, _afDelta, _afVolEma, _afDeltaEma;
     private readonly Queue<decimal> _afVolSma = new();
     private readonly Queue<decimal> _afDeltaSma = new();
+
+    // Net Imbalance alert state
+    private int _lastNetImbalanceAlert;
 
     private readonly RenderStringFormat _stringLeftFormat = new()
 	{
@@ -578,6 +593,30 @@ public class ClusterStatistic : Indicator
         set => RowsOrder.SetEnabled(DataType.PeakDeltaPerVol, value);
     }
 
+    [DisplayName("Buy Imbalances")]
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Rows), Order = 201)]
+    public bool ShowBuyImbalance
+    {
+        get => RowsOrder.TryGetValue(DataType.BuyImbalance, out var ri) && ri.Enabled;
+        set => RowsOrder.SetEnabled(DataType.BuyImbalance, value);
+    }
+
+    [DisplayName("Sell Imbalances")]
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Rows), Order = 202)]
+    public bool ShowSellImbalance
+    {
+        get => RowsOrder.TryGetValue(DataType.SellImbalance, out var ri) && ri.Enabled;
+        set => RowsOrder.SetEnabled(DataType.SellImbalance, value);
+    }
+
+    [DisplayName("Net Imbalances")]
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Rows), Order = 203)]
+    public bool ShowNetImbalance
+    {
+        get => RowsOrder.TryGetValue(DataType.NetImbalance, out var ri) && ri.Enabled;
+        set => RowsOrder.SetEnabled(DataType.NetImbalance, value);
+    }
+
     #endregion
 
     #region Max vol/sec settings
@@ -661,6 +700,18 @@ public class ClusterStatistic : Indicator
         }
     }
 
+
+    #endregion
+
+    #region Imbalance settings
+
+    [Display(Name = "Imbalance Threshold (%)", GroupName = "Imbalance", Order = 300)]
+    [Range(101, 999)]
+    public int ImbalanceThreshold { get; set; } = 300;
+
+    [Display(Name = "Imbalance Volume Filter", GroupName = "Imbalance", Order = 310)]
+    [Range(1, 100000)]
+    public int ImbalanceVolumeFilter { get; set; } = 30;
 
     #endregion
 
@@ -787,6 +838,20 @@ public class ClusterStatistic : Indicator
         Description = nameof(Strings.AlertFileDescription), Order = 520)]
     public string DeltaAlertFile { get; set; } = "alert1";
 
+    #endregion
+
+    #region Net Imbalance alert
+    [Display(Name = "Enabled", GroupName = "Net Imbalance Alert", Order = 600)]
+    public bool UseNetImbalanceAlert { get; set; }
+
+    [Display(Name = "Filter", GroupName = "Net Imbalance Alert", Order = 610)]
+    public int NetImbalanceAlertValue { get; set; }
+
+    [Display(Name = "Use closed candle", GroupName = "Net Imbalance Alert", Order = 620)]
+    public bool UseClosedCandleForNetImbalanceAlert { get; set; }
+
+    [Display(Name = "Alert File", GroupName = "Net Imbalance Alert", Order = 630)]
+    public string NetImbalanceAlertFile { get; set; } = "alert1";
     #endregion
 
     #endregion
@@ -1104,9 +1169,49 @@ public class ClusterStatistic : Indicator
 		_lastVolumeValue = candle.Volume;
 		_lastDeltaValue = candle.Delta;
 		_lastBar = bar;
-	}
 
-	protected override void OnRender(RenderContext context, DrawingLayouts layout)
+        // --- Basic footprint imbalances (Buy/Sell/Net) ---
+        int buy = 0, sell = 0;
+
+        decimal ratio = ImbalanceThreshold / 100m;
+        int volumeMin = ImbalanceVolumeFilter;
+
+        for (decimal price = candle.High; price >= candle.Low + InstrumentInfo.TickSize; price -= InstrumentInfo.TickSize)
+        {
+            var upper = candle.GetPriceVolumeInfo(price);
+            var lower = candle.GetPriceVolumeInfo(price - InstrumentInfo.TickSize);
+            if (upper == null || lower == null) continue;
+
+            // BUY imbalance: Ask(upper) vs Bid(lower)
+            if (lower.Bid > 0 && upper.Ask / lower.Bid >= ratio && upper.Ask - lower.Bid >= volumeMin)
+                buy++;
+            // SELL imbalance: Bid(lower) vs Ask(upper)
+            else if (upper.Ask > 0 && lower.Bid / upper.Ask >= ratio && lower.Bid - upper.Ask >= volumeMin)
+                sell++;
+        }
+
+        _buyImbalance[bar] = buy;
+        _sellImbalance[bar] = sell;
+        _netImbalance[bar] = buy - sell;
+
+        // Optional Net alert
+        if (bar == CurrentBar - 1 && UseNetImbalanceAlert)
+        {
+            int alertBar = UseClosedCandleForNetImbalanceAlert ? bar - 1 : bar;
+            if (alertBar >= 0 && _lastNetImbalanceAlert != alertBar)
+            {
+                var net = _netImbalance[alertBar];
+                if (net >= NetImbalanceAlertValue || net <= -NetImbalanceAlertValue)
+                {
+                    AddAlert(NetImbalanceAlertFile, $"Cluster statistic Net Imbalance alert: {net}");
+                    _lastNetImbalanceAlert = alertBar;
+                }
+            }
+        }
+
+    }
+
+    protected override void OnRender(RenderContext context, DrawingLayouts layout)
 	{
 		if (ChartInfo is not { PriceChartContainer.BarsWidth: > 2 })
 			return;
@@ -1447,8 +1552,13 @@ public class ClusterStatistic : Indicator
 			DataType.DeltaChange => GetDeltaChangeBrush(candle, bar, rate),
             DataType.PeakDeltaPerSec or DataType.PeakDeltaPerVol => Blend(_peakDeltaPerSec[bar] >= 0 ? AskColor : BidColor, BackGroundColor, rate),
             DataType.None => System.Drawing.Color.Transparent,
+			DataType.BuyImbalance => Blend(AskColor, BackGroundColor, rate),
+			DataType.SellImbalance => Blend(BidColor, BackGroundColor, rate),
+			DataType.NetImbalance => Blend(_netImbalance[bar] >= 0 ? AskColor : BidColor, BackGroundColor, rate),
             _ => throw new ArgumentOutOfRangeException()
-		};
+
+        }
+        ;
 	}
 
 	private decimal GetRate(MaxValues maxValues, DataType type, IndicatorCandle candle, int bar)
@@ -1497,6 +1607,9 @@ public class ClusterStatistic : Indicator
 			DataType.Height => GetRate(_candleHeights[bar], maxValues.MaxHeight),
 			DataType.Time => GetRate(_cVolume[bar], maxValues.CumVolume),
 			DataType.Duration => GetRate(_candleDurations[bar], maxValues.MaxDuration),
+            DataType.BuyImbalance => GetRate(_buyImbalance[bar], maxValues.MaxBuyImb),
+            DataType.SellImbalance => GetRate(_sellImbalance[bar], maxValues.MaxSellImb),
+            DataType.NetImbalance => GetRate(Math.Abs(_netImbalance[bar]), maxValues.MaxNetImb),
             DataType.None => 0,
 
 			_ => throw new ArgumentOutOfRangeException()
@@ -1525,6 +1638,7 @@ public class ClusterStatistic : Indicator
         decimal maxPeakVolPerSec = 0m;
         decimal maxPeakDeltaPerSec = 0m;
         decimal maxPeakDeltaPerVol = 0m;
+        int maxBuy = 0, maxSell = 0, maxNet = 0;
 
         if (VisibleProportion)
 		{
@@ -1552,6 +1666,9 @@ public class ClusterStatistic : Indicator
                 maxPeakVolPerSec = Math.Max(maxPeakVolPerSec, Math.Abs(_peakVolPerSec[i]));
                 maxPeakDeltaPerSec = Math.Max(maxPeakDeltaPerSec, Math.Abs(_peakDeltaPerSec[i]));
                 maxPeakDeltaPerVol = Math.Max(maxPeakDeltaPerVol, Math.Abs(_peakDeltaPerVol[i]));
+                maxBuy = Math.Max(maxBuy, (int)_buyImbalance[i]);
+                maxSell = Math.Max(maxSell, (int)_sellImbalance[i]);
+                maxNet = Math.Max(maxNet, (int)Math.Abs(_netImbalance[i]));
 
                 if (i == 0)
 					continue;
@@ -1589,10 +1706,17 @@ public class ClusterStatistic : Indicator
                 maxPeakVolPerSec = Math.Max(maxPeakVolPerSec, Math.Abs(_peakVolPerSec[i]));
                 maxPeakDeltaPerSec = Math.Max(maxPeakDeltaPerSec, Math.Abs(_peakDeltaPerSec[i]));
                 maxPeakDeltaPerVol = Math.Max(maxPeakDeltaPerVol, Math.Abs(_peakDeltaPerVol[i]));
+                maxBuy = Math.Max(maxBuy, (int)_buyImbalance[i]);
+                maxSell = Math.Max(maxSell, (int)_sellImbalance[i]);
+                maxNet = Math.Max(maxNet, (int)Math.Abs(_netImbalance[i]));
             }
         }
 
-		return new MaxValues
+        if (maxBuy == 0) maxBuy = 1;
+        if (maxSell == 0) maxSell = 1;
+        if (maxNet == 0) maxNet = 1;
+
+        return new MaxValues
 		{
 			MaxAsk = maxAsk,
 			MaxBid = maxBid,
@@ -1613,7 +1737,10 @@ public class ClusterStatistic : Indicator
             MaxDeltaSec = maxDeltaSec,
             MaxPeakVolPerSec = maxPeakVolPerSec,
             MaxPeakDeltaPerSec = maxPeakDeltaPerSec,
-            MaxPeakDeltaPerVol = maxPeakDeltaPerVol
+            MaxPeakDeltaPerVol = maxPeakDeltaPerVol,
+            MaxBuyImb = maxBuy,
+            MaxSellImb = maxSell,
+            MaxNetImb = maxNet,
         };
 	}
 
@@ -1641,6 +1768,9 @@ public class ClusterStatistic : Indicator
             DataType.PeakVolPerSec => ChartInfo.TryGetMinimizedVolumeString(_peakVolPerSec[bar]),
             DataType.PeakDeltaPerSec => ChartInfo.TryGetMinimizedVolumeString(_peakDeltaPerSec[bar]),
             DataType.PeakDeltaPerVol => _peakDeltaPerVol[bar].ToString("+#0.00;-#0.00;0.00", CultureInfo.InvariantCulture),
+            DataType.BuyImbalance => _buyImbalance[bar].ToString(),
+            DataType.SellImbalance => _sellImbalance[bar].ToString(),
+            DataType.NetImbalance => _netImbalance[bar].ToString("+#;-#;0", CultureInfo.InvariantCulture),
             DataType.None => string.Empty,
 			_ => throw new ArgumentOutOfRangeException()
 		};
@@ -1732,6 +1862,9 @@ public class ClusterStatistic : Indicator
             DataType.PeakVolPerSec => "Max Vol/sec",
             DataType.PeakDeltaPerSec => "Delta at Max vol/sec",
             DataType.PeakDeltaPerVol => "Delta/Vol Max vol/sec",
+			DataType.BuyImbalance => "Buy Imb.",
+			DataType.SellImbalance => "Sell Imb.",
+			DataType.NetImbalance => "Net Imb.",
             DataType.None => string.Empty,
 
 			_ => throw new ArgumentOutOfRangeException()

--- a/Technical/ClusterStatistic.cs
+++ b/Technical/ClusterStatistic.cs
@@ -2054,6 +2054,54 @@ public class ClusterStatistic : Indicator
             _peakDeltaAuto[i] = 0m;
         }
     }
+    #endregion
+
+    #region AutoFilter helpers
+    private void UpdateAutoFilterWithClosedBar(int bar)
+    {
+        if (!SotUseAutoFilter) return;
+
+        var vAbs = Math.Abs(_peakVolPerSec[bar]);
+        var dAbs = Math.Abs(_peakDeltaPerSec[bar]);
+
+        if (SotAutoFilterUseEma)
+        {
+            var p = Math.Max(1, SotAutoFilterPeriod);
+            var alpha = 2m / (p + 1m);
+            _afVolEma = _afCount == 0 ? vAbs : (alpha * vAbs + (1m - alpha) * _afVolEma);
+            _afDeltaEma = _afCount == 0 ? dAbs : (alpha * dAbs + (1m - alpha) * _afDeltaEma);
+            _afVol = _afVolEma;
+            _afDelta = _afDeltaEma;
+        }
+        else
+        {
+            var p = Math.Max(1, SotAutoFilterPeriod);
+            _afVolSma.Enqueue(vAbs);
+            _afDeltaSma.Enqueue(dAbs);
+            if (_afVolSma.Count > p) _afVolSma.Dequeue();
+            if (_afDeltaSma.Count > p) _afDeltaSma.Dequeue();
+
+            _afVol = _afVolSma.Average();
+            _afDelta = _afDeltaSma.Average();
+        }
+
+        _afCount++;
+        _peakVolAuto[bar] = _afVol;
+        _peakDeltaAuto[bar] = _afDelta;
+    }
+
+    private void ResetAutoFilter()
+    {
+        _afCount = 0;
+        _afVol = _afDelta = _afVolEma = _afDeltaEma = 0m;
+        _afVolSma.Clear();
+        _afDeltaSma.Clear();
+        for (int i = 0; i < CurrentBar; i++)
+        {
+            _peakVolAuto[i] = 0m;
+            _peakDeltaAuto[i] = 0m;
+        }
+    }
 
     // Escalado 10..100 usando "cuánto por encima/debajo" de la media está el valor
     private decimal GetRateByMean(decimal value, decimal mean)
@@ -2068,7 +2116,8 @@ public class ClusterStatistic : Indicator
         if (r >= hi) return 100m;
         return 10m + (r - lo) * (90m / (hi - lo));
     }
-    #endregion
+
+
 
     #endregion
 }

--- a/Technical/ClusterStatistic.cs
+++ b/Technical/ClusterStatistic.cs
@@ -783,7 +783,7 @@ public class ClusterStatistic : Indicator
 		_maxSessionDelta = Math.Max(Math.Abs(_cDelta[bar]), _maxSessionDelta);
 
 		_maxAsk = Math.Max(candle.Ask, _maxAsk);
-		_maxBid = Math.Max(candle.Ask, _maxBid);
+		_maxBid = Math.Max(candle.Bid, _maxBid);
 
 		_maxDeltaChange = Math.Max(Math.Abs(candle.Delta - prevCandle.Delta), _maxDeltaChange);
 
@@ -798,7 +798,7 @@ public class ClusterStatistic : Indicator
 
 		_maxDeltaPerVolume = candle.Volume is 0
 			? 0
-			: Math.Max(Math.Abs(100 * candle.Delta / candle.Volume), _minDelta);
+			: Math.Max(Math.Abs(100 * candle.Delta / candle.Volume), _maxDeltaPerVolume);
 
 		var candleHeight = candle.High - candle.Low;
 		_maxHeight = Math.Max(candleHeight, _maxHeight);
@@ -1245,7 +1245,7 @@ public class ClusterStatistic : Indicator
 				maxVolume = Math.Max(candle.Volume, maxVolume);
 				minDelta = Math.Min(candle.MinDelta, minDelta);
 				maxAsk = Math.Max(candle.Ask, maxAsk);
-				maxBid = Math.Max(candle.Ask, maxBid);
+				maxBid = Math.Max(candle.Bid, maxBid);
 				maxMaxDelta = Math.Max(Math.Abs(candle.MaxDelta), maxMaxDelta);
 				maxMinDelta = Math.Max(Math.Abs(candle.MinDelta), maxMinDelta);
 				maxSessionDelta = Math.Max(Math.Abs(_cDelta[i]), maxSessionDelta);

--- a/Technical/ClusterStatistic.cs
+++ b/Technical/ClusterStatistic.cs
@@ -68,7 +68,8 @@ public class ClusterStatistic : Indicator
 			Add(DataType.Height, new RenderInfo(13));
 			Add(DataType.Time, new RenderInfo(14));
 			Add(DataType.Duration, new RenderInfo(15));
-		}
+            Add(DataType.DeltaSecond, new RenderInfo(16));
+        }
 
 		#endregion
 
@@ -164,7 +165,8 @@ public class ClusterStatistic : Indicator
 		public decimal MaxHeight { get; set; }
 
 		public decimal MaxVolumeSec { get; set; }
-	}
+		public decimal MaxDeltaSec { get; set; }
+    }
 
 	public enum DataType
 	{
@@ -179,7 +181,8 @@ public class ClusterStatistic : Indicator
 		DeltaChange,
 		Volume,
 		VolumeSecond,
-		SessionVolume,
+        DeltaSecond,
+        SessionVolume,
 		Trades,
 		Height,
 		Time,
@@ -209,8 +212,9 @@ public class ClusterStatistic : Indicator
 	private readonly ValueDataSeries _cDeltaPerVol = new("DeltaPerVol");
 	private readonly ValueDataSeries _cVolume = new("cVolume");
 	private readonly ValueDataSeries _deltaPerVol = new("BarDeltaPerVol");
+    private readonly ValueDataSeries _deltaPerSecond = new("Delta/sec");
 
-	private readonly RenderStringFormat _stringLeftFormat = new()
+    private readonly RenderStringFormat _stringLeftFormat = new()
 	{
 		Alignment = StringAlignment.Near,
 		LineAlignment = StringAlignment.Center,
@@ -277,7 +281,8 @@ public class ClusterStatistic : Indicator
 	private bool _showTime;
 	private bool _showVolume;
 	private bool _showVolumePerSecond;
-	private System.Drawing.Color _textColor;
+    private bool _showDeltaPerSecond;
+    private System.Drawing.Color _textColor;
 	private string _tipText;
 
 	[Browsable(false)]
@@ -483,6 +488,19 @@ public class ClusterStatistic : Indicator
         {
             _showDuration = value;
             RowsOrder.SetEnabled(DataType.Duration, value);
+        }
+    }
+
+    [DisplayName("Delta/sec")]
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Rows),
+     Description = "Show Delta per second", Order = 197)]
+    public bool ShowDeltaPerSecond
+    {
+        get => _showDeltaPerSecond;
+        set
+        {
+            _showDeltaPerSecond = value;
+            RowsOrder.SetEnabled(DataType.DeltaSecond, value);
         }
     }
 
@@ -742,8 +760,9 @@ public class ClusterStatistic : Indicator
 			candleSeconds = 1;
 
 		_volPerSecond[bar] = candle.Volume / candleSeconds;
+        _deltaPerSecond[bar] = candle.Delta / candleSeconds;
 
-		if (bar == 0)
+        if (bar == 0)
 		{
 			_cumVolume = 0;
 			_maxVolume = 0;
@@ -1176,7 +1195,7 @@ public class ClusterStatistic : Indicator
 	{
 		return type switch
 		{
-			DataType.Ask or DataType.Bid or DataType.Delta or DataType.DeltaVolume =>
+			DataType.Ask or DataType.Bid or DataType.Delta or DataType.DeltaVolume or DataType.DeltaSecond =>
 				Blend(candle.Delta > 0 ? AskColor : BidColor, BackGroundColor, rate),
 
 			DataType.Volume or DataType.VolumeSecond or DataType.SessionVolume or
@@ -1206,7 +1225,8 @@ public class ClusterStatistic : Indicator
 			DataType.DeltaChange => GetRate(Math.Abs(candle.Delta - GetCandle(Math.Max(bar - 1, 0)).Delta), maxValues.MaxDeltaChange),
 			DataType.Volume => GetRate(candle.Volume, maxValues.MaxVolume),
 			DataType.VolumeSecond => GetRate(_volPerSecond[bar], maxValues.MaxVolumeSec),
-			DataType.SessionVolume => GetRate(_cVolume[bar], maxValues.CumVolume),
+            DataType.DeltaSecond => GetRate(Math.Abs(_deltaPerSecond[bar]), maxValues.MaxDeltaSec),
+            DataType.SessionVolume => GetRate(_cVolume[bar], maxValues.CumVolume),
 			DataType.Trades => GetRate(candle.Ticks, maxValues.MaxTicks),
 			DataType.Height => GetRate(_candleHeights[bar], maxValues.MaxHeight),
 			DataType.Time => GetRate(_cVolume[bar], maxValues.CumVolume),
@@ -1235,8 +1255,9 @@ public class ClusterStatistic : Indicator
 		var maxHeight = 0m;
 		var maxTicks = 0m;
 		var maxDuration = 0m;
+        decimal maxDeltaSec = 0m;
 
-		if (VisibleProportion)
+        if (VisibleProportion)
 		{
 			for (var i = FirstVisibleBarNumber; i <= LastVisibleBarNumber; i++)
 			{
@@ -1256,7 +1277,10 @@ public class ClusterStatistic : Indicator
 				maxSessionDeltaPerVolume = Math.Max(Math.Abs(_cDeltaPerVol[i]), maxSessionDeltaPerVolume);
 				cumVolume += candle.Volume;
 
-				if (i == 0)
+                // Absolute peak for Delta/sec over the visible range
+                maxDeltaSec = Math.Max(Math.Abs(_deltaPerSecond[i]), maxDeltaSec);
+
+                if (i == 0)
 					continue;
 
 				var prevCandle = GetCandle(i - 1);
@@ -1286,7 +1310,9 @@ public class ClusterStatistic : Indicator
 			maxDeltaChange = _maxDeltaChange;
 			maxHeight = _maxHeight;
 			maxVolumeSec = _volPerSecond.MAX(CurrentBar - 1, CurrentBar - 1);
-		}
+            for (int i = 0; i <= CurrentBar - 1; i++)
+                maxDeltaSec = Math.Max(Math.Abs(_deltaPerSecond[i]), maxDeltaSec);
+        }
 
 		return new MaxValues
 		{
@@ -1305,8 +1331,9 @@ public class ClusterStatistic : Indicator
 			CumVolume = cumVolume,
 			MaxDeltaChange = maxDeltaChange,
 			MaxHeight = maxHeight,
-			MaxVolumeSec = maxVolumeSec
-		};
+			MaxVolumeSec = maxVolumeSec,
+            MaxDeltaSec = maxDeltaSec
+        };
 	}
 
 	private string GetValueText(DataType type, IndicatorCandle candle, int bar)
@@ -1329,7 +1356,8 @@ public class ClusterStatistic : Indicator
 			DataType.Height => _candleHeights[bar].ToString(CultureInfo.InvariantCulture),
 			DataType.Time => candle.Time.AddHours(InstrumentInfo.TimeZone).ToString("HH:mm:ss"),
 			DataType.Duration => ((int)(candle.LastTime - candle.Time).TotalSeconds).ToString(),
-			DataType.None => string.Empty,
+            DataType.DeltaSecond => ChartInfo.TryGetMinimizedVolumeString(_deltaPerSecond[bar]),
+            DataType.None => string.Empty,
 			_ => throw new ArgumentOutOfRangeException()
 		};
 	}
@@ -1416,7 +1444,8 @@ public class ClusterStatistic : Indicator
 			DataType.Height => "Height",
 			DataType.Time => "Time",
 			DataType.Duration => "Duration",
-			DataType.None => string.Empty,
+            DataType.DeltaSecond => "Delta/sec",
+            DataType.None => string.Empty,
 
 			_ => throw new ArgumentOutOfRangeException()
 		};

--- a/Technical/ClusterStatistic.cs
+++ b/Technical/ClusterStatistic.cs
@@ -2086,53 +2086,6 @@ public class ClusterStatistic : Indicator
     }
     #endregion
 
-    #region AutoFilter helpers
-    private void UpdateAutoFilterWithClosedBar(int bar)
-    {
-        if (!SotUseAutoFilter) return;
-
-        var vAbs = Math.Abs(_peakVolPerSec[bar]);
-        var dAbs = Math.Abs(_peakDeltaPerSec[bar]);
-
-        if (SotAutoFilterUseEma)
-        {
-            var p = Math.Max(1, SotAutoFilterPeriod);
-            var alpha = 2m / (p + 1m);
-            _afVolEma = _afCount == 0 ? vAbs : (alpha * vAbs + (1m - alpha) * _afVolEma);
-            _afDeltaEma = _afCount == 0 ? dAbs : (alpha * dAbs + (1m - alpha) * _afDeltaEma);
-            _afVol = _afVolEma;
-            _afDelta = _afDeltaEma;
-        }
-        else
-        {
-            var p = Math.Max(1, SotAutoFilterPeriod);
-            _afVolSma.Enqueue(vAbs);
-            _afDeltaSma.Enqueue(dAbs);
-            if (_afVolSma.Count > p) _afVolSma.Dequeue();
-            if (_afDeltaSma.Count > p) _afDeltaSma.Dequeue();
-
-            _afVol = _afVolSma.Average();
-            _afDelta = _afDeltaSma.Average();
-        }
-
-        _afCount++;
-        _peakVolAuto[bar] = _afVol;
-        _peakDeltaAuto[bar] = _afDelta;
-    }
-
-    private void ResetAutoFilter()
-    {
-        _afCount = 0;
-        _afVol = _afDelta = _afVolEma = _afDeltaEma = 0m;
-        _afVolSma.Clear();
-        _afDeltaSma.Clear();
-        for (int i = 0; i < CurrentBar; i++)
-        {
-            _peakVolAuto[i] = 0m;
-            _peakDeltaAuto[i] = 0m;
-        }
-    }
-
     // Escalado 10..100 usando "cuánto por encima/debajo" de la media está el valor
     private decimal GetRateByMean(decimal value, decimal mean)
     {

--- a/Technical/ClusterStatistic.cs
+++ b/Technical/ClusterStatistic.cs
@@ -223,10 +223,11 @@ public class ClusterStatistic : Indicator
     private readonly ValueDataSeries _peakDeltaPerSec = new("PeakDeltaPerSec");
     private readonly ValueDataSeries _peakDeltaPerVol = new("Delta/Vol at Max vol/sec");
 
-    // --- SoT core state (historical + real-time) ---
-    private List<CumulativeTrade> _allCumulativeTrades;     // historical storage
-    
-	// --- SoT user-tunable params with backing fields ---
+    // --- SoT core state (historical) ---
+    private List<CumulativeTrade> _allCumulativeTrades;
+
+    // --- SoT user-tunable params with backing fields ---
+    // Threshold is total contracts within the sliding window
     private int _sotTimeWindowSec = 5;
     private int _SotMinVolume  = 150;
 
@@ -249,8 +250,8 @@ public class ClusterStatistic : Indicator
     private decimal _rtPeakVolPerSec = 0m;   // per-bar RT peak (Vol/sec)
     private decimal _rtPeakDeltaPerSec = 0m; // per-bar RT paired Delta/sec
 
-    private bool _seededLiveSoT = false;          // live bar seeded desde histórico
-    private bool _hasSoTSampleThisBar = false;    // ya hay al menos 1 muestra en esta barra
+    private bool _seededLiveSoT = false;          // live bar seeded from historical data
+    private bool _hasSoTSampleThisBar = false;    // at least one SoT sample exists in this bar
 
     private readonly RenderStringFormat _stringLeftFormat = new()
 	{
@@ -1646,7 +1647,9 @@ public class ClusterStatistic : Indicator
 		};
 	}
 
-	private decimal GetRate(decimal value, decimal maximumValue)
+    // Normalize against 60% of the maximum to increase contrast in the heat map.
+    // Clamp to [10, 100] so low values still render visibly.
+    private decimal GetRate(decimal value, decimal maximumValue)
 	{
 		if (maximumValue == 0)
 			return 10;
@@ -1811,10 +1814,10 @@ public class ClusterStatistic : Indicator
     // Centralized reaction when SoT params change from UI
     private void OnSoTParamsChanged()
     {
-        // EN: Always reset RT accumulators so the next ticks start fresh with new params.
+        // Always reset RT accumulators so the next ticks start fresh with new params.
         ResetSoTRuntimeState();
 
-        // EN: Clear current peaks to avoid showing stale values while recomputing
+        // Clear current peaks to avoid showing stale values while recomputing
         if (CurrentBar > 0)
         {
             for (int i = 0; i <= CurrentBar - 1; i++)
@@ -1825,7 +1828,7 @@ public class ClusterStatistic : Indicator
             }
         }
 
-        // EN: If we already have history, recompute immediately (no waiting)
+        // If we already have history, recompute immediately (no waiting)
         if (_allCumulativeTrades != null && _allCumulativeTrades.Count > 0)
         {
             RebuildHistoricalSoT();
@@ -1834,7 +1837,7 @@ public class ClusterStatistic : Indicator
             return;
         }
 
-        // EN: Otherwise, request history and refresh when it arrives
+        // Otherwise, request history and refresh when it arrives
         if (CurrentBar > 0)
         {
             try
@@ -1847,11 +1850,11 @@ public class ClusterStatistic : Indicator
             }
             catch
             {
-                // EN: If candles are not ready yet, do nothing; the next full recalc will request history.
+                // If candles are not ready yet, do nothing; the next full recalc will request history.
             }
         }
 
-        // EN: Force a redraw so the table updates quickly (even before history returns).
+        // Force a redraw so the table updates quickly (even before history returns).
         RedrawChart();
     }
 
@@ -1878,17 +1881,16 @@ public class ClusterStatistic : Indicator
         _rtPeakDeltaPerSec = 0m;
 
         // Collect trades in chronological order inside the window (cutoff, nowRight]
-        // Primero recolectamos en una lista y luego encolamos en orden.
         var chunk = new List<CumulativeTrade>();
 
-        // Búsqueda lineal desde el final hasta salir del rango; luego invertimos.
+        // Linear scan from the end until we exit the range; then reverse.
         for (int i = _allCumulativeTrades.Count - 1; i >= 0; i--)
         {
             var t = _allCumulativeTrades[i];
-            if (t.Time <= cutoff) break;          // ya fuera por la izquierda
-            if (t.Time <= nowRight) chunk.Add(t); // dentro de (cutoff, nowRight]
+            if (t.Time <= cutoff) break;          // out of range on the left (older than cutoff)
+            if (t.Time <= nowRight) chunk.Add(t); // inside (cutoff, nowRight]
         }
-        chunk.Reverse(); // aseguramos orden temporal ascendente
+        chunk.Reverse(); // ensure ascending chronological order
 
         foreach (var t in chunk)
         {
@@ -1898,7 +1900,7 @@ public class ClusterStatistic : Indicator
             _winDelta += sgnVol;
         }
 
-        // Purga defensiva por tiempo (igual que en RT)
+        // Defensive time-based purge (same logic as in RT)
         while (_win.Count > 0 && _win.Peek().T <= cutoff)
         {
             var u = _win.Dequeue();
@@ -1906,7 +1908,7 @@ public class ClusterStatistic : Indicator
             _winDelta -= u.Delta;
         }
 
-        // Primer snapshot RT para la live bar
+        // First RT snapshot for the live bar
         if (_winVol >= SotMinVolume )
         {
             var vps = _winVol / SotTimeWindowSec;
@@ -1929,7 +1931,7 @@ public class ClusterStatistic : Indicator
         _seededLiveSoT = _win.Count > 0;
         _hasSoTSampleThisBar = _seededLiveSoT;
 
-        // Alinear acumulados para que el siguiente OnCalculate empiece en 0 incremento
+        // Align accumulators so the next OnCalculate starts from zero increment
         _rtBar = liveBar;
         _prevCumVol = cLive.Volume;
         _prevCumDelta = cLive.Delta;

--- a/Technical/ClusterStatistic.cs
+++ b/Technical/ClusterStatistic.cs
@@ -2219,14 +2219,13 @@ public class ClusterStatistic : Indicator
             _peakDeltaAuto[i] = 0m;
         }
     }
-    #endregion
-
-    // Escalado 10..100 usando "cuánto por encima/debajo" de la media está el valor
+    
+    // Scaling 10..100 based on "how far above/below" the mean the value is
     private decimal GetRateByMean(decimal value, decimal mean)
     {
         if (mean <= 0m) return 10m;
         var r = value / mean;              // >= 0
-        var gamma = 1.35m;                 // >1: enfatiza valores altos
+        var gamma = 1.35m;                 // >1: emphasizes higher values
         r = (decimal)Math.Pow((double)r, (double)gamma);
 
         const decimal lo = 0.85m, hi = 1.35m;
@@ -2236,9 +2235,6 @@ public class ClusterStatistic : Indicator
     }
 
     #endregion
-
-
-
 
     #endregion
 }

--- a/Technical/ClusterStatistic.cs
+++ b/Technical/ClusterStatistic.cs
@@ -71,6 +71,7 @@ public class ClusterStatistic : Indicator
             Add(DataType.DeltaSecond, new RenderInfo(16));
             Add(DataType.PeakVolPerSec, new RenderInfo(17));
             Add(DataType.PeakDeltaPerSec, new RenderInfo(18));
+            Add(DataType.PeakDeltaPerVol, new RenderInfo(19));
         }
 
 		#endregion
@@ -170,6 +171,7 @@ public class ClusterStatistic : Indicator
 		public decimal MaxDeltaSec { get; set; }
         public decimal MaxPeakVolPerSec { get; set; }
         public decimal MaxPeakDeltaPerSec { get; set; }
+        public decimal MaxPeakDeltaPerVol { get; set; }
     }
 
 	public enum DataType
@@ -193,6 +195,7 @@ public class ClusterStatistic : Indicator
 		Duration,
         PeakVolPerSec,
         PeakDeltaPerSec,
+        PeakDeltaPerVol,
         None
 	}
 
@@ -565,6 +568,14 @@ public class ClusterStatistic : Indicator
     {
         get => RowsOrder.TryGetValue(DataType.PeakDeltaPerSec, out var ri) && ri.Enabled;
         set => RowsOrder.SetEnabled(DataType.PeakDeltaPerSec, value);
+    }
+
+    [DisplayName("Delta/Vol at Max vol/sec")]
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Rows), Order = 200)]
+    public bool ShowPeakDeltaPerVol
+    {
+        get => RowsOrder.TryGetValue(DataType.PeakDeltaPerVol, out var ri) && ri.Enabled;
+        set => RowsOrder.SetEnabled(DataType.PeakDeltaPerVol, value);
     }
 
     #endregion
@@ -1434,7 +1445,7 @@ public class ClusterStatistic : Indicator
             DataType.SessionDeltaVolume => Blend(_cDeltaPerVol[bar] > 0 ? AskColor : BidColor, BackGroundColor, rate),
 			DataType.SessionDelta => Blend(_cDelta[bar] > 0 ? AskColor : BidColor, BackGroundColor, rate),
 			DataType.DeltaChange => GetDeltaChangeBrush(candle, bar, rate),
-            DataType.PeakDeltaPerSec => Blend(_peakDeltaPerSec[bar] >= 0 ? AskColor : BidColor, BackGroundColor, rate),
+            DataType.PeakDeltaPerSec or DataType.PeakDeltaPerVol => Blend(_peakDeltaPerSec[bar] >= 0 ? AskColor : BidColor, BackGroundColor, rate),
             DataType.None => System.Drawing.Color.Transparent,
             _ => throw new ArgumentOutOfRangeException()
 		};
@@ -1458,6 +1469,14 @@ public class ClusterStatistic : Indicator
                 return GetRateByMean(v, _peakDeltaAuto[bar]);
             return GetRate(v, maxValues.MaxPeakDeltaPerSec);
         }
+
+        if (type == DataType.PeakDeltaPerVol)
+            {
+                var v = Math.Abs(_peakDeltaPerVol[bar]);
+                if (SotUseAutoFilter && _afCount > 0)
+                    return GetRateByMean(v, _peakDeltaAuto[bar] == 0m ? 0m : (_peakDeltaAuto[bar] / (_peakVolAuto[bar] == 0m ? 1m : _peakVolAuto[bar])));
+                return GetRate(v, maxValues.MaxPeakDeltaPerVol);
+            }
 
         return type switch
 		{
@@ -1505,6 +1524,7 @@ public class ClusterStatistic : Indicator
         decimal maxDeltaSec = 0m;
         decimal maxPeakVolPerSec = 0m;
         decimal maxPeakDeltaPerSec = 0m;
+        decimal maxPeakDeltaPerVol = 0m;
 
         if (VisibleProportion)
 		{
@@ -1531,6 +1551,7 @@ public class ClusterStatistic : Indicator
 
                 maxPeakVolPerSec = Math.Max(maxPeakVolPerSec, Math.Abs(_peakVolPerSec[i]));
                 maxPeakDeltaPerSec = Math.Max(maxPeakDeltaPerSec, Math.Abs(_peakDeltaPerSec[i]));
+                maxPeakDeltaPerVol = Math.Max(maxPeakDeltaPerVol, Math.Abs(_peakDeltaPerVol[i]));
 
                 if (i == 0)
 					continue;
@@ -1567,6 +1588,7 @@ public class ClusterStatistic : Indicator
                 maxDeltaSec = Math.Max(Math.Abs(_deltaPerSecond[i]), maxDeltaSec);
                 maxPeakVolPerSec = Math.Max(maxPeakVolPerSec, Math.Abs(_peakVolPerSec[i]));
                 maxPeakDeltaPerSec = Math.Max(maxPeakDeltaPerSec, Math.Abs(_peakDeltaPerSec[i]));
+                maxPeakDeltaPerVol = Math.Max(maxPeakDeltaPerVol, Math.Abs(_peakDeltaPerVol[i]));
             }
         }
 
@@ -1590,7 +1612,8 @@ public class ClusterStatistic : Indicator
 			MaxVolumeSec = maxVolumeSec,
             MaxDeltaSec = maxDeltaSec,
             MaxPeakVolPerSec = maxPeakVolPerSec,
-            MaxPeakDeltaPerSec = maxPeakDeltaPerSec
+            MaxPeakDeltaPerSec = maxPeakDeltaPerSec,
+            MaxPeakDeltaPerVol = maxPeakDeltaPerVol
         };
 	}
 
@@ -1617,6 +1640,7 @@ public class ClusterStatistic : Indicator
             DataType.DeltaSecond => ChartInfo.TryGetMinimizedVolumeString(_deltaPerSecond[bar]),
             DataType.PeakVolPerSec => ChartInfo.TryGetMinimizedVolumeString(_peakVolPerSec[bar]),
             DataType.PeakDeltaPerSec => ChartInfo.TryGetMinimizedVolumeString(_peakDeltaPerSec[bar]),
+            DataType.PeakDeltaPerVol => _peakDeltaPerVol[bar].ToString("+#0.00;-#0.00;0.00", CultureInfo.InvariantCulture),
             DataType.None => string.Empty,
 			_ => throw new ArgumentOutOfRangeException()
 		};
@@ -1707,6 +1731,7 @@ public class ClusterStatistic : Indicator
             DataType.DeltaSecond => "Delta/sec",
             DataType.PeakVolPerSec => "Max Vol/sec",
             DataType.PeakDeltaPerSec => "Delta at Max vol/sec",
+            DataType.PeakDeltaPerVol => "Delta/Vol Max vol/sec",
             DataType.None => string.Empty,
 
 			_ => throw new ArgumentOutOfRangeException()
@@ -1857,6 +1882,11 @@ public class ClusterStatistic : Indicator
             // Store per-bar peaks (0 if no qualifying window)
             _peakVolPerSec[bar] = Math.Round(peakVolPerSec, 0);
             _peakDeltaPerSec[bar] = Math.Round(peakDeltaPerSec, 0);
+
+            _peakDeltaPerVol[bar] = _peakVolPerSec[bar] == 0m
+				? 0m
+				: (_peakDeltaPerSec[bar] / _peakVolPerSec[bar]);
+
             UpdateAutoFilterWithClosedBar(bar);
         }
 

--- a/Technical/ClusterStatistic.cs
+++ b/Technical/ClusterStatistic.cs
@@ -222,6 +222,8 @@ public class ClusterStatistic : Indicator
     private readonly ValueDataSeries _peakVolPerSec = new("PeakVolPerSec");
     private readonly ValueDataSeries _peakDeltaPerSec = new("PeakDeltaPerSec");
     private readonly ValueDataSeries _peakDeltaPerVol = new("Delta/Vol at Max vol/sec");
+    private readonly ValueDataSeries _peakVolAuto = new("MaxVol/sec AutoThr");
+    private readonly ValueDataSeries _peakDeltaAuto = new("Delta@MaxVol AutoThr");
 
     // --- SoT core state (historical) ---
     private List<CumulativeTrade> _allCumulativeTrades;
@@ -252,6 +254,12 @@ public class ClusterStatistic : Indicator
 
     private bool _seededLiveSoT = false;          // live bar seeded from historical data
     private bool _hasSoTSampleThisBar = false;    // at least one SoT sample exists in this bar
+
+    // AutoFilter state
+    private int _afCount;
+    private decimal _afVol, _afDelta, _afVolEma, _afDeltaEma;
+    private readonly Queue<decimal> _afVolSma = new();
+    private readonly Queue<decimal> _afDeltaSma = new();
 
     private readonly RenderStringFormat _stringLeftFormat = new()
 	{
@@ -599,6 +607,49 @@ public class ClusterStatistic : Indicator
             OnSoTParamsChanged();
         }
     }
+
+    private bool _sotUseAutoFilter = true;
+    [Display(Name = "Use Auto Filter", GroupName = "Max vol/sec", Order = 203)]
+    public bool SotUseAutoFilter
+    {
+        get => _sotUseAutoFilter;
+        set
+        {
+            if (_sotUseAutoFilter == value) return;
+            _sotUseAutoFilter = value;
+            ResetAutoFilter();
+            RebuildHistoricalSoT();
+        }
+    }
+
+    private int _sotAutoFilterPeriod = 3;
+    [Display(Name = "Auto Filter Period", GroupName = "Max vol/sec", Order = 204)]
+    [Range(1, 200)]
+    public int SotAutoFilterPeriod
+    {
+        get => _sotAutoFilterPeriod;
+        set
+        {
+            _sotAutoFilterPeriod = value;
+            ResetAutoFilter();
+            RebuildHistoricalSoT();
+        }
+    }
+
+    private bool _sotAutoFilterUseEma = true;
+    [Display(Name = "Auto Filter = EMA (off=SMA)", GroupName = "Max vol/sec", Order = 205)]
+    public bool SotAutoFilterUseEma
+    {
+        get => _sotAutoFilterUseEma;
+        set
+        {
+            if (_sotAutoFilterUseEma == value) return;
+            _sotAutoFilterUseEma = value;
+            ResetAutoFilter();
+            RebuildHistoricalSoT();
+        }
+    }
+
 
     #endregion
 
@@ -1391,7 +1442,24 @@ public class ClusterStatistic : Indicator
 
 	private decimal GetRate(MaxValues maxValues, DataType type, IndicatorCandle candle, int bar)
 	{
-		return type switch
+
+        if (type == DataType.PeakVolPerSec)
+        {
+            var v = Math.Abs(_peakVolPerSec[bar]);
+            if (SotUseAutoFilter && _afCount > 0)
+                return GetRateByMean(v, _peakVolAuto[bar]); // v vs threshold
+            return GetRate(v, maxValues.MaxPeakVolPerSec); // fallback: visible max scaling
+        }
+
+        if (type == DataType.PeakDeltaPerSec)
+        {
+            var v = Math.Abs(_peakDeltaPerSec[bar]);
+            if (SotUseAutoFilter && _afCount > 0)
+                return GetRateByMean(v, _peakDeltaAuto[bar]);
+            return GetRate(v, maxValues.MaxPeakDeltaPerSec);
+        }
+
+        return type switch
 		{
 			DataType.Ask => GetRate(candle.Ask, maxValues.MaxAsk),
 			DataType.Bid => GetRate(candle.Bid, maxValues.MaxBid),
@@ -1410,8 +1478,6 @@ public class ClusterStatistic : Indicator
 			DataType.Height => GetRate(_candleHeights[bar], maxValues.MaxHeight),
 			DataType.Time => GetRate(_cVolume[bar], maxValues.CumVolume),
 			DataType.Duration => GetRate(_candleDurations[bar], maxValues.MaxDuration),
-            DataType.PeakVolPerSec => GetRate(_peakVolPerSec[bar], maxValues.MaxPeakVolPerSec),
-            DataType.PeakDeltaPerSec => GetRate(Math.Abs(_peakDeltaPerSec[bar]), maxValues.MaxPeakDeltaPerSec),
             DataType.None => 0,
 
 			_ => throw new ArgumentOutOfRangeException()
@@ -1672,9 +1738,10 @@ public class ClusterStatistic : Indicator
 		var b = (byte)(color.B + (backColor.B - color.B) * (1 - amount * 0.01m));
 		return System.Drawing.Color.FromArgb(_bgAlpha, r, g, b);
 	}
-
+    #region Peak Vol/sec helpers
     protected override void OnFinishRecalculate()
     {
+        ResetAutoFilter();
         // Reset RT sliding-window state after a full rebuild
         _win.Clear();
         _winVol = 0m;
@@ -1790,6 +1857,7 @@ public class ClusterStatistic : Indicator
             // Store per-bar peaks (0 if no qualifying window)
             _peakVolPerSec[bar] = Math.Round(peakVolPerSec, 0);
             _peakDeltaPerSec[bar] = Math.Round(peakDeltaPerSec, 0);
+            UpdateAutoFilterWithClosedBar(bar);
         }
 
         // Do NOT touch the live bar here; it will be seeded right after this call.
@@ -1937,6 +2005,69 @@ public class ClusterStatistic : Indicator
         _prevCumDelta = cLive.Delta;
     }
 
+
+    #endregion
+
+    #region AutoFilter helpers
+    private void UpdateAutoFilterWithClosedBar(int bar)
+    {
+        if (!SotUseAutoFilter) return;
+
+        var vAbs = Math.Abs(_peakVolPerSec[bar]);
+        var dAbs = Math.Abs(_peakDeltaPerSec[bar]);
+
+        if (SotAutoFilterUseEma)
+        {
+            var p = Math.Max(1, SotAutoFilterPeriod);
+            var alpha = 2m / (p + 1m);
+            _afVolEma = _afCount == 0 ? vAbs : (alpha * vAbs + (1m - alpha) * _afVolEma);
+            _afDeltaEma = _afCount == 0 ? dAbs : (alpha * dAbs + (1m - alpha) * _afDeltaEma);
+            _afVol = _afVolEma;
+            _afDelta = _afDeltaEma;
+        }
+        else
+        {
+            var p = Math.Max(1, SotAutoFilterPeriod);
+            _afVolSma.Enqueue(vAbs);
+            _afDeltaSma.Enqueue(dAbs);
+            if (_afVolSma.Count > p) _afVolSma.Dequeue();
+            if (_afDeltaSma.Count > p) _afDeltaSma.Dequeue();
+
+            _afVol = _afVolSma.Average();
+            _afDelta = _afDeltaSma.Average();
+        }
+
+        _afCount++;
+        _peakVolAuto[bar] = _afVol;
+        _peakDeltaAuto[bar] = _afDelta;
+    }
+
+    private void ResetAutoFilter()
+    {
+        _afCount = 0;
+        _afVol = _afDelta = _afVolEma = _afDeltaEma = 0m;
+        _afVolSma.Clear();
+        _afDeltaSma.Clear();
+        for (int i = 0; i < CurrentBar; i++)
+        {
+            _peakVolAuto[i] = 0m;
+            _peakDeltaAuto[i] = 0m;
+        }
+    }
+
+    // Escalado 10..100 usando "cuánto por encima/debajo" de la media está el valor
+    private decimal GetRateByMean(decimal value, decimal mean)
+    {
+        if (mean <= 0m) return 10m;
+        var r = value / mean;              // >= 0
+        var gamma = 1.35m;                 // >1: enfatiza valores altos
+        r = (decimal)Math.Pow((double)r, (double)gamma);
+
+        const decimal lo = 0.85m, hi = 1.35m;
+        if (r <= lo) return 10m;
+        if (r >= hi) return 100m;
+        return 10m + (r - lo) * (90m / (hi - lo));
+    }
 
     #endregion
 }

--- a/Technical/ClusterStatistic.cs
+++ b/Technical/ClusterStatistic.cs
@@ -1792,6 +1792,8 @@ public class ClusterStatistic : Indicator
 
     protected override void OnCumulativeTradesResponse(CumulativeTradesRequest request, IEnumerable<CumulativeTrade> cumulativeTrades)
     {
+        ResetAutoFilter();
+
         // Store and rebuild the SoT peaks over history
         _allCumulativeTrades = cumulativeTrades?.ToList() ?? new List<CumulativeTrade>();
         RebuildHistoricalSoT();
@@ -2099,6 +2101,9 @@ public class ClusterStatistic : Indicator
         if (r >= hi) return 100m;
         return 10m + (r - lo) * (90m / (hi - lo));
     }
+
+    #endregion
+
 
 
 

--- a/Technical/ClusterStatistic.cs
+++ b/Technical/ClusterStatistic.cs
@@ -221,18 +221,36 @@ public class ClusterStatistic : Indicator
     private readonly ValueDataSeries _deltaPerSecond = new("Delta/sec");
     private readonly ValueDataSeries _peakVolPerSec = new("PeakVolPerSec");
     private readonly ValueDataSeries _peakDeltaPerSec = new("PeakDeltaPerSec");
+    private readonly ValueDataSeries _peakDeltaPerVol = new("Delta/Vol at Max vol/sec");
 
     // --- SoT core state (historical + real-time) ---
     private List<CumulativeTrade> _allCumulativeTrades;     // historical storage
-    private readonly Queue<CumulativeTrade> _liveQueue = new(); // sliding RT window
+    
+	// --- SoT user-tunable params with backing fields ---
+    private int _sotTimeWindowSec = 5;
+    private int _SotMinVolume  = 150;
 
-    // Sliding-window aggregates for RT
-    private int _winTrades;                 // number of executions (sum of Ticks.Count)
-    private decimal _winDelta;              // signed delta (buy vol - sell vol)
+    // --- Sliding window sample for RT computed in OnCalculate ---
+    private sealed class Sample
+    {
+        public DateTime T;
+        public decimal Vol;   // incremental volume since last sample
+        public decimal Delta; // incremental delta since last sample
+    }
 
-    // Per-live-bar peaks while the bar is forming
-    private decimal _rtPeakTradesPerSec;    // trades/sec peak for the current live bar
-    private decimal _rtPeakDeltaPerSec;     // delta/sec at the same window as trades/sec peak
+    private readonly Queue<Sample> _win = new(); // RT rolling window across bars
+    private decimal _winVol = 0m;
+    private decimal _winDelta = 0m;
+
+    private int _rtBar = -1;           // last observed live bar index in OnCalculate
+    private decimal _prevCumVol = 0m;  // candle.Volume seen on previous OnCalculate tick
+    private decimal _prevCumDelta = 0m;// candle.Delta seen on previous OnCalculate tick
+
+    private decimal _rtPeakVolPerSec = 0m;   // per-bar RT peak (Vol/sec)
+    private decimal _rtPeakDeltaPerSec = 0m; // per-bar RT paired Delta/sec
+
+    private bool _seededLiveSoT = false;          // live bar seeded desde histórico
+    private bool _hasSoTSampleThisBar = false;    // ya hay al menos 1 muestra en esta barra
 
     private readonly RenderStringFormat _stringLeftFormat = new()
 	{
@@ -546,11 +564,40 @@ public class ClusterStatistic : Indicator
 
     [Display(Name = "Time Window (sec)", GroupName = "Max vol/sec", Order = 201)]
     [Range(1, 600)]
-    public int SotTimeWindowSec { get; set; } = 5;
+    public int SotTimeWindowSec
+    {
+        get => _sotTimeWindowSec;
+        set
+        {
+            // EN: Defensive clamp + early exit if no change
+            var v = Math.Max(1, Math.Min(600, value));
+            if (_sotTimeWindowSec == v)
+                return;
 
-    [Display(Name = "Min Trades per Window", GroupName = "Max vol/sec", Order = 202)]
+            _sotTimeWindowSec = v;
+
+            // EN: Immediately rebuild historical SoT and reset RT window
+            OnSoTParamsChanged();
+        }
+    }
+
+    [Display(Name = "Min Volume per Window", GroupName = "Max vol/sec", Order = 202)]
     [Range(1, 100000)]
-    public int SotMinTrades { get; set; } = 150;
+    public int SotMinVolume 
+    {
+        get => _SotMinVolume ;
+        set
+        {
+            var v = Math.Max(1, Math.Min(100000, value));
+            if (_SotMinVolume  == v)
+                return;
+
+            _SotMinVolume  = v;
+
+            // EN: Same reaction: reset RT and recompute history with the new threshold
+            OnSoTParamsChanged();
+        }
+    }
 
     #endregion
 
@@ -907,7 +954,89 @@ public class ClusterStatistic : Indicator
 					_lastVolumeAlert = bar;
 				}
 			}
-		}
+
+            // Detect bar change and reset per-bar peaks (very important)
+            if (_rtBar != bar)
+            {
+                _rtBar = bar;
+
+                // Candle accumulators restart per bar
+                _prevCumVol = 0m;
+                _prevCumDelta = 0m;
+
+                // Reset per-bar peaks so each bar shows its own max, not a global running max
+                _rtPeakVolPerSec = 0m;
+                _rtPeakDeltaPerSec = 0m;
+                _hasSoTSampleThisBar = false;
+
+                // Also clear the seed flag on bar change
+                _seededLiveSoT = false;
+            }
+
+            // Build increments from candle cumulative
+            var incVol = candle.Volume - _prevCumVol;
+            var incDelta = candle.Delta - _prevCumDelta;
+
+            // Defensive guard for re-ticks/recalc
+            if (incVol < 0m || Math.Abs(incDelta) > Math.Abs(candle.Delta))
+            {
+                incVol = 0m;
+                incDelta = 0m;
+            }
+
+            _prevCumVol = candle.Volume;
+            _prevCumDelta = candle.Delta;
+
+            // "Right edge" timestamp for this sample
+            var now = candle.LastTime;
+
+            // Always purge by time first, even if there is no new increment
+            var cutoff = now.AddSeconds(-_sotTimeWindowSec);
+            while (_win.Count > 0 && _win.Peek().T <= cutoff)
+            {
+                var old = _win.Dequeue();
+                _winVol -= old.Vol;
+                _winDelta -= old.Delta;
+            }
+
+            // Enqueue new increment if any
+            if (incVol > 0m || incDelta != 0m)
+            {
+                _win.Enqueue(new Sample { T = now, Vol = incVol, Delta = incDelta });
+                _winVol += incVol;
+                _winDelta += incDelta;
+                _hasSoTSampleThisBar = true;
+            }
+
+            // If window passes threshold, compute current vps/dps and update *per-bar* peaks
+            if (_winVol >= SotMinVolume )
+            {
+                var vps = _winVol / SotTimeWindowSec;
+                var dps = _winDelta / SotTimeWindowSec;
+
+                if (vps > _rtPeakVolPerSec)
+                {
+                    _rtPeakVolPerSec = vps;
+                    _rtPeakDeltaPerSec = dps;
+                }
+            }
+
+            // Publish per-bar peaks (rounded for UI consistency)
+            if (_hasSoTSampleThisBar || _seededLiveSoT)
+            {
+                var newVps = Math.Round(_rtPeakVolPerSec, 0);
+                var newDps = Math.Round(_rtPeakDeltaPerSec, 0);
+
+                // Do not overwrite if the stored series already shows a higher peak for this live bar
+                if (newVps > _peakVolPerSec[bar])
+                {
+                    _peakVolPerSec[bar] = newVps;
+                    _peakDeltaPerSec[bar] = newDps;
+                    _peakDeltaPerVol[bar] = newVps == 0m ? 0m : (newDps / newVps);
+                }
+                // else: keep existing higher value (monotonic per bar)
+            }
+        }
 
 		_lastVolumeValue = candle.Volume;
 		_lastDeltaValue = candle.Delta;
@@ -1543,170 +1672,268 @@ public class ClusterStatistic : Indicator
 
     protected override void OnFinishRecalculate()
     {
-        // Clear RT window state when a full recalc completes
-        _liveQueue.Clear();
-        _winTrades = 0;
+        // Reset RT sliding-window state after a full rebuild
+        _win.Clear();
+        _winVol = 0m;
         _winDelta = 0m;
-        _rtPeakTradesPerSec = 0m;
+        _rtPeakVolPerSec = 0m;
         _rtPeakDeltaPerSec = 0m;
+        _rtBar = -1;
+        _prevCumVol = 0m;
+        _prevCumDelta = 0m;
 
         if (CurrentBar <= 0)
             return;
 
         // Request historical cumulative trades for the loaded range
         var startTime = GetCandle(0).Time;
-        var endTime = GetCandle(CurrentBar - 1).LastTime;
+        var endTime = GetCandle(CurrentBar - 2).LastTime;
 
         // 0,0 means "no size filter" — ask for all trades
         var request = new CumulativeTradesRequest(startTime, endTime, 0, 0);
         RequestForCumulativeTrades(request);
     }
 
+
     protected override void OnCumulativeTradesResponse(CumulativeTradesRequest request, IEnumerable<CumulativeTrade> cumulativeTrades)
     {
         // Store and rebuild the SoT peaks over history
         _allCumulativeTrades = cumulativeTrades?.ToList() ?? new List<CumulativeTrade>();
         RebuildHistoricalSoT();
+        SeedLiveWindowFromHistory();
+
+        RedrawChart();
     }
 
-    // Recompute SoT peaks (trades/sec peak inside each bar and its delta/sec) using historical cumulative trades
+    // Recompute SoT peaks (volume/sec peak inside each bar and its paired delta/sec)
+    // using historical cumulative trades — SAME METRIC AS RT (volume/sec).
     private void RebuildHistoricalSoT()
     {
         if (_allCumulativeTrades == null || _allCumulativeTrades.Count == 0 || CurrentBar <= 0)
             return;
 
-        // Optional: clear Peak* series before full rebuild
-        for (int i = 0; i < CurrentBar; i++)
+        // We only (re)write CLOSED bars here. Live bar (CurrentBar-1) is handled by RT.
+        int lastClosedBar = CurrentBar - 2;
+        if (lastClosedBar < 0)
+            return;
+
+        // Clear target series up to the last closed bar
+        for (int i = 0; i <= lastClosedBar; i++)
         {
             _peakVolPerSec[i] = 0m;
             _peakDeltaPerSec[i] = 0m;
         }
 
+        // Sliding window over cumulative trades
         var q = new Queue<CumulativeTrade>();
-        int tradeIdx = 0;
+        int k = 0;                   // cursor in _allCumulativeTrades
 
-        // Sliding-window aggregates
-        int winTrades = 0;
-        decimal winDelta = 0m;
+        decimal winVol = 0m;         // window total volume (contracts)
+        decimal winDelta = 0m;       // window signed delta (contracts)
 
-        // Iterate bars chronologically
-        for (int bar = 0; bar < CurrentBar; bar++)
+        // Walk bar by bar chronologically
+        for (int bar = 0; bar <= lastClosedBar; bar++)
         {
             var c = GetCandle(bar);
-            var barStart = c.Time;
-            var barEnd = c.LastTime;
+            DateTime barStart = c.Time;
+            DateTime barEnd = c.LastTime;
 
             // Reset per-bar peaks
-            decimal peakTradesPerSec = 0m;
+            decimal peakVolPerSec = 0m;
             decimal peakDeltaPerSec = 0m;
 
-            // Move cursor to this bar's start
-            while (tradeIdx < _allCumulativeTrades.Count && _allCumulativeTrades[tradeIdx].Time < barStart)
-                tradeIdx++;
+            // Advance cursor to the first trade that belongs to this bar (>= barStart)
+            while (k < _allCumulativeTrades.Count && _allCumulativeTrades[k].Time < barStart)
+                k++;
 
-            int j = tradeIdx;
+            int j = k;
 
-            // Walk through trades within this bar's time
+            // Consume trades inside [barStart, barEnd]
             while (j < _allCumulativeTrades.Count && _allCumulativeTrades[j].Time <= barEnd)
             {
                 var t = _allCumulativeTrades[j++];
                 q.Enqueue(t);
 
-                // Count number of executions in this bundle; fallback to 1 if null
-                int ticksCount = (t.Ticks != null ? t.Ticks.Count : 1);
-                winTrades += ticksCount;
+                // Add the trade bundle volume to the time-window
+                winVol += t.Volume;
 
-                // Signed delta using Direction
+                // Signed delta from bundle direction
                 winDelta += (t.Direction == TradeDirection.Buy ? t.Volume : -t.Volume);
 
-                // Slide the window: drop trades older than T seconds from current trade time
+                // Drop trades older than T seconds from current right-edge (t.Time)
                 var cutoff = t.Time.AddSeconds(-SotTimeWindowSec);
                 while (q.Count > 0 && q.Peek().Time <= cutoff)
                 {
                     var u = q.Dequeue();
-                    int uTicks = (u.Ticks != null ? u.Ticks.Count : 1);
-                    winTrades -= uTicks;
+                    winVol -= u.Volume;
                     winDelta -= (u.Direction == TradeDirection.Buy ? u.Volume : -u.Volume);
                 }
 
-                // Evaluate if window meets the minimum trade count
-                if (winTrades >= SotMinTrades)
+                // Only evaluate if the window meets the minimum threshold (volume-based)
+                if (winVol >= SotMinVolume )
                 {
-                    var tradesPerSec = (decimal)winTrades / SotTimeWindowSec; // SoT Vol/sec
-                    var deltaPerSec = winDelta / SotTimeWindowSec;            // SoT Delta/sec (same window)
+                    var vps = winVol / SotTimeWindowSec;   // volume per second
+                    var dps = winDelta / SotTimeWindowSec; // delta per second for the same window
 
-                    // Keep delta/sec from the window with the greatest trades/sec (break ties by higher vol/sec)
-                    if (tradesPerSec > peakTradesPerSec)
+                    // Keep the window with the largest volume/sec; break ties by larger vps (implicit)
+                    if (vps > peakVolPerSec)
                     {
-                        peakTradesPerSec = tradesPerSec;
-                        peakDeltaPerSec = deltaPerSec;
+                        peakVolPerSec = vps;
+                        peakDeltaPerSec = dps;
                     }
                 }
             }
 
-            // Store peak-of-bar values (0 if no window met the minimum)
-            _peakVolPerSec[bar] = Math.Round(peakTradesPerSec, 0);
+            // Store per-bar peaks (0 if no qualifying window)
+            _peakVolPerSec[bar] = Math.Round(peakVolPerSec, 0);
             _peakDeltaPerSec[bar] = Math.Round(peakDeltaPerSec, 0);
         }
+
+        // Do NOT touch the live bar here; it will be seeded right after this call.
     }
 
-    // Called by the platform for each incoming cumulative trade in real-time
-    protected override void OnCumulativeTrade(CumulativeTrade trade)
+
+    // Small helper: reset RT sliding window and per-bar peaks
+    private void ResetSoTRuntimeState()
     {
-        if (trade == null || trade.Volume <= 0)
-            return;
+        _win.Clear();
+        _winVol = 0m;
+        _winDelta = 0m;
 
-        var bar = CurrentBar - 1;
-        if (bar < 0)
-            return;
+        _rtBar = -1;
+        _prevCumVol = 0m;
+        _prevCumDelta = 0m;
 
-        // Maintain a sliding window of last SotTimeWindowSec seconds
-        _liveQueue.Enqueue(trade);
+        _rtPeakVolPerSec = 0m;
+        _rtPeakDeltaPerSec = 0m;
+    }
 
-        int ticksCount = (trade.Ticks != null ? trade.Ticks.Count : 1);
-        _winTrades += ticksCount;
-        _winDelta += (trade.Direction == TradeDirection.Buy ? trade.Volume : -trade.Volume);
+    // Centralized reaction when SoT params change from UI
+    private void OnSoTParamsChanged()
+    {
+        // EN: Always reset RT accumulators so the next ticks start fresh with new params.
+        ResetSoTRuntimeState();
 
-        // Remove outdated trades (older than T seconds from current trade time)
-        var cutoff = trade.Time.AddSeconds(-SotTimeWindowSec);
-        while (_liveQueue.Count > 0 && _liveQueue.Peek().Time <= cutoff)
+        // EN: Clear current peaks to avoid showing stale values while recomputing
+        if (CurrentBar > 0)
         {
-            var old = _liveQueue.Dequeue();
-            int oldTicks = (old.Ticks != null ? old.Ticks.Count : 1);
-            _winTrades -= oldTicks;
-            _winDelta -= (old.Direction == TradeDirection.Buy ? old.Volume : -old.Volume);
-        }
-
-        // Only compute/update peaks if the window meets the minimum trades
-        if (_winTrades >= SotMinTrades)
-        {
-            var tradesPerSec = (decimal)_winTrades / SotTimeWindowSec;
-            var deltaPerSec = _winDelta / SotTimeWindowSec;
-
-            if (tradesPerSec > _rtPeakTradesPerSec)
+            for (int i = 0; i <= CurrentBar - 1; i++)
             {
-                _rtPeakTradesPerSec = tradesPerSec;
-                _rtPeakDeltaPerSec = deltaPerSec;
+                _peakVolPerSec[i] = 0m;
+                _peakDeltaPerSec[i] = 0m;
+                _peakDeltaPerVol[i] = 0m;
             }
         }
 
-        // Write to Peak* series (rounded to int-like display like your UI)
-        _peakVolPerSec[bar] = Math.Round(_rtPeakTradesPerSec, 0);
-        _peakDeltaPerSec[bar] = Math.Round(_rtPeakDeltaPerSec, 0);
-
-        // If bar changes, reset RT peaks for the next bar
-        if (_lastBar != bar)
+        // EN: If we already have history, recompute immediately (no waiting)
+        if (_allCumulativeTrades != null && _allCumulativeTrades.Count > 0)
         {
-            _rtPeakTradesPerSec = 0m;
-            _rtPeakDeltaPerSec = 0m;
-            _winTrades = 0;
-            _winDelta = 0m;
-            _liveQueue.Clear();
+            RebuildHistoricalSoT();
+            SeedLiveWindowFromHistory();
+            RedrawChart(); // EN: immediate visual feedback
+            return;
         }
 
-        _lastBar = bar;
+        // EN: Otherwise, request history and refresh when it arrives
+        if (CurrentBar > 0)
+        {
+            try
+            {
+                var startTime = GetCandle(0).Time;
+                var endTime = GetCandle(CurrentBar - 1).LastTime;
+
+                var req = new CumulativeTradesRequest(startTime, endTime, 0, 0);
+                RequestForCumulativeTrades(req);
+            }
+            catch
+            {
+                // EN: If candles are not ready yet, do nothing; the next full recalc will request history.
+            }
+        }
+
+        // EN: Force a redraw so the table updates quickly (even before history returns).
+        RedrawChart();
     }
 
+    // Seed the RT window (_win) from historical trades for the current live bar
+    // so that the live bar doesn't show zeros after a rebuild.
+    // Window = (nowRight - SotTimeWindowSec, nowRight], threshold & metrics in VOLUME.
+    private void SeedLiveWindowFromHistory()
+    {
+        if (CurrentBar <= 0 || _allCumulativeTrades == null || _allCumulativeTrades.Count == 0)
+            return;
+
+        int liveBar = CurrentBar - 1;
+        if (liveBar < 0) return;
+
+        var cLive = GetCandle(liveBar);
+        DateTime nowRight = cLive.LastTime;
+        DateTime cutoff = nowRight.AddSeconds(-SotTimeWindowSec);
+
+        // Reset RT window state
+        _win.Clear();
+        _winVol = 0m;
+        _winDelta = 0m;
+        _rtPeakVolPerSec = 0m;
+        _rtPeakDeltaPerSec = 0m;
+
+        // Collect trades in chronological order inside the window (cutoff, nowRight]
+        // Primero recolectamos en una lista y luego encolamos en orden.
+        var chunk = new List<CumulativeTrade>();
+
+        // Búsqueda lineal desde el final hasta salir del rango; luego invertimos.
+        for (int i = _allCumulativeTrades.Count - 1; i >= 0; i--)
+        {
+            var t = _allCumulativeTrades[i];
+            if (t.Time <= cutoff) break;          // ya fuera por la izquierda
+            if (t.Time <= nowRight) chunk.Add(t); // dentro de (cutoff, nowRight]
+        }
+        chunk.Reverse(); // aseguramos orden temporal ascendente
+
+        foreach (var t in chunk)
+        {
+            var sgnVol = (t.Direction == TradeDirection.Buy ? t.Volume : -t.Volume);
+            _win.Enqueue(new Sample { T = t.Time, Vol = t.Volume, Delta = sgnVol });
+            _winVol += t.Volume;
+            _winDelta += sgnVol;
+        }
+
+        // Purga defensiva por tiempo (igual que en RT)
+        while (_win.Count > 0 && _win.Peek().T <= cutoff)
+        {
+            var u = _win.Dequeue();
+            _winVol -= u.Vol;
+            _winDelta -= u.Delta;
+        }
+
+        // Primer snapshot RT para la live bar
+        if (_winVol >= SotMinVolume )
+        {
+            var vps = _winVol / SotTimeWindowSec;
+            var dps = _winDelta / SotTimeWindowSec;
+
+            _rtPeakVolPerSec = vps;
+            _rtPeakDeltaPerSec = dps;
+
+            var newVps = Math.Round(_rtPeakVolPerSec, 0);
+            var newDps = Math.Round(_rtPeakDeltaPerSec, 0);
+
+            if (newVps > _peakVolPerSec[liveBar])
+            {
+                _peakVolPerSec[liveBar] = newVps;
+                _peakDeltaPerSec[liveBar] = newDps;
+                _peakDeltaPerVol[liveBar] = newVps == 0m ? 0m : (newDps / newVps);
+            }
+        }
+
+        _seededLiveSoT = _win.Count > 0;
+        _hasSoTSampleThisBar = _seededLiveSoT;
+
+        // Alinear acumulados para que el siguiente OnCalculate empiece en 0 incremento
+        _rtBar = liveBar;
+        _prevCumVol = cLive.Volume;
+        _prevCumDelta = cLive.Delta;
+    }
 
 
     #endregion

--- a/Technical/ClusterStatistic.cs
+++ b/Technical/ClusterStatistic.cs
@@ -69,6 +69,8 @@ public class ClusterStatistic : Indicator
 			Add(DataType.Time, new RenderInfo(14));
 			Add(DataType.Duration, new RenderInfo(15));
             Add(DataType.DeltaSecond, new RenderInfo(16));
+            Add(DataType.PeakVolPerSec, new RenderInfo(17));
+            Add(DataType.PeakDeltaPerSec, new RenderInfo(18));
         }
 
 		#endregion
@@ -166,6 +168,8 @@ public class ClusterStatistic : Indicator
 
 		public decimal MaxVolumeSec { get; set; }
 		public decimal MaxDeltaSec { get; set; }
+        public decimal MaxPeakVolPerSec { get; set; }
+        public decimal MaxPeakDeltaPerSec { get; set; }
     }
 
 	public enum DataType
@@ -187,7 +191,9 @@ public class ClusterStatistic : Indicator
 		Height,
 		Time,
 		Duration,
-		None
+        PeakVolPerSec,
+        PeakDeltaPerSec,
+        None
 	}
 
 	#endregion
@@ -213,6 +219,8 @@ public class ClusterStatistic : Indicator
 	private readonly ValueDataSeries _cVolume = new("cVolume");
 	private readonly ValueDataSeries _deltaPerVol = new("BarDeltaPerVol");
     private readonly ValueDataSeries _deltaPerSecond = new("Delta/sec");
+    private readonly ValueDataSeries _peakVolPerSec = new("PeakVolPerSec");
+    private readonly ValueDataSeries _peakDeltaPerSec = new("PeakDeltaPerSec");
 
     private readonly RenderStringFormat _stringLeftFormat = new()
 	{
@@ -502,6 +510,22 @@ public class ClusterStatistic : Indicator
             _showDeltaPerSecond = value;
             RowsOrder.SetEnabled(DataType.DeltaSecond, value);
         }
+    }
+
+    [DisplayName("Max Vol/sec (peak)")]
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Rows), Order = 198)]
+    public bool ShowPeakVolPerSec
+    {
+        get => RowsOrder.TryGetValue(DataType.PeakVolPerSec, out var ri) && ri.Enabled;
+        set => RowsOrder.SetEnabled(DataType.PeakVolPerSec, value);
+    }
+
+    [DisplayName("Delta at Max vol/sec")]
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Rows), Order = 199)]
+    public bool ShowPeakDeltaPerSec
+    {
+        get => RowsOrder.TryGetValue(DataType.PeakDeltaPerSec, out var ri) && ri.Enabled;
+        set => RowsOrder.SetEnabled(DataType.PeakDeltaPerSec, value);
     }
 
     #endregion
@@ -1199,14 +1223,15 @@ public class ClusterStatistic : Indicator
 				Blend(candle.Delta > 0 ? AskColor : BidColor, BackGroundColor, rate),
 
 			DataType.Volume or DataType.VolumeSecond or DataType.SessionVolume or
-				DataType.Trades or DataType.Height or DataType.Time or DataType.Duration => Blend(VolumeColor, BackGroundColor, rate),
+				DataType.Trades or DataType.Height or DataType.Time or DataType.Duration or DataType.PeakVolPerSec => Blend(VolumeColor, BackGroundColor, rate),
 			DataType.MaxDelta => Blend(candle.MaxDelta > 0 ?  AskColor : BidColor, BackGroundColor, rate),
 			DataType.MinDelta => Blend(candle.MinDelta > 0 ?  AskColor : BidColor, BackGroundColor, rate),
             DataType.SessionDeltaVolume => Blend(_cDeltaPerVol[bar] > 0 ? AskColor : BidColor, BackGroundColor, rate),
 			DataType.SessionDelta => Blend(_cDelta[bar] > 0 ? AskColor : BidColor, BackGroundColor, rate),
 			DataType.DeltaChange => GetDeltaChangeBrush(candle, bar, rate),
-			DataType.None => System.Drawing.Color.Transparent,
-			_ => throw new ArgumentOutOfRangeException()
+            DataType.PeakDeltaPerSec => Blend(_peakDeltaPerSec[bar] >= 0 ? AskColor : BidColor, BackGroundColor, rate),
+            DataType.None => System.Drawing.Color.Transparent,
+            _ => throw new ArgumentOutOfRangeException()
 		};
 	}
 
@@ -1231,7 +1256,9 @@ public class ClusterStatistic : Indicator
 			DataType.Height => GetRate(_candleHeights[bar], maxValues.MaxHeight),
 			DataType.Time => GetRate(_cVolume[bar], maxValues.CumVolume),
 			DataType.Duration => GetRate(_candleDurations[bar], maxValues.MaxDuration),
-			DataType.None => 0,
+            DataType.PeakVolPerSec => GetRate(_peakVolPerSec[bar], maxValues.MaxPeakVolPerSec),
+            DataType.PeakDeltaPerSec => GetRate(Math.Abs(_peakDeltaPerSec[bar]), maxValues.MaxPeakDeltaPerSec),
+            DataType.None => 0,
 
 			_ => throw new ArgumentOutOfRangeException()
 		};
@@ -1256,6 +1283,8 @@ public class ClusterStatistic : Indicator
 		var maxTicks = 0m;
 		var maxDuration = 0m;
         decimal maxDeltaSec = 0m;
+        decimal maxPeakVolPerSec = 0m;
+        decimal maxPeakDeltaPerSec = 0m;
 
         if (VisibleProportion)
 		{
@@ -1279,6 +1308,9 @@ public class ClusterStatistic : Indicator
 
                 // Absolute peak for Delta/sec over the visible range
                 maxDeltaSec = Math.Max(Math.Abs(_deltaPerSecond[i]), maxDeltaSec);
+
+                maxPeakVolPerSec = Math.Max(maxPeakVolPerSec, Math.Abs(_peakVolPerSec[i]));
+                maxPeakDeltaPerSec = Math.Max(maxPeakDeltaPerSec, Math.Abs(_peakDeltaPerSec[i]));
 
                 if (i == 0)
 					continue;
@@ -1311,7 +1343,11 @@ public class ClusterStatistic : Indicator
 			maxHeight = _maxHeight;
 			maxVolumeSec = _volPerSecond.MAX(CurrentBar - 1, CurrentBar - 1);
             for (int i = 0; i <= CurrentBar - 1; i++)
+			{
                 maxDeltaSec = Math.Max(Math.Abs(_deltaPerSecond[i]), maxDeltaSec);
+                maxPeakVolPerSec = Math.Max(maxPeakVolPerSec, Math.Abs(_peakVolPerSec[i]));
+                maxPeakDeltaPerSec = Math.Max(maxPeakDeltaPerSec, Math.Abs(_peakDeltaPerSec[i]));
+            }
         }
 
 		return new MaxValues
@@ -1332,7 +1368,9 @@ public class ClusterStatistic : Indicator
 			MaxDeltaChange = maxDeltaChange,
 			MaxHeight = maxHeight,
 			MaxVolumeSec = maxVolumeSec,
-            MaxDeltaSec = maxDeltaSec
+            MaxDeltaSec = maxDeltaSec,
+            MaxPeakVolPerSec = maxPeakVolPerSec,
+            MaxPeakDeltaPerSec = maxPeakDeltaPerSec
         };
 	}
 
@@ -1357,6 +1395,8 @@ public class ClusterStatistic : Indicator
 			DataType.Time => candle.Time.AddHours(InstrumentInfo.TimeZone).ToString("HH:mm:ss"),
 			DataType.Duration => ((int)(candle.LastTime - candle.Time).TotalSeconds).ToString(),
             DataType.DeltaSecond => ChartInfo.TryGetMinimizedVolumeString(_deltaPerSecond[bar]),
+            DataType.PeakVolPerSec => ChartInfo.TryGetMinimizedVolumeString(_peakVolPerSec[bar]),
+            DataType.PeakDeltaPerSec => ChartInfo.TryGetMinimizedVolumeString(_peakDeltaPerSec[bar]),
             DataType.None => string.Empty,
 			_ => throw new ArgumentOutOfRangeException()
 		};
@@ -1445,6 +1485,8 @@ public class ClusterStatistic : Indicator
 			DataType.Time => "Time",
 			DataType.Duration => "Duration",
             DataType.DeltaSecond => "Delta/sec",
+            DataType.PeakVolPerSec => "Max Vol/sec",
+            DataType.PeakDeltaPerSec => "Delta at Max vol/sec",
             DataType.None => string.Empty,
 
 			_ => throw new ArgumentOutOfRangeException()

--- a/Technical/ClusterStatistic.cs
+++ b/Technical/ClusterStatistic.cs
@@ -2068,6 +2068,7 @@ public class ClusterStatistic : Indicator
         if (r >= hi) return 100m;
         return 10m + (r - lo) * (90m / (hi - lo));
     }
+    #endregion
 
     #endregion
 }

--- a/Technical/ClusterStatistic.cs
+++ b/Technical/ClusterStatistic.cs
@@ -222,6 +222,18 @@ public class ClusterStatistic : Indicator
     private readonly ValueDataSeries _peakVolPerSec = new("PeakVolPerSec");
     private readonly ValueDataSeries _peakDeltaPerSec = new("PeakDeltaPerSec");
 
+    // --- SoT core state (historical + real-time) ---
+    private List<CumulativeTrade> _allCumulativeTrades;     // historical storage
+    private readonly Queue<CumulativeTrade> _liveQueue = new(); // sliding RT window
+
+    // Sliding-window aggregates for RT
+    private int _winTrades;                 // number of executions (sum of Ticks.Count)
+    private decimal _winDelta;              // signed delta (buy vol - sell vol)
+
+    // Per-live-bar peaks while the bar is forming
+    private decimal _rtPeakTradesPerSec;    // trades/sec peak for the current live bar
+    private decimal _rtPeakDeltaPerSec;     // delta/sec at the same window as trades/sec peak
+
     private readonly RenderStringFormat _stringLeftFormat = new()
 	{
 		Alignment = StringAlignment.Near,
@@ -527,6 +539,18 @@ public class ClusterStatistic : Indicator
         get => RowsOrder.TryGetValue(DataType.PeakDeltaPerSec, out var ri) && ri.Enabled;
         set => RowsOrder.SetEnabled(DataType.PeakDeltaPerSec, value);
     }
+
+    #endregion
+
+    #region Max vol/sec settings
+
+    [Display(Name = "Time Window (sec)", GroupName = "Max vol/sec", Order = 201)]
+    [Range(1, 600)]
+    public int SotTimeWindowSec { get; set; } = 5;
+
+    [Display(Name = "Min Trades per Window", GroupName = "Max vol/sec", Order = 202)]
+    [Range(1, 100000)]
+    public int SotMinTrades { get; set; } = 150;
 
     #endregion
 
@@ -1517,5 +1541,173 @@ public class ClusterStatistic : Indicator
 		return System.Drawing.Color.FromArgb(_bgAlpha, r, g, b);
 	}
 
-	#endregion
+    protected override void OnFinishRecalculate()
+    {
+        // Clear RT window state when a full recalc completes
+        _liveQueue.Clear();
+        _winTrades = 0;
+        _winDelta = 0m;
+        _rtPeakTradesPerSec = 0m;
+        _rtPeakDeltaPerSec = 0m;
+
+        if (CurrentBar <= 0)
+            return;
+
+        // Request historical cumulative trades for the loaded range
+        var startTime = GetCandle(0).Time;
+        var endTime = GetCandle(CurrentBar - 1).LastTime;
+
+        // 0,0 means "no size filter" — ask for all trades
+        var request = new CumulativeTradesRequest(startTime, endTime, 0, 0);
+        RequestForCumulativeTrades(request);
+    }
+
+    protected override void OnCumulativeTradesResponse(CumulativeTradesRequest request, IEnumerable<CumulativeTrade> cumulativeTrades)
+    {
+        // Store and rebuild the SoT peaks over history
+        _allCumulativeTrades = cumulativeTrades?.ToList() ?? new List<CumulativeTrade>();
+        RebuildHistoricalSoT();
+    }
+
+    // Recompute SoT peaks (trades/sec peak inside each bar and its delta/sec) using historical cumulative trades
+    private void RebuildHistoricalSoT()
+    {
+        if (_allCumulativeTrades == null || _allCumulativeTrades.Count == 0 || CurrentBar <= 0)
+            return;
+
+        // Optional: clear Peak* series before full rebuild
+        for (int i = 0; i < CurrentBar; i++)
+        {
+            _peakVolPerSec[i] = 0m;
+            _peakDeltaPerSec[i] = 0m;
+        }
+
+        var q = new Queue<CumulativeTrade>();
+        int tradeIdx = 0;
+
+        // Sliding-window aggregates
+        int winTrades = 0;
+        decimal winDelta = 0m;
+
+        // Iterate bars chronologically
+        for (int bar = 0; bar < CurrentBar; bar++)
+        {
+            var c = GetCandle(bar);
+            var barStart = c.Time;
+            var barEnd = c.LastTime;
+
+            // Reset per-bar peaks
+            decimal peakTradesPerSec = 0m;
+            decimal peakDeltaPerSec = 0m;
+
+            // Move cursor to this bar's start
+            while (tradeIdx < _allCumulativeTrades.Count && _allCumulativeTrades[tradeIdx].Time < barStart)
+                tradeIdx++;
+
+            int j = tradeIdx;
+
+            // Walk through trades within this bar's time
+            while (j < _allCumulativeTrades.Count && _allCumulativeTrades[j].Time <= barEnd)
+            {
+                var t = _allCumulativeTrades[j++];
+                q.Enqueue(t);
+
+                // Count number of executions in this bundle; fallback to 1 if null
+                int ticksCount = (t.Ticks != null ? t.Ticks.Count : 1);
+                winTrades += ticksCount;
+
+                // Signed delta using Direction
+                winDelta += (t.Direction == TradeDirection.Buy ? t.Volume : -t.Volume);
+
+                // Slide the window: drop trades older than T seconds from current trade time
+                var cutoff = t.Time.AddSeconds(-SotTimeWindowSec);
+                while (q.Count > 0 && q.Peek().Time <= cutoff)
+                {
+                    var u = q.Dequeue();
+                    int uTicks = (u.Ticks != null ? u.Ticks.Count : 1);
+                    winTrades -= uTicks;
+                    winDelta -= (u.Direction == TradeDirection.Buy ? u.Volume : -u.Volume);
+                }
+
+                // Evaluate if window meets the minimum trade count
+                if (winTrades >= SotMinTrades)
+                {
+                    var tradesPerSec = (decimal)winTrades / SotTimeWindowSec; // SoT Vol/sec
+                    var deltaPerSec = winDelta / SotTimeWindowSec;            // SoT Delta/sec (same window)
+
+                    // Keep delta/sec from the window with the greatest trades/sec (break ties by higher vol/sec)
+                    if (tradesPerSec > peakTradesPerSec)
+                    {
+                        peakTradesPerSec = tradesPerSec;
+                        peakDeltaPerSec = deltaPerSec;
+                    }
+                }
+            }
+
+            // Store peak-of-bar values (0 if no window met the minimum)
+            _peakVolPerSec[bar] = Math.Round(peakTradesPerSec, 0);
+            _peakDeltaPerSec[bar] = Math.Round(peakDeltaPerSec, 0);
+        }
+    }
+
+    // Called by the platform for each incoming cumulative trade in real-time
+    protected override void OnCumulativeTrade(CumulativeTrade trade)
+    {
+        if (trade == null || trade.Volume <= 0)
+            return;
+
+        var bar = CurrentBar - 1;
+        if (bar < 0)
+            return;
+
+        // Maintain a sliding window of last SotTimeWindowSec seconds
+        _liveQueue.Enqueue(trade);
+
+        int ticksCount = (trade.Ticks != null ? trade.Ticks.Count : 1);
+        _winTrades += ticksCount;
+        _winDelta += (trade.Direction == TradeDirection.Buy ? trade.Volume : -trade.Volume);
+
+        // Remove outdated trades (older than T seconds from current trade time)
+        var cutoff = trade.Time.AddSeconds(-SotTimeWindowSec);
+        while (_liveQueue.Count > 0 && _liveQueue.Peek().Time <= cutoff)
+        {
+            var old = _liveQueue.Dequeue();
+            int oldTicks = (old.Ticks != null ? old.Ticks.Count : 1);
+            _winTrades -= oldTicks;
+            _winDelta -= (old.Direction == TradeDirection.Buy ? old.Volume : -old.Volume);
+        }
+
+        // Only compute/update peaks if the window meets the minimum trades
+        if (_winTrades >= SotMinTrades)
+        {
+            var tradesPerSec = (decimal)_winTrades / SotTimeWindowSec;
+            var deltaPerSec = _winDelta / SotTimeWindowSec;
+
+            if (tradesPerSec > _rtPeakTradesPerSec)
+            {
+                _rtPeakTradesPerSec = tradesPerSec;
+                _rtPeakDeltaPerSec = deltaPerSec;
+            }
+        }
+
+        // Write to Peak* series (rounded to int-like display like your UI)
+        _peakVolPerSec[bar] = Math.Round(_rtPeakTradesPerSec, 0);
+        _peakDeltaPerSec[bar] = Math.Round(_rtPeakDeltaPerSec, 0);
+
+        // If bar changes, reset RT peaks for the next bar
+        if (_lastBar != bar)
+        {
+            _rtPeakTradesPerSec = 0m;
+            _rtPeakDeltaPerSec = 0m;
+            _winTrades = 0;
+            _winDelta = 0m;
+            _liveQueue.Clear();
+        }
+
+        _lastBar = bar;
+    }
+
+
+
+    #endregion
 }


### PR DESCRIPTION
# feat(ClusterStatistic): basic footprint imbalances (buy/sell/net) + optional Net alert

## Summary
Adds **basic intra-bar footprint imbalance counters**:
- **BuyImbalance** (count of buy-side imbalances),
- **SellImbalance** (count of sell-side imbalances),
- **NetImbalance** (Buy − Sell).

Includes configurable **threshold (%)** and **minimum volume filter** per price level, plus an **optional Net Imbalance alert**.

---

## What’s included
- **New rows & series**
  - `DataType.BuyImbalance`, `DataType.SellImbalance`, `DataType.NetImbalance`
  - Backing series: `_buyImbalance`, `_sellImbalance`, `_netImbalance`
  - Default: rows appended at the end; **OFF by default**

- **Detection logic (per candle)**
  - Iterate price levels (upper ask vs lower bid) and classify:
    - **Buy imbalance** when `upper.Ask / lower.Bid >= ImbalanceThreshold%` **and** `(upper.Ask − lower.Bid) >= ImbalanceVolumeFilter`
    - **Sell imbalance** (mirror condition)
  - Aggregate per candle: `NetImbalance = BuyImbalance − SellImbalance`

- **Parameters (Imbalance group)**
  - `ImbalanceThreshold` (%, default **300**)
  - `ImbalanceVolumeFilter` (default **30**)

- **Optional alert (Net Imbalance)**
  - `UseNetImbalanceAlert` (toggle)
  - `NetImbalanceAlertValue` (absolute threshold)
  - `UseClosedCandleForNetImbalanceAlert` (evaluate on closed candle or live)
  - `NetImbalanceAlertFile` (sound id)
  - Debounced via `_lastNetImbalanceAlert` per bar

- **Rendering**
  - **Colors**:
    - Buy → `AskColor`
    - Sell → `BidColor`
    - Net → `AskColor` when `>= 0`, `BidColor` when `< 0`
  - **Scaling**:
    - Buy/Sell by their respective max counts
    - Net by `abs(NetImbalance)` max

- **UI**
  - Toggles under *Rows*: **Buy Imbalances**, **Sell Imbalances**, **Net Imbalances**
  - Simple headers: “Buy Imb.”, “Sell Imb.”, “Net Imb.”
  - Value text: integers; Net uses signed format `+#;-#;0`

---

## Backward compatibility
- ✅ **No breaking changes** — rows appended; no reorder of existing indices
- ✅ Defaults OFF; existing layouts unchanged unless toggled on

---

## Performance
- O(n) over visible candle price levels; integer counters only
- No heavy allocations; uses existing candle price-volume accessors

---

## How to use
1. Enable **Buy Imbalances**, **Sell Imbalances**, and/or **Net Imbalances** in *Rows*.
2. In *Imbalance* settings:
   - Set **Imbalance Threshold (%)** (e.g., 300)
   - Set **Imbalance Volume Filter** (e.g., 30)
3. (Optional) Turn on **Net Imbalance Alert** and configure the threshold and source (closed or live candle).

---

## Testing steps
1. Load a symbol with footprint data and enable the new rows.
2. Move the threshold between **200–400%** and the volume filter between **0–100** to verify sensitivity.
3. Visually confirm:
   - Buy/Sell counts reflect expected side dominance at adjacent price levels.
   - **Net Imbalance** sign flips with side predominance.
4. Alert test:
   - Set `NetImbalanceAlertValue` low (e.g., 1–2) and toggle `UseClosedCandleForNetImbalanceAlert` to verify both modes trigger `AddAlert(...)` once per bar.

---

## Screenshot
<img width="755" height="203" alt="image" src="https://github.com/user-attachments/assets/ba7adb62-116f-46bf-a810-337fff5617f1" />
