### PR TITLE
Feature/delta threshold: add price-panel triangle signals and configurable threshold lines

### DIFF
--- a/Technical/Delta.cs
+++ b/Technical/Delta.cs
@@ -385,17 +385,19 @@ public class Delta : Indicator
             }
         }
 
-        // --- price signals (UI) ---
-        [Display(ResourceType = typeof(Strings), Name = "ShowPriceSignals", GroupName = nameof(Strings.Visualization),
-            Description = "Draw visual signals on price when delta crosses thresholds", Order = 70)]
+    // --- price signals (UI) ---
+        [DisplayName("Show Signals at Price")]
+        [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization),
+        Description = "Draw visual signals on price when delta crosses thresholds", Order = 70)]
         public bool ShowPriceSignals
         {
             get => _showPriceSignals;
             set { _showPriceSignals = value; RedrawChart(); }
         }
 
-        [Display(ResourceType = typeof(Strings), Name = "PriceSignalOffsetTicks", GroupName = nameof(Strings.Visualization),
-            Description = "Distance from High/Low in ticks", Order = 80)]
+        [DisplayName("Price signal Offset ticks")]
+        [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization),
+        Description = "Distance from High/Low in ticks", Order = 80)]
         [Range(0, 50)]
         public int PriceSignalOffsetTicks
         {
@@ -403,8 +405,9 @@ public class Delta : Indicator
             set { _priceSignalOffsetTicks = value; RedrawChart(); }
         }
 
-        [Display(ResourceType = typeof(Strings), Name = "PriceSignalSize", GroupName = nameof(Strings.Visualization),
-            Description = "Signal size in pixels", Order = 90)]
+        [DisplayName("Price Signal Size")]
+        [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization),
+        Description = "Signal size in pixels", Order = 90)]
         [Range(6, 24)]
         public int PriceSignalSize
         {
@@ -412,16 +415,18 @@ public class Delta : Indicator
             set { _priceSignalSize = value; RedrawChart(); }
         }
 
-        [Display(ResourceType = typeof(Strings), Name = "PriceSignalUpColor", GroupName = nameof(Strings.Drawing),
-            Description = "Up signal color", Order = 95)]
+        [DisplayName("Price Signal up color")]
+        [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization),
+        Description = "Up signal color", Order = 95)]
         public CrossColor PriceSignalUpColor
         {
             get => _priceSignalUpColor.Convert();
             set { _priceSignalUpColor = value.Convert(); RedrawChart(); }
         }
 
-        [Display(ResourceType = typeof(Strings), Name = "PriceSignalDownColor", GroupName = nameof(Strings.Drawing),
-            Description = "Down signal color", Order = 96)]
+        [DisplayName("Price Signal down color")]
+        [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization),
+        Description = "Down signal color", Order = 96)]
         public CrossColor PriceSignalDownColor
         {
             get => _priceSignalDownColor.Convert();
@@ -474,14 +479,14 @@ public class Delta : Indicator
 
         #region Divergence
 
-    private Indicators.FilterColor _divergenceBarsFilter = new(true) { Enabled = false, Value = CrossColor.FromArgb(255, 255, 165, 0) };
+        private Indicators.FilterColor _divergenceBarsFilter = new(true) { Enabled = false, Value = CrossColor.FromArgb(255, 255, 165, 0) };
 
         [Display(ResourceType = typeof(Strings), Name = "DivergenceDots", GroupName = nameof(Strings.Divergence),
             Description = nameof(Strings.BarDirVsDeltaDivergenceDescription), Order = 130)]
         public bool ShowDivergence { get; set; }
 
         [Display(ResourceType = typeof(Strings), Name = "DivergenceBars", GroupName = nameof(Strings.Divergence), Order = 135)]
-    public Indicators.FilterColor DivergenceBarsFilter
+        public Indicators.FilterColor DivergenceBarsFilter
         {
             get => _divergenceBarsFilter;
             set
@@ -637,25 +642,38 @@ public class Delta : Indicator
             Description = nameof(Strings.AlertFillColorDescription), Order = 340)]
         public CrossColor AlertBGColor { get; set; } = CrossColor.FromArgb(255, 75, 72, 72);
 
-        // Threshold lines (UI)
-        [Display(ResourceType = typeof(Strings), Name = "ShowThresholdLines",
-            GroupName = nameof(Strings.Visualization), Description = "Show horizontal threshold lines in the Delta panel", Order = 360)]
+    // Threshold lines (UI)
+        [DisplayName("Show Threshold lines")]
+        [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization),
+        Description = "Show horizontal threshold lines in the Delta panel", Order = 360)]
         public bool ShowThresholdLines { get; set; } = true;
 
-        [Display(ResourceType = typeof(Strings), Name = "UpMajorLevel",
-            GroupName = nameof(Strings.Filters), Description = "Upper major threshold", Order = 361)]
+        [DisplayName("Upper major")]
+        [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization),
+        Description = "Upper major threshold", Order = 361)]
+        [Range(0, int.MaxValue)]
+        [DisplayFormat(DataFormatString = "F0")]
         public decimal UpMajorLevel { get; set; } = 500m;
 
-        [Display(ResourceType = typeof(Strings), Name = "UpMinorLevel",
-            GroupName = nameof(Strings.Filters), Description = "Upper minor threshold", Order = 362)]
-        public decimal UpMinorLevel { get; set; } = 250m;
+        [DisplayName("Upper minor")]
+        [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization), 
+        Description = "Upper minor threshold", Order = 362)]
+        [Range(0, int.MaxValue)]
+        [DisplayFormat(DataFormatString = "F0")]
+    public decimal UpMinorLevel { get; set; } = 250m;
 
-        [Display(ResourceType = typeof(Strings), Name = "DownMinorLevel",
-            GroupName = nameof(Strings.Filters), Description = "Lower minor threshold", Order = 363)]
+        [DisplayName("Lower minor")]
+        [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization),
+        Description = "Lower minor threshold", Order = 363)]
+        [Range(int.MinValue, 0)]
+        [DisplayFormat(DataFormatString = "F0")]
         public decimal DownMinorLevel { get; set; } = -250m;
 
-        [Display(ResourceType = typeof(Strings), Name = "DownMajorLevel",
-            GroupName = nameof(Strings.Filters), Description = "Lower major threshold", Order = 364)]
+        [DisplayName("Lower major")]
+        [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization),
+        Description = "Lower major threshold", Order = 364)]
+        [Range(int.MinValue, 0)]
+        [DisplayFormat(DataFormatString = "F0")]
         public decimal DownMajorLevel { get; set; } = -500m;
 
         #endregion

--- a/Technical/Delta.cs
+++ b/Technical/Delta.cs
@@ -19,688 +19,861 @@ using CrossColor = CrossColor;
 [HelpLink("https://help.atas.net/support/solutions/articles/72000602362")]
 public class Delta : Indicator
 {
-	#region Nested types
+     #region Nested types
 
-	[Serializable]
-	public enum BarDirection
-	{
-		[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Any))]
-		Any = 0,
-
-		[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Bullish))]
-		Bullish = 1,
-
-		[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Bearlish))]
-		Bearlish = 2
-	}
-
-	[Serializable]
-	public enum DeltaType
-	{
-		[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Any))]
-		Any = 0,
-
-		[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Positive))]
-		Positive = 1,
-
-		[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Negative))]
-		Negative = 2
-	}
-
-	[Serializable]
-	public enum DeltaVisualMode
-	{
-		[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Candles))]
-		Candles = 0,
-
-		[Display(ResourceType = typeof(Strings), Name = nameof(Strings.HighLow))]
-		HighLow = 1,
-
-		[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Histogram))]
-		Histogram = 2,
-
-		[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Bars))]
-		Bars = 3
-	}
-
-	public enum Location
-	{
-		[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Up))]
-		Up,
-
-		[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Middle))]
-		Middle,
-
-		[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Down))]
-		Down
-	}
-
-	#endregion
-
-	#region Fields
-
-	private readonly CandleDataSeries _candles = new("Candles", "Delta candles")
-	{
-		DownCandleColor = Color.Red.Convert(),
-		UpCandleColor = Color.Green.Convert(),
-		IsHidden = true,
-		ShowCurrentValue = false,
-		UseMinimizedModeIfEnabled = true,
-		ResetAlertsOnNewBar = true
-	};
-
-	private readonly ValueDataSeries _currentValues = new("CurrentValues", "Current Values")
-	{
-		IsHidden = true,
-		VisualType = VisualMode.OnlyValueOnAxis,
-		ShowZeroValue = false,
-		UseMinimizedModeIfEnabled = true,
-		IgnoredByAlerts = true
-	};
-
-	private readonly ValueDataSeries _delta = new("DeltaId", "Delta")
-	{
-		Color = Color.Red.Convert(),
-		VisualType = VisualMode.Hide,
-		ShowZeroValue = false,
-		ShowCurrentValue = false,
-		IsHidden = true,
-		UseMinimizedModeIfEnabled = true,
-		ResetAlertsOnNewBar = true
-	};
-
-	private readonly ValueDataSeries _diapasonHigh = new("DiapasonHigh", "Delta range high")
-	{
-		Color = CrossColor.FromArgb(128, 128, 128, 128),
-		ShowZeroValue = false,
-		ShowCurrentValue = false,
-		VisualType = VisualMode.Hide,
-		IsHidden = true,
-		UseMinimizedModeIfEnabled = true,
-		IgnoredByAlerts = true
-	};
-
-	private readonly ValueDataSeries _diapasonLow = new("DiapasonLow", "Delta range low")
-	{
-		Color = CrossColor.FromArgb(128, 128, 128, 128),
-		ShowZeroValue = false,
-		ShowCurrentValue = false,
-		VisualType = VisualMode.Hide,
-		IsHidden = true,
-		UseMinimizedModeIfEnabled = true,
-		IgnoredByAlerts = true
-	};
-
-	private readonly Dictionary<int, bool> _divergenceBars = new();
-
-	private readonly CandleDataSeries _divergenceCandles = new("DivergenceCandles", "Divergence candles")
-	{
-		IsHidden = false,
-		ShowCurrentValue = false,
-		UseMinimizedModeIfEnabled = true,
-		Visible = false,
-		DrawCandleBorder = false
-	};
-
-	private readonly CandleDataSeries _divergenceDownCandles = new("DivergenceDownCandles", "Divergence down candles")
-	{
-		IsHidden = false,
-		ShowCurrentValue = false,
-		UseMinimizedModeIfEnabled = true,
-		Visible = false,
-		DrawCandleBorder = false
-	};
-
-	private readonly CandleDataSeries _downCandles = new("DownCandles", "Delta candles")
-	{
-		DownCandleColor = Color.Green.Convert(),
-		UpCandleColor = Color.Red.Convert(),
-		IsHidden = true,
-		ShowCurrentValue = false,
-		UseMinimizedModeIfEnabled = true,
-		ResetAlertsOnNewBar = true
-	};
-
-	private BarDirection _barDirection;
-	private DeltaType _deltaType;
-	private Color _downColor = Color.Red;
-
-	private ValueDataSeries _downSeries = new("DownSeries", Strings.Down)
-	{
-		VisualType = VisualMode.Hide,
-		IsHidden = true,
-		UseMinimizedModeIfEnabled = true,
-		IgnoredByAlerts = true
-	};
-
-	private decimal _filter;
-
-	private Color _fontColor;
-
-	private RenderStringFormat _format = new()
-	{
-		Alignment = StringAlignment.Center,
-		LineAlignment = StringAlignment.Center
-	};
-
-	private int _lastBar;
-	private int _lastBarAlert;
-	private int _lastBarNegativeAlert;
-	private bool _minimizedMode;
-	private DeltaVisualMode _mode = DeltaVisualMode.Candles;
-
-	private Color _neutralColor = Color.Gray;
-	private decimal _prevDeltaValue;
-	private bool _showCurrentValues = true;
-
-	private Color _upColor = Color.Green;
-
-	private ValueDataSeries _upSeries = new("UpSeries", Strings.Up)
-	{
-		Color = Color.Green.Convert(),
-		VisualType = VisualMode.Hide,
-		IsHidden = true,
-		UseMinimizedModeIfEnabled = true,
-		IgnoredByAlerts = true
-	};
-
-    #endregion
-
-    #region Properties
-
-    #region Visualization
-
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.VisualMode), GroupName = nameof(Strings.Visualization),
-        Description = nameof(Strings.VisualModeDescription), Order = 10)]
-    public DeltaVisualMode Mode
-    {
-        get => _mode;
-        set
+        [Serializable]
+        public enum BarDirection
         {
-            _mode = value;
+            [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Any))]
+            Any = 0,
 
-            if (_mode == DeltaVisualMode.Histogram)
+            [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Bullish))]
+            Bullish = 1,
+
+            [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Bearlish))]
+            Bearlish = 2
+        }
+
+        [Serializable]
+        public enum DeltaType
+        {
+            [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Any))]
+            Any = 0,
+
+            [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Positive))]
+            Positive = 1,
+
+            [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Negative))]
+            Negative = 2
+        }
+
+        [Serializable]
+        public enum DeltaVisualMode
+        {
+            [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Candles))]
+            Candles = 0,
+
+            [Display(ResourceType = typeof(Strings), Name = nameof(Strings.HighLow))]
+            HighLow = 1,
+
+            [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Histogram))]
+            Histogram = 2,
+
+            [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Bars))]
+            Bars = 3
+        }
+
+        public enum Location
+        {
+            [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Up))]
+            Up,
+
+            [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Middle))]
+            Middle,
+
+            [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Down))]
+            Down
+        }
+
+        #endregion
+
+        #region Fields
+
+        private readonly CandleDataSeries _candles = new("Candles", "Delta candles")
+        {
+            DownCandleColor = Color.Red.Convert(),
+            UpCandleColor = Color.Green.Convert(),
+            IsHidden = true,
+            ShowCurrentValue = false,
+            UseMinimizedModeIfEnabled = true,
+            ResetAlertsOnNewBar = true
+        };
+
+        private readonly ValueDataSeries _currentValues = new("CurrentValues", "Current Values")
+        {
+            IsHidden = true,
+            VisualType = VisualMode.OnlyValueOnAxis,
+            ShowZeroValue = false,
+            UseMinimizedModeIfEnabled = true,
+            IgnoredByAlerts = true
+        };
+
+        private readonly ValueDataSeries _delta = new("DeltaId", "Delta")
+        {
+            Color = Color.Red.Convert(),
+            VisualType = VisualMode.Hide,
+            ShowZeroValue = false,
+            ShowCurrentValue = false,
+            IsHidden = true,
+            UseMinimizedModeIfEnabled = true,
+            ResetAlertsOnNewBar = true
+        };
+
+        private readonly ValueDataSeries _diapasonHigh = new("DiapasonHigh", "Delta range high")
+        {
+            Color = CrossColor.FromArgb(128, 128, 128, 128),
+            ShowZeroValue = false,
+            ShowCurrentValue = false,
+            VisualType = VisualMode.Hide,
+            IsHidden = true,
+            UseMinimizedModeIfEnabled = true,
+            IgnoredByAlerts = true
+        };
+
+        private readonly ValueDataSeries _diapasonLow = new("DiapasonLow", "Delta range low")
+        {
+            Color = CrossColor.FromArgb(128, 128, 128, 128),
+            ShowZeroValue = false,
+            ShowCurrentValue = false,
+            VisualType = VisualMode.Hide,
+            IsHidden = true,
+            UseMinimizedModeIfEnabled = true,
+            IgnoredByAlerts = true
+        };
+
+        private readonly Dictionary<int, bool> _divergenceBars = new();
+
+        private readonly CandleDataSeries _divergenceCandles = new("DivergenceCandles", "Divergence candles")
+        {
+            IsHidden = false,
+            ShowCurrentValue = false,
+            UseMinimizedModeIfEnabled = true,
+            Visible = false,
+            DrawCandleBorder = false
+        };
+
+        private readonly CandleDataSeries _divergenceDownCandles = new("DivergenceDownCandles", "Divergence down candles")
+        {
+            IsHidden = false,
+            ShowCurrentValue = false,
+            UseMinimizedModeIfEnabled = true,
+            Visible = false,
+            DrawCandleBorder = false
+        };
+
+        private readonly CandleDataSeries _downCandles = new("DownCandles", "Delta candles")
+        {
+            DownCandleColor = Color.Green.Convert(),
+            UpCandleColor = Color.Red.Convert(),
+            IsHidden = true,
+            ShowCurrentValue = false,
+            UseMinimizedModeIfEnabled = true,
+            ResetAlertsOnNewBar = true
+        };
+
+        private BarDirection _barDirection;
+        private DeltaType _deltaType;
+        private Color _downColor = Color.Red;
+
+        private ValueDataSeries _downSeries = new("DownSeries", Strings.Down)
+        {
+            VisualType = VisualMode.Hide,
+            IsHidden = true,
+            UseMinimizedModeIfEnabled = true,
+            IgnoredByAlerts = true
+        };
+
+        private decimal _filter;
+
+        private Color _fontColor;
+
+        private RenderStringFormat _format = new()
+        {
+            Alignment = StringAlignment.Center,
+            LineAlignment = StringAlignment.Center
+        };
+
+        private int _lastBar;
+        private int _lastBarAlert;
+        private int _lastBarNegativeAlert;
+        private bool _minimizedMode;
+        private DeltaVisualMode _mode = DeltaVisualMode.Candles;
+
+        private Color _neutralColor = Color.Gray;
+        private decimal _prevDeltaValue;
+        private bool _showCurrentValues = true;
+
+        private Color _upColor = Color.Green;
+
+        private ValueDataSeries _upSeries = new("UpSeries", Strings.Up)
+        {
+            Color = Color.Green.Convert(),
+            VisualType = VisualMode.Hide,
+            IsHidden = true,
+            UseMinimizedModeIfEnabled = true,
+            IgnoredByAlerts = true
+        };
+
+        #endregion
+
+        #region Fields (price signals)
+
+        private readonly ValueDataSeries _priceSignalUp = new("PriceSignalUp", "Price Signal Up")
+        {
+            VisualType = VisualMode.Hide,
+            IsHidden = true,
+            UseMinimizedModeIfEnabled = true,
+            IgnoredByAlerts = true
+        };
+
+        private readonly ValueDataSeries _priceSignalDown = new("PriceSignalDown", "Price Signal Down")
+        {
+            VisualType = VisualMode.Hide,
+            IsHidden = true,
+            UseMinimizedModeIfEnabled = true,
+            IgnoredByAlerts = true
+        };
+
+        private bool _showPriceSignals = true;
+        private int _priceSignalOffsetTicks = 2;
+        private int _priceSignalSize = 10;
+        private Color _priceSignalUpColor = Color.Lime;
+        private Color _priceSignalDownColor = Color.Fuchsia;
+
+        #endregion
+
+        #region Fields (threshold lines)
+
+        private readonly ValueDataSeries _upMajor = new("UpMajor", "Up Major") { VisualType = VisualMode.Line, ShowCurrentValue = false, UseMinimizedModeIfEnabled = true };
+        private readonly ValueDataSeries _upMinor = new("UpMinor", "Up Minor") { VisualType = VisualMode.Line, ShowCurrentValue = false, UseMinimizedModeIfEnabled = true };
+        private readonly ValueDataSeries _dnMinor = new("DnMinor", "Down Minor") { VisualType = VisualMode.Line, ShowCurrentValue = false, UseMinimizedModeIfEnabled = true };
+        private readonly ValueDataSeries _dnMajor = new("DnMajor", "Down Major") { VisualType = VisualMode.Line, ShowCurrentValue = false, UseMinimizedModeIfEnabled = true };
+
+        private void SetupThresholdPens()
+        {
+            // Solid majors
+            _upMajor.Color = CrossColor.FromArgb(255, 255, 165, 0);   // orange
+            _upMajor.Width = 2;
+            _upMajor.LineDashStyle = LineDashStyle.Solid;
+
+            _dnMajor.Color = CrossColor.FromArgb(255, 128, 0, 128);   // purple
+            _dnMajor.Width = 2;
+            _dnMajor.LineDashStyle = LineDashStyle.Solid;
+
+            // Dotted minors
+            _upMinor.Color = CrossColor.FromArgb(255, 255, 215, 0);   // yellow
+            _upMinor.Width = 2;
+            _upMinor.LineDashStyle = LineDashStyle.Dot;
+
+            _dnMinor.Color = CrossColor.FromArgb(255, 30, 144, 255);  // dodger blue
+            _dnMinor.Width = 2;
+            _dnMinor.LineDashStyle = LineDashStyle.Dot;
+        }
+
+        #endregion
+
+        #region Properties
+
+        #region Visualization
+
+        [Display(ResourceType = typeof(Strings), Name = nameof(Strings.VisualMode), GroupName = nameof(Strings.Visualization),
+            Description = nameof(Strings.VisualModeDescription), Order = 10)]
+        public DeltaVisualMode Mode
+        {
+            get => _mode;
+            set
             {
-                _delta.VisualType = VisualMode.Histogram;
-                _diapasonHigh.VisualType = VisualMode.Hide;
-                _diapasonLow.VisualType = VisualMode.Hide;
-                _candles.Visible = _downCandles.Visible = false;
-                _divergenceCandles.Visible = _divergenceDownCandles.Visible = false;
+                _mode = value;
+
+                if (_mode == DeltaVisualMode.Histogram)
+                {
+                    _delta.VisualType = VisualMode.Histogram;
+                    _diapasonHigh.VisualType = VisualMode.Hide;
+                    _diapasonLow.VisualType = VisualMode.Hide;
+                    _candles.Visible = _downCandles.Visible = false;
+                    _divergenceCandles.Visible = _divergenceDownCandles.Visible = false;
+                }
+                else if (_mode == DeltaVisualMode.HighLow)
+                {
+                    _delta.VisualType = VisualMode.Histogram;
+                    _diapasonHigh.VisualType = VisualMode.Histogram;
+                    _diapasonLow.VisualType = VisualMode.Histogram;
+                    _candles.Visible = _downCandles.Visible = false;
+                    _divergenceCandles.Visible = _divergenceDownCandles.Visible = false;
+                }
+                else if (_mode == DeltaVisualMode.Candles)
+                {
+                    _delta.VisualType = VisualMode.Hide;
+                    _diapasonHigh.VisualType = VisualMode.Hide;
+                    _diapasonLow.VisualType = VisualMode.Hide;
+                    _candles.Visible = _downCandles.Visible = true;
+                    _candles.Mode = _downCandles.Mode = CandleVisualMode.Candles;
+                    _divergenceCandles.Mode = _divergenceDownCandles.Mode = CandleVisualMode.Candles;
+                }
+                else
+                {
+                    _delta.VisualType = VisualMode.Hide;
+                    _diapasonHigh.VisualType = VisualMode.Hide;
+                    _diapasonLow.VisualType = VisualMode.Hide;
+                    _candles.Visible = _downCandles.Visible = true;
+                    _candles.Mode = _downCandles.Mode = CandleVisualMode.Bars;
+                    _divergenceCandles.Mode = _divergenceDownCandles.Mode = CandleVisualMode.Bars;
+                }
+
+                RaisePropertyChanged("Mode");
+                RecalculateValues();
+
+                ApplyDivergenceColorsToCurrentMode();
+                UpdateDivergenceCandlesVisibility();
             }
-            else if (_mode == DeltaVisualMode.HighLow)
+        }
+
+        [Display(ResourceType = typeof(Strings), Name = nameof(Strings.MinimizedMode), GroupName = nameof(Strings.Visualization),
+            Description = nameof(Strings.HistogramMinimizedModeDescription), Order = 20)]
+
+        public bool MinimizedMode
+        {
+            get => _minimizedMode;
+            set
             {
-                _delta.VisualType = VisualMode.Histogram;
-                _diapasonHigh.VisualType = VisualMode.Histogram;
-                _diapasonLow.VisualType = VisualMode.Histogram;
-                _candles.Visible = _downCandles.Visible = false;
-                _divergenceCandles.Visible = _divergenceDownCandles.Visible = false;
+                _minimizedMode = value;
+                RaisePropertyChanged("MinimizedMode");
+                RecalculateValues();
+                UpdateDivergenceCandlesVisibility();
             }
-            else if (_mode == DeltaVisualMode.Candles)
+        }
+
+        [Display(ResourceType = typeof(Strings), Name = nameof(Strings.ShowCurrentValue), GroupName = nameof(Strings.Visualization),
+            Description = nameof(Strings.ShowCurrentValueDescription), Order = 30)]
+        public bool ShowCurrentValues
+        {
+            get => _showCurrentValues;
+            set
             {
-                _delta.VisualType = VisualMode.Hide;
-                _diapasonHigh.VisualType = VisualMode.Hide;
-                _diapasonLow.VisualType = VisualMode.Hide;
-                _candles.Visible = _downCandles.Visible = true;
-                _candles.Mode = _downCandles.Mode = CandleVisualMode.Candles;
-                _divergenceCandles.Mode = _divergenceDownCandles.Mode = CandleVisualMode.Candles;
+                _showCurrentValues = value;
+                _currentValues.ShowCurrentValue = value;
             }
-            else
+        }
+
+        [Display(ResourceType = typeof(Strings), Name = nameof(Strings.BullishColor), GroupName = nameof(Strings.Drawing),
+            Description = nameof(Strings.PositiveValueColorDescription), Order = 40)]
+        public CrossColor UpColor
+        {
+            get => _upColor.Convert();
+            set
             {
-                _delta.VisualType = VisualMode.Hide;
-                _diapasonHigh.VisualType = VisualMode.Hide;
-                _diapasonLow.VisualType = VisualMode.Hide;
-                _candles.Visible = _downCandles.Visible = true;
-                _candles.Mode = _downCandles.Mode = CandleVisualMode.Bars;
-                _divergenceCandles.Mode = _divergenceDownCandles.Mode = CandleVisualMode.Bars;
+                _upColor = value.Convert();
+                _candles.UpCandleColor = value;
+                _upSeries.Color = value;
             }
-
-            RaisePropertyChanged("Mode");
-            RecalculateValues();
-
-			ApplyDivergenceColorsToCurrentMode();
-            UpdateDivergenceCandlesVisibility();
         }
-    }
 
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.MinimizedMode), GroupName = nameof(Strings.Visualization),
-        Description = nameof(Strings.HistogramMinimizedModeDescription), Order = 20)]
-
-    public bool MinimizedMode
-    {
-        get => _minimizedMode;
-        set
+        [Display(ResourceType = typeof(Strings), Name = nameof(Strings.BearlishColor), GroupName = nameof(Strings.Drawing),
+            Description = nameof(Strings.NegativeValueColorDescription), Order = 50)]
+        public CrossColor DownColor
         {
-            _minimizedMode = value;
-            RaisePropertyChanged("MinimizedMode");
-            RecalculateValues();
-			UpdateDivergenceCandlesVisibility();
+            get => _downColor.Convert();
+            set
+            {
+                _downColor = value.Convert();
+                _candles.DownCandleColor = value;
+                _downCandles.UpCandleColor = value;
+                _downSeries.Color = value;
+            }
         }
-    }
 
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.ShowCurrentValue), GroupName = nameof(Strings.Visualization),
-        Description = nameof(Strings.ShowCurrentValueDescription), Order = 30)]
-    public bool ShowCurrentValues
-    {
-        get => _showCurrentValues;
-        set
+        [Display(ResourceType = typeof(Strings), Name = nameof(Strings.NeutralBorderColor), GroupName = nameof(Strings.Drawing),
+            Description = nameof(Strings.NeutralValueDescription), Order = 60)]
+        public CrossColor NeutralColor
         {
-            _showCurrentValues = value;
-            _currentValues.ShowCurrentValue = value;
+            get => _neutralColor.Convert();
+            set
+            {
+                _neutralColor = value.Convert();
+                _candles.BorderColor = _downCandles.BorderColor = value;
+                _diapasonHigh.Color = _diapasonLow.Color = value;
+            }
         }
-    }
 
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.BullishColor), GroupName = nameof(Strings.Drawing),
-        Description = nameof(Strings.PositiveValueColorDescription), Order = 40)]
-    public CrossColor UpColor
-    {
-        get => _upColor.Convert();
-        set
+        // --- price signals (UI) ---
+        [Display(ResourceType = typeof(Strings), Name = "ShowPriceSignals", GroupName = nameof(Strings.Visualization),
+            Description = "Draw visual signals on price when delta crosses thresholds", Order = 70)]
+        public bool ShowPriceSignals
         {
-            _upColor = value.Convert();
-            _candles.UpCandleColor = value;
-            _upSeries.Color = value;
+            get => _showPriceSignals;
+            set { _showPriceSignals = value; RedrawChart(); }
         }
-    }
 
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.BearlishColor), GroupName = nameof(Strings.Drawing),
-        Description = nameof(Strings.NegativeValueColorDescription), Order = 50)]
-    public CrossColor DownColor
-    {
-        get => _downColor.Convert();
-        set
+        [Display(ResourceType = typeof(Strings), Name = "PriceSignalOffsetTicks", GroupName = nameof(Strings.Visualization),
+            Description = "Distance from High/Low in ticks", Order = 80)]
+        [Range(0, 50)]
+        public int PriceSignalOffsetTicks
         {
-            _downColor = value.Convert();
-            _candles.DownCandleColor = value;
-            _downCandles.UpCandleColor = value;
-            _downSeries.Color = value;
+            get => _priceSignalOffsetTicks;
+            set { _priceSignalOffsetTicks = value; RedrawChart(); }
         }
-    }
 
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.NeutralBorderColor), GroupName = nameof(Strings.Drawing),
-        Description = nameof(Strings.NeutralValueDescription), Order = 60)]
-    public CrossColor NeutralColor
-    {
-        get => _neutralColor.Convert();
-        set
+        [Display(ResourceType = typeof(Strings), Name = "PriceSignalSize", GroupName = nameof(Strings.Visualization),
+            Description = "Signal size in pixels", Order = 90)]
+        [Range(6, 24)]
+        public int PriceSignalSize
         {
-            _neutralColor = value.Convert();
-            _candles.BorderColor = _downCandles.BorderColor = value;
-            _diapasonHigh.Color = _diapasonLow.Color = value;
+            get => _priceSignalSize;
+            set { _priceSignalSize = value; RedrawChart(); }
         }
-    }
 
-    #endregion
-
-    #region Filters
-
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.BarsDirection), GroupName = nameof(Strings.Filters),
-        Description = nameof(Strings.BarDirectionDescription), Order = 100)]
-    public BarDirection BarsDirection
-    {
-        get => _barDirection;
-        set
+        [Display(ResourceType = typeof(Strings), Name = "PriceSignalUpColor", GroupName = nameof(Strings.Drawing),
+            Description = "Up signal color", Order = 95)]
+        public CrossColor PriceSignalUpColor
         {
-            _barDirection = value;
-            RecalculateValues();
+            get => _priceSignalUpColor.Convert();
+            set { _priceSignalUpColor = value.Convert(); RedrawChart(); }
         }
-    }
 
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.DeltaType), GroupName = nameof(Strings.Filters),
-        Description = nameof(Strings.DeltaTypeDescription), Order = 110)]
-    public DeltaType DeltaTypes
-    {
-        get => _deltaType;
-        set
+        [Display(ResourceType = typeof(Strings), Name = "PriceSignalDownColor", GroupName = nameof(Strings.Drawing),
+            Description = "Down signal color", Order = 96)]
+        public CrossColor PriceSignalDownColor
         {
-            _deltaType = value;
-            RecalculateValues();
+            get => _priceSignalDownColor.Convert();
+            set { _priceSignalDownColor = value.Convert(); RedrawChart(); }
         }
-    }
 
-    [Parameter]
-    [Range(0, int.MaxValue)]
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Filter), GroupName = nameof(Strings.Filters),
-        Description = nameof(Strings.MinDeltaVolumeFilterCommonDescription), Order = 120)]
-    public decimal Filter
-    {
-        get => _filter;
-        set
+        #endregion
+
+        #region Filters
+
+        [Display(ResourceType = typeof(Strings), Name = nameof(Strings.BarsDirection), GroupName = nameof(Strings.Filters),
+            Description = nameof(Strings.BarDirectionDescription), Order = 100)]
+        public BarDirection BarsDirection
         {
-            _filter = value;
-            RecalculateValues();
+            get => _barDirection;
+            set
+            {
+                _barDirection = value;
+                RecalculateValues();
+            }
         }
-    }
 
-    #endregion
+        [Display(ResourceType = typeof(Strings), Name = nameof(Strings.DeltaType), GroupName = nameof(Strings.Filters),
+            Description = nameof(Strings.DeltaTypeDescription), Order = 110)]
+        public DeltaType DeltaTypes
+        {
+            get => _deltaType;
+            set
+            {
+                _deltaType = value;
+                RecalculateValues();
+            }
+        }
 
-    #region Divergence
+        [Parameter]
+        [Range(0, int.MaxValue)]
+        [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Filter), GroupName = nameof(Strings.Filters),
+            Description = nameof(Strings.MinDeltaVolumeFilterCommonDescription), Order = 120)]
+        public decimal Filter
+        {
+            get => _filter;
+            set
+            {
+                _filter = value;
+                RecalculateValues();
+            }
+        }
+
+        #endregion
+
+        #region Divergence
 
     private Indicators.FilterColor _divergenceBarsFilter = new(true) { Enabled = false, Value = CrossColor.FromArgb(255, 255, 165, 0) };
 
-    [Display(ResourceType = typeof(Strings), Name = "DivergenceDots", GroupName = nameof(Strings.Divergence),
-        Description = nameof(Strings.BarDirVsDeltaDivergenceDescription), Order = 130)]
-    public bool ShowDivergence { get; set; }
+        [Display(ResourceType = typeof(Strings), Name = "DivergenceDots", GroupName = nameof(Strings.Divergence),
+            Description = nameof(Strings.BarDirVsDeltaDivergenceDescription), Order = 130)]
+        public bool ShowDivergence { get; set; }
 
-    [Display(ResourceType = typeof(Strings), Name = "DivergenceBars", GroupName = nameof(Strings.Divergence), Order = 135)]
+        [Display(ResourceType = typeof(Strings), Name = "DivergenceBars", GroupName = nameof(Strings.Divergence), Order = 135)]
     public Indicators.FilterColor DivergenceBarsFilter
-    {
-        get => _divergenceBarsFilter;
-        set
         {
-            if (_divergenceBarsFilter == value)
-                return;
+            get => _divergenceBarsFilter;
+            set
+            {
+                if (_divergenceBarsFilter == value)
+                    return;
 
-            if (_divergenceBarsFilter != null)
-                _divergenceBarsFilter.PropertyChanged -= OnDivergenceFilterChanged;
+                if (_divergenceBarsFilter != null)
+                    _divergenceBarsFilter.PropertyChanged -= OnDivergenceFilterChanged;
 
-            _divergenceBarsFilter = value;
+                _divergenceBarsFilter = value;
 
-            if (_divergenceBarsFilter != null)
-                _divergenceBarsFilter.PropertyChanged += OnDivergenceFilterChanged;
+                if (_divergenceBarsFilter != null)
+                    _divergenceBarsFilter.PropertyChanged += OnDivergenceFilterChanged;
 
-            RaisePropertyChanged(nameof(DivergenceBarsFilter));
+                RaisePropertyChanged(nameof(DivergenceBarsFilter));
+            }
         }
-    }
 
-    #endregion
+        #endregion
 
-    #region Absorption
+        #region Absorption
 
-    private readonly CandleDataSeries _absorptionCandles = new("AbsorptionDotsCandles", "Absorption Dots")
-    {
-        UpCandleColor = Color.Green.Convert(),
-        DownCandleColor = Color.Red.Convert(),
-        BorderColor = CrossColor.FromArgb(0, 0, 0, 0),
-        IsHidden = false,
-        UseMinimizedModeIfEnabled = true,
-        ShowCurrentValue = false
-    };
-
-    private int _absorptionThreshold = 250;
+        private readonly CandleDataSeries _absorptionCandles = new("AbsorptionDotsCandles", "Absorption Dots")
+        {
+            UpCandleColor = Color.Green.Convert(),
+            DownCandleColor = Color.Red.Convert(),
+            BorderColor = CrossColor.FromArgb(0, 0, 0, 0),
+            IsHidden = false,
+            UseMinimizedModeIfEnabled = true,
+            ShowCurrentValue = false
+        };
 
     private FilterInt _absorption = new(true) { Enabled = false, Value = 250 };
 
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Absorption), GroupName = nameof(Strings.Absorption),
-        Description = "AbsorptionThresholdDesc", Order = 140)]
-    [Range(0, int.MaxValue)]
-    public FilterInt Absorption
-    {
-        get => _absorption;
-        set
+        [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Absorption), GroupName = nameof(Strings.Absorption),
+            Description = "AbsorptionThresholdDesc", Order = 140)]
+        [Range(0, int.MaxValue)]
+        public FilterInt Absorption
         {
-            if (_absorption == value)
-                return;
+            get => _absorption;
+            set
+            {
+                if (_absorption == value)
+                    return;
 
-            if (_absorption != null)
-                _absorption.PropertyChanged -= OnAbsorptionFilterChanged;
+                if (_absorption != null)
+                    _absorption.PropertyChanged -= OnAbsorptionFilterChanged;
 
-            _absorption = value;
+                _absorption = value;
 
-            if (_absorption != null)
-                _absorption.PropertyChanged += OnAbsorptionFilterChanged;
+                if (_absorption != null)
+                    _absorption.PropertyChanged += OnAbsorptionFilterChanged;
 
-            RaisePropertyChanged(nameof(Absorption));
+                RaisePropertyChanged(nameof(Absorption));
+            }
         }
-    }
 
-    // Backward compatibility properties (hidden from UI)
-    [Browsable(false)]
-    public bool ShowAbsorptionDots
-    {
-        get => Absorption.Enabled;
-        set => Absorption.Enabled = value;
-    }
+        // Backward compatibility properties (hidden from UI)
+        [Browsable(false)]
+        public bool ShowAbsorptionDots
+        {
+            get => Absorption.Enabled;
+            set => Absorption.Enabled = value;
+        }
 
-    [Browsable(false)]
-    public int AbsorptionDeltaThreshold
-    {
-        get => Absorption.Value;
-        set => Absorption.Value = value;
-    }
+        [Browsable(false)]
+        public int AbsorptionDeltaThreshold
+        {
+            get => Absorption.Value;
+            set => Absorption.Value = value;
+        }
 
-    #endregion
+        #endregion
 
-    #region Volume
+        #region Volume
 
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Show), GroupName = nameof(Strings.VolumeLabel), Order = 200,
-        Description = nameof(Strings.VolumeLabelDescription))]
-    public bool ShowVolume { get; set; }
+        [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Show), GroupName = nameof(Strings.VolumeLabel), Order = 200,
+            Description = nameof(Strings.VolumeLabelDescription))]
+        public bool ShowVolume { get; set; }
 
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Color), GroupName = nameof(Strings.VolumeLabel),
-        Description = nameof(Strings.LabelTextColorDescription), Order = 210)]
-    public CrossColor FontColor
-    {
-        get => _fontColor.Convert();
-        set => _fontColor = value.Convert();
-    }
+        [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Color), GroupName = nameof(Strings.VolumeLabel),
+            Description = nameof(Strings.LabelTextColorDescription), Order = 210)]
+        public CrossColor FontColor
+        {
+            get => _fontColor.Convert();
+            set => _fontColor = value.Convert();
+        }
 
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Location), GroupName = nameof(Strings.VolumeLabel),
-        Description = nameof(Strings.LabelLocationDescription), Order = 220)]
-    public Location VolLocation { get; set; } = Location.Middle;
+        [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Location), GroupName = nameof(Strings.VolumeLabel),
+            Description = nameof(Strings.LabelLocationDescription), Order = 220)]
+        public Location VolLocation { get; set; } = Location.Middle;
 
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Font), GroupName = nameof(Strings.VolumeLabel),
-        Description = nameof(Strings.FontSettingDescription), Order = 230)]
-    public FontSetting Font { get; set; } = new("Arial", 10);
+        [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Font), GroupName = nameof(Strings.VolumeLabel),
+            Description = nameof(Strings.FontSettingDescription), Order = 230)]
+        public FontSetting Font { get; set; } = new("Arial", 10);
 
-    #endregion
+        #endregion
 
-    #region Alerts
+        #region Alerts
 
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.UpAlert), GroupName = nameof(Strings.Alerts),
-        Description = nameof(Strings.UpAlertFileFilterDescription), Order = 300)]
-    [Range(0, int.MaxValue)]
-    [DisplayFormat(DataFormatString = "F0")]
+        [Display(ResourceType = typeof(Strings), Name = nameof(Strings.UpAlert), GroupName = nameof(Strings.Alerts),
+            Description = nameof(Strings.UpAlertFileFilterDescription), Order = 300)]
+        [Range(0, int.MaxValue)]
+        [DisplayFormat(DataFormatString = "F0")]
     public Filter UpAlert { get; set; } = new()
     { Enabled = false, Value = 0 };
 
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.DownAlert), GroupName = nameof(Strings.Alerts),
-        Description = nameof(Strings.DownAlertFileFilterDescription), Order = 310)]
-    [Range(int.MinValue, 0)]
-    [DisplayFormat(DataFormatString = "F0")]
+        [Display(ResourceType = typeof(Strings), Name = nameof(Strings.DownAlert), GroupName = nameof(Strings.Alerts),
+            Description = nameof(Strings.DownAlertFileFilterDescription), Order = 310)]
+        [Range(int.MinValue, 0)]
+        [DisplayFormat(DataFormatString = "F0")]
     public Filter DownAlert { get; set; } = new()
     { Enabled = false, Value = 0 };
 
-    [Browsable(false)]
-    public bool UseAlerts
-    {
-        get => UpAlert.Enabled;
-        set => UpAlert.Enabled = value;
-    }
+        [Browsable(false)]
+        public bool UseAlerts
+        {
+            get => UpAlert.Enabled;
+            set => UpAlert.Enabled = value;
+        }
 
-    [Browsable(false)]
-    public decimal AlertFilter
-    {
-        get => UpAlert.Value;
-        set => UpAlert.Value = value;
-    }
+        [Browsable(false)]
+        public decimal AlertFilter
+        {
+            get => UpAlert.Value;
+            set => UpAlert.Value = value;
+        }
 
-    [Browsable(false)]
-    public bool UseNegativeAlerts
-    {
-        get => DownAlert.Enabled;
-        set => DownAlert.Enabled = value;
-    }
+        [Browsable(false)]
+        public bool UseNegativeAlerts
+        {
+            get => DownAlert.Enabled;
+            set => DownAlert.Enabled = value;
+        }
 
-    [Browsable(false)]
-    public decimal NegativeAlertFilter
-    {
-        get => DownAlert.Value;
-        set => DownAlert.Value = value;
-    }
+        [Browsable(false)]
+        public decimal NegativeAlertFilter
+        {
+            get => DownAlert.Value;
+            set => DownAlert.Value = value;
+        }
 
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.AlertFile), GroupName = nameof(Strings.Alerts),
-        Description = nameof(Strings.AlertFileDescription), Order = 320)]
-    public string AlertFile { get; set; } = "alert1";
+        [Display(ResourceType = typeof(Strings), Name = nameof(Strings.AlertFile), GroupName = nameof(Strings.Alerts),
+            Description = nameof(Strings.AlertFileDescription), Order = 320)]
+        public string AlertFile { get; set; } = "alert1";
 
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.FontColor), GroupName = nameof(Strings.Alerts),
-        Description = nameof(Strings.AlertTextColorDescription), Order = 330)]
-    public CrossColor AlertForeColor { get; set; } = CrossColor.FromArgb(255, 247, 249, 249);
+        [Display(ResourceType = typeof(Strings), Name = nameof(Strings.FontColor), GroupName = nameof(Strings.Alerts),
+            Description = nameof(Strings.AlertTextColorDescription), Order = 330)]
+        public CrossColor AlertForeColor { get; set; } = CrossColor.FromArgb(255, 247, 249, 249);
 
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.BackGround), GroupName = nameof(Strings.Alerts),
-        Description = nameof(Strings.AlertFillColorDescription), Order = 340)]
-    public CrossColor AlertBGColor { get; set; } = CrossColor.FromArgb(255, 75, 72, 72);
+        [Display(ResourceType = typeof(Strings), Name = nameof(Strings.BackGround), GroupName = nameof(Strings.Alerts),
+            Description = nameof(Strings.AlertFillColorDescription), Order = 340)]
+        public CrossColor AlertBGColor { get; set; } = CrossColor.FromArgb(255, 75, 72, 72);
 
-    #endregion
+        // Threshold lines (UI)
+        [Display(ResourceType = typeof(Strings), Name = "ShowThresholdLines",
+            GroupName = nameof(Strings.Visualization), Description = "Show horizontal threshold lines in the Delta panel", Order = 360)]
+        public bool ShowThresholdLines { get; set; } = true;
 
-    #endregion
+        [Display(ResourceType = typeof(Strings), Name = "UpMajorLevel",
+            GroupName = nameof(Strings.Filters), Description = "Upper major threshold", Order = 361)]
+        public decimal UpMajorLevel { get; set; } = 500m;
 
-    #region ctor
+        [Display(ResourceType = typeof(Strings), Name = "UpMinorLevel",
+            GroupName = nameof(Strings.Filters), Description = "Upper minor threshold", Order = 362)]
+        public decimal UpMinorLevel { get; set; } = 250m;
 
-    public Delta()
-		: base(true)
-	{
-		EnableCustomDrawing = true;
-		SubscribeToDrawingEvents(DrawingLayouts.Final);
-		FontColor = Color.Blue.Convert();
+        [Display(ResourceType = typeof(Strings), Name = "DownMinorLevel",
+            GroupName = nameof(Strings.Filters), Description = "Lower minor threshold", Order = 363)]
+        public decimal DownMinorLevel { get; set; } = -250m;
 
-		Panel = IndicatorDataProvider.NewPanel;
-		DataSeries[0] = _delta;
+        [Display(ResourceType = typeof(Strings), Name = "DownMajorLevel",
+            GroupName = nameof(Strings.Filters), Description = "Lower major threshold", Order = 364)]
+        public decimal DownMajorLevel { get; set; } = -500m;
 
-		DataSeries.Insert(0, _diapasonHigh);
-		DataSeries.Insert(1, _diapasonLow);
-		DataSeries.Add(_candles);
+        #endregion
 
-		DataSeries.Add(_upSeries);
-		DataSeries.Add(_downSeries);
-		DataSeries.Add(_currentValues);
-		DataSeries.Add(_downCandles);
-		DataSeries.Add(_divergenceCandles);
-		DataSeries.Add(_divergenceDownCandles);
+        #endregion
 
-		DataSeries.Add(_absorptionCandles);
+        #region ctor
 
-		UpAlert.PropertyChanged += (sender, e) => _lastBarAlert = 0;
-		DownAlert.PropertyChanged += (sender, e) => _lastBarNegativeAlert = 0;
-		_divergenceBarsFilter.PropertyChanged += OnDivergenceFilterChanged;
-		_absorption.PropertyChanged += OnAbsorptionFilterChanged;
+        public Delta()
+            : base(true)
+        {
+            EnableCustomDrawing = true;
+            SubscribeToDrawingEvents(DrawingLayouts.Final);
+            FontColor = Color.Blue.Convert();
 
-		UpdateDivergenceCandlesVisibility();
+            Panel = IndicatorDataProvider.NewPanel;
+            DataSeries[0] = _delta;
 
-		if (DivergenceBarsFilter?.Enabled == true)
-			RecalculateValues();
-	}
+            DataSeries.Insert(0, _diapasonHigh);
+            DataSeries.Insert(1, _diapasonLow);
+            DataSeries.Add(_candles);
 
-	#endregion
+            DataSeries.Add(_upSeries);
+            DataSeries.Add(_downSeries);
+            DataSeries.Add(_currentValues);
+            DataSeries.Add(_downCandles);
+            DataSeries.Add(_divergenceCandles);
+            DataSeries.Add(_divergenceDownCandles);
 
-	#region Protected methods
+            // price signals + absorption
+            DataSeries.Add(_priceSignalUp);
+            DataSeries.Add(_priceSignalDown);
+            DataSeries.Add(_absorptionCandles);
 
-	protected override void OnApplyDefaultColors()
-	{
-		if (ChartInfo is null)
-			return;
+            // threshold lines
+            DataSeries.Add(_upMajor);
+            DataSeries.Add(_upMinor);
+            DataSeries.Add(_dnMinor);
+            DataSeries.Add(_dnMajor);
+            SetupThresholdPens();
 
-		UpColor = ChartInfo.ColorsStore.UpCandleColor.Convert();
-		DownColor = ChartInfo.ColorsStore.DownCandleColor.Convert();
-		NeutralColor = ChartInfo.ColorsStore.BarBorderPen.Color.Convert();
-		FontColor = ChartInfo.ColorsStore.FootprintMaximumVolumeTextColor.Convert();
+            UpAlert.PropertyChanged += (sender, e) => _lastBarAlert = 0;
+            DownAlert.PropertyChanged += (sender, e) => _lastBarNegativeAlert = 0;
+            _divergenceBarsFilter.PropertyChanged += OnDivergenceFilterChanged;
+            _absorption.PropertyChanged += OnAbsorptionFilterChanged;
 
-		UpdateDivergenceCandlesVisibility();
-	}
+            UpdateDivergenceCandlesVisibility();
 
-	protected override void OnRender(RenderContext context, DrawingLayouts layout)
-	{
-		if (ChartInfo is null || InstrumentInfo is null)
-			return;
+            if (DivergenceBarsFilter?.Enabled == true)
+                RecalculateValues();
+        }
 
-	
-		if (ShowDivergence)
-		{
-			for (var i = FirstVisibleBarNumber; i <= LastVisibleBarNumber; i++)
-			{
-				try
-				{
-					if (_upSeries[i] == 0 && _downSeries[i] == 0)
-						continue;
+        #endregion
 
-					var candle = GetCandle(i);
-					var x = ChartInfo.PriceChartContainer.GetXByBar(i, false);
+        #region Protected methods
 
-					if (_upSeries[i] != 0)
-					{
-						var yPrice = ChartInfo.PriceChartContainer.GetYByPrice(candle.Low, false) + 10;
+        protected override void OnApplyDefaultColors()
+        {
+            if (ChartInfo is null)
+                return;
 
-						if (yPrice <= ChartInfo.PriceChartContainer.Region.Bottom)
-						{
-							var rect = new Rectangle(x - 5, yPrice - 4, 8, 8);
-							context.FillEllipse(_upColor, rect);
-						}
-					}
+            UpColor = ChartInfo.ColorsStore.UpCandleColor.Convert();
+            DownColor = ChartInfo.ColorsStore.DownCandleColor.Convert();
+            NeutralColor = ChartInfo.ColorsStore.BarBorderPen.Color.Convert();
+            FontColor = ChartInfo.ColorsStore.FootprintMaximumVolumeTextColor.Convert();
 
-					if (_downSeries[i] != 0)
-					{
-						var yPrice = ChartInfo.PriceChartContainer.GetYByPrice(candle.High, false) - 10;
+            UpdateDivergenceCandlesVisibility();
+        }
 
-						if (yPrice <= ChartInfo.PriceChartContainer.Region.Bottom)
-						{
-							var rect = new Rectangle(x - 5, yPrice - 4, 8, 8);
-							context.FillEllipse(_downColor, rect);
-						}
-					}
-				}
-				catch (OverflowException)
-				{
-					return;
-				}
-			}
-		}
+        protected override void OnRender(RenderContext context, DrawingLayouts layout)
+        {
+            if (ChartInfo is null || InstrumentInfo is null)
+                return;
 
-		if (!ShowVolume || ChartInfo.ChartVisualMode != ChartVisualModes.Clusters || Panel == IndicatorDataProvider.CandlesPanel)
-			return;
+            // Divergence dots on price panel
+            if (ShowDivergence)
+            {
+                for (var i = FirstVisibleBarNumber; i <= LastVisibleBarNumber; i++)
+                {
+                    try
+                    {
+                        if (_upSeries[i] == 0 && _downSeries[i] == 0)
+                            continue;
 
-		var minWidth = GetMinWidth(context, FirstVisibleBarNumber, LastVisibleBarNumber);
-		var barWidth = ChartInfo.GetXByBar(1) - ChartInfo.GetXByBar(0);
+                        var candle = GetCandle(i);
+                        var x = ChartInfo.PriceChartContainer.GetXByBar(i, false);
 
-		if (minWidth > barWidth)
-			return;
+                        if (_upSeries[i] != 0)
+                        {
+                            var yPrice = ChartInfo.PriceChartContainer.GetYByPrice(candle.Low, false) + 10;
+                            if (yPrice >= ChartInfo.PriceChartContainer.Region.Top &&
+                                yPrice <= ChartInfo.PriceChartContainer.Region.Bottom)
+                            {
+                                var rect = new Rectangle(x - 5, yPrice - 4, 8, 8);
+                                context.FillEllipse(_upColor, rect);
+                            }
+                        }
 
-		var strHeight = context.MeasureString("0", Font.RenderObject).Height;
+                        if (_downSeries[i] != 0)
+                        {
+                            var yPrice = ChartInfo.PriceChartContainer.GetYByPrice(candle.High, false) - 10;
+                            if (yPrice >= ChartInfo.PriceChartContainer.Region.Top &&
+                                yPrice <= ChartInfo.PriceChartContainer.Region.Bottom)
+                            {
+                                var rect = new Rectangle(x - 5, yPrice - 4, 8, 8);
+                                context.FillEllipse(_downColor, rect);
+                            }
+                        }
+                    }
+                    catch (OverflowException)
+                    {
+                        return;
+                    }
+                }
+            }
 
-		var y = VolLocation switch
-		{
-			Location.Up => Container.Region.Y,
-			Location.Down => Container.Region.Bottom - strHeight,
-			_ => Container.Region.Y + (Container.Region.Bottom - Container.Region.Y) / 2
-		};
+            // Price signals (triangles) – only on price panel
+            if (ShowPriceSignals)
+            {
+                var priceRc = ChartInfo.PriceChartContainer.Region;
+                var half = _priceSignalSize / 2;
 
-		for (var i = FirstVisibleBarNumber; i <= LastVisibleBarNumber; i++)
-		{
-			decimal value;
+                for (var i = FirstVisibleBarNumber; i <= LastVisibleBarNumber; i++)
+                {
+                    var x = ChartInfo.PriceChartContainer.GetXByBar(i, false);
 
-			if (MinimizedMode)
-			{
-				value = _candles[i].Close > 0
-					? _candles[i].Close
-					: -_downCandles[i].Close;
-			}
-			else
-				value = _candles[i].Close;
+                    // Up triangle
+                    var upPrice = _priceSignalUp[i];
+                    if (upPrice > 0)
+                    {
+                        var yPx = ChartInfo.PriceChartContainer.GetYByPrice(upPrice, false);
+                        if (yPx >= priceRc.Top && yPx <= priceRc.Bottom)
+                        {
+                            var p1 = new System.Drawing.Point(x, yPx - half);
+                            var p2 = new System.Drawing.Point(x - half, yPx + half);
+                            var p3 = new System.Drawing.Point(x + half, yPx + half);
+                            context.FillPolygon(_priceSignalUpColor, new[] { p1, p2, p3 });
+                        }
+                    }
 
-			var renderText = ChartInfo.TryGetMinimizedVolumeString(value);
+                    // Down triangle
+                    var dnPrice = _priceSignalDown[i];
+                    if (dnPrice > 0)
+                    {
+                        var yPx = ChartInfo.PriceChartContainer.GetYByPrice(dnPrice, false);
+                        if (yPx >= priceRc.Top && yPx <= priceRc.Bottom)
+                        {
+                            var p1 = new System.Drawing.Point(x, yPx + half);
+                            var p2 = new System.Drawing.Point(x - half, yPx - half);
+                            var p3 = new System.Drawing.Point(x + half, yPx - half);
+                            context.FillPolygon(_priceSignalDownColor, new[] { p1, p2, p3 });
+                        }
+                    }
+                }
+            }
 
-			var strRect = new Rectangle(ChartInfo.GetXByBar(i),
-				y,
-				barWidth,
-				strHeight);
+            // Volume labels on delta panel (same as original)
+            if (!ShowVolume || ChartInfo.ChartVisualMode != ChartVisualModes.Clusters || Panel == IndicatorDataProvider.CandlesPanel)
+                return;
 
-			context.DrawString(renderText, Font.RenderObject, _fontColor, strRect, _format);
-		}
-	}
+            var minWidth = GetMinWidth(context, FirstVisibleBarNumber, LastVisibleBarNumber);
+            var barWidth = ChartInfo.GetXByBar(1) - ChartInfo.GetXByBar(0);
 
-	protected override void OnCalculate(int bar, decimal value)
-	{
-		if (bar == 0)
-		{
-			DataSeries.ForEach(x => x.Clear());
-			_upSeries.Clear();
-			_downSeries.Clear();
-			_divergenceBars.Clear();
-		}
+            if (minWidth > barWidth)
+                return;
 
-		var candle = GetCandle(bar);
-		var deltaValue = candle.Delta;
-		var absDelta = Math.Abs(deltaValue);
-		var maxDelta = candle.MaxDelta;
-		var minDelta = candle.MinDelta;
+            var strHeight = context.MeasureString("0", Font.RenderObject).Height;
+
+            var y = VolLocation switch
+            {
+                Location.Up => Container.Region.Y,
+                Location.Down => Container.Region.Bottom - strHeight,
+                _ => Container.Region.Y + (Container.Region.Bottom - Container.Region.Y) / 2
+            };
+
+            for (var i = FirstVisibleBarNumber; i <= LastVisibleBarNumber; i++)
+            {
+                decimal value;
+
+                if (MinimizedMode)
+                {
+                    value = _candles[i].Close > 0
+                    ? _candles[i].Close
+                    : -_downCandles[i].Close;
+                }
+                else
+                    value = _candles[i].Close;
+
+                var renderText = ChartInfo.TryGetMinimizedVolumeString(value);
+
+                var strRect = new Rectangle(ChartInfo.GetXByBar(i),
+                    y,
+                    barWidth,
+                    strHeight);
+
+                context.DrawString(renderText, Font.RenderObject, _fontColor, strRect, _format);
+            }
+        }
+
+        protected override void OnCalculate(int bar, decimal value)
+        {
+            if (bar == 0)
+            {
+                DataSeries.ForEach(x => x.Clear());
+                _upSeries.Clear();
+                _downSeries.Clear();
+                _divergenceBars.Clear();
+            }
+
+            // clear price signal by default
+            _priceSignalUp[bar] = 0;
+            _priceSignalDown[bar] = 0;
+
+            var candle = GetCandle(bar);
+            var deltaValue = candle.Delta;
+            var absDelta = Math.Abs(deltaValue);
+            var maxDelta = candle.MaxDelta;
+            var minDelta = candle.MinDelta;
 
 		if (maxDelta == minDelta)
 		{
@@ -712,364 +885,420 @@ public class Delta : Indicator
 
 		var isUnderFilter = absDelta < _filter;
 
-		if (_barDirection == BarDirection.Bullish)
-		{
-			if (candle.Close < candle.Open)
-				isUnderFilter = true;
-		}
-		else if (_barDirection == BarDirection.Bearlish)
-		{
-			if (candle.Close > candle.Open)
-				isUnderFilter = true;
-		}
+            if (_barDirection == BarDirection.Bullish)
+            {
+                if (candle.Close < candle.Open)
+                    isUnderFilter = true;
+            }
+            else if (_barDirection == BarDirection.Bearlish)
+            {
+                if (candle.Close > candle.Open)
+                    isUnderFilter = true;
+            }
 
-		if (_deltaType == DeltaType.Negative && deltaValue > 0)
-			isUnderFilter = true;
+            if (_deltaType == DeltaType.Negative && deltaValue > 0)
+                isUnderFilter = true;
 
-		if (_deltaType == DeltaType.Positive && deltaValue < 0)
-			isUnderFilter = true;
+            if (_deltaType == DeltaType.Positive && deltaValue < 0)
+                isUnderFilter = true;
 
-		if (isUnderFilter)
-		{
-			deltaValue = 0;
-			absDelta = 0;
-			minDelta = maxDelta = 0;
-		}
+            if (isUnderFilter)
+            {
+                deltaValue = 0;
+                absDelta = 0;
+                minDelta = maxDelta = 0;
+            }
 
-		_delta[bar] = MinimizedMode ? absDelta : deltaValue;
+            _delta[bar] = MinimizedMode ? absDelta : deltaValue;
 
-		if (MinimizedMode)
-		{
-			var high = Math.Abs(maxDelta);
-			var low = Math.Abs(minDelta);
-			_diapasonLow[bar] = Math.Min(Math.Min(high, low), absDelta);
-			_diapasonHigh[bar] = Math.Max(high, low);
+            if (MinimizedMode)
+            {
+                var high = Math.Abs(maxDelta);
+                var low = Math.Abs(minDelta);
+                _diapasonLow[bar] = Math.Min(Math.Min(high, low), absDelta);
+                _diapasonHigh[bar] = Math.Max(high, low);
 
-			if (deltaValue >= 0)
-			{
-				var currentCandle = _candles[bar];
-				currentCandle.Open = deltaValue > 0 ? 0 : absDelta;
-				currentCandle.Close = deltaValue > 0 ? absDelta : 0;
-				currentCandle.High = _diapasonHigh[bar];
-				currentCandle.Low = _diapasonLow[bar];
-				_downCandles[bar] = new Candle();
-			}
-			else
-			{
-				var currentCandle = _downCandles[bar];
-				currentCandle.Open = 0;
-				currentCandle.Close = absDelta;
-				currentCandle.High = _diapasonHigh[bar];
-				currentCandle.Low = _diapasonLow[bar];
-				_candles[bar] = new Candle();
-			}
-		}
-		else
-		{
-			_diapasonLow[bar] = minDelta;
-			_diapasonHigh[bar] = maxDelta;
+                if (deltaValue >= 0)
+                {
+                    var currentCandle = _candles[bar];
+                    currentCandle.Open = deltaValue > 0 ? 0 : absDelta;
+                    currentCandle.Close = deltaValue > 0 ? absDelta : 0;
+                    currentCandle.High = _diapasonHigh[bar];
+                    currentCandle.Low = _diapasonLow[bar];
+                    _downCandles[bar] = new Candle();
+                }
+                else
+                {
+                    var currentCandle = _downCandles[bar];
+                    currentCandle.Open = 0;
+                    currentCandle.Close = absDelta;
+                    currentCandle.High = _diapasonHigh[bar];
+                    currentCandle.Low = _diapasonLow[bar];
+                    _candles[bar] = new Candle();
+                }
+            }
+            else
+            {
+                _diapasonLow[bar] = minDelta;
+                _diapasonHigh[bar] = maxDelta;
 
-			_candles[bar].Open = 0;
-			_candles[bar].Close = deltaValue;
-			_candles[bar].High = maxDelta;
-			_candles[bar].Low = minDelta;
-		}
+                _candles[bar].Open = 0;
+                _candles[bar].Close = deltaValue;
+                _candles[bar].High = maxDelta;
+                _candles[bar].Low = minDelta;
+            }
 
-		var hasDivergence = false;
+            var hasDivergence = false;
 
-		if (MinimizedMode)
-		{
-			if (candle.Close > candle.Open && deltaValue < 0)
-			{
-				_downSeries[bar] = _downCandles[bar].High;
-				hasDivergence = true;
-			}
-			else if (candle.Close < candle.Open && deltaValue > 0)
-			{
-				_upSeries[bar] = _candles[bar].High;
-				hasDivergence = true;
-			}
-			else
-			{
-				_upSeries[bar] = 0;
-				_downSeries[bar] = 0;
-			}
-		}
-		else
-		{
-			if (candle.Close > candle.Open && _candles[bar].Close < _candles[bar].Open)
-			{
-				_downSeries[bar] = _candles[bar].High;
-				hasDivergence = true;
-			}
-			else
-				_downSeries[bar] = 0;
+            if (MinimizedMode)
+            {
+                if (candle.Close > candle.Open && deltaValue < 0)
+                {
+                    _downSeries[bar] = _downCandles[bar].High;
+                    hasDivergence = true;
+                }
+                else if (candle.Close < candle.Open && deltaValue > 0)
+                {
+                    _upSeries[bar] = _candles[bar].High;
+                    hasDivergence = true;
+                }
+                else
+                {
+                    _upSeries[bar] = 0;
+                    _downSeries[bar] = 0;
+                }
+            }
+            else
+            {
+                if (candle.Close > candle.Open && _candles[bar].Close < _candles[bar].Open)
+                {
+                    _downSeries[bar] = _candles[bar].High;
+                    hasDivergence = true;
+                }
+                else
+                    _downSeries[bar] = 0;
 
-			if (candle.Close < candle.Open && _candles[bar].Close > _candles[bar].Open)
-			{
-				_upSeries[bar] = _candles[bar].High;
-				hasDivergence = true;
-			}
-			else
-				_upSeries[bar] = 0;
-		}
+                if (candle.Close < candle.Open && _candles[bar].Close > _candles[bar].Open)
+                {
+                    _upSeries[bar] = _candles[bar].High;
+                    hasDivergence = true;
+                }
+                else
+                    _upSeries[bar] = 0;
+            }
 
-		_divergenceBars[bar] = hasDivergence;
+            _divergenceBars[bar] = hasDivergence;
 
-		if (hasDivergence && DivergenceBarsFilter != null && DivergenceBarsFilter.Enabled &&
-		    (_mode == DeltaVisualMode.Candles || _mode == DeltaVisualMode.Bars))
-		{
-			if (MinimizedMode)
-			{
-				if (deltaValue >= 0)
-				{
-					_divergenceCandles[bar] = _candles[bar];
-					_divergenceDownCandles[bar] = new Candle();
-				}
-				else
-				{
-					_divergenceDownCandles[bar] = _downCandles[bar];
-					_divergenceCandles[bar] = new Candle();
-				}
-			}
-			else
-			{
-				_divergenceCandles[bar] = _candles[bar];
-				_divergenceDownCandles[bar] = new Candle();
-			}
-		}
-		else
-		{
-			_divergenceCandles[bar] = new Candle();
-			_divergenceDownCandles[bar] = new Candle();
-		}
+            if (hasDivergence && DivergenceBarsFilter != null && DivergenceBarsFilter.Enabled &&
+                (_mode == DeltaVisualMode.Candles || _mode == DeltaVisualMode.Bars))
+            {
+                if (MinimizedMode)
+                {
+                    if (deltaValue >= 0)
+                    {
+                        _divergenceCandles[bar] = _candles[bar];
+                        _divergenceDownCandles[bar] = new Candle();
+                    }
+                    else
+                    {
+                        _divergenceDownCandles[bar] = _downCandles[bar];
+                        _divergenceCandles[bar] = new Candle();
+                    }
+                }
+                else
+                {
+                    _divergenceCandles[bar] = _candles[bar];
+                    _divergenceDownCandles[bar] = new Candle();
+                }
+            }
+            else
+            {
+                _divergenceCandles[bar] = new Candle();
+                _divergenceDownCandles[bar] = new Candle();
+            }
 
-		_delta.Colors[bar] = deltaValue > 0 ? _upColor : _downColor;
+            _delta.Colors[bar] = deltaValue > 0 ? _upColor : _downColor;
 
-		if (DivergenceBarsFilter != null && DivergenceBarsFilter.Enabled &&
-		    (_mode == DeltaVisualMode.Histogram || _mode == DeltaVisualMode.HighLow))
-		{
-			if (hasDivergence)
-			{
-				var divergenceColor = DivergenceBarsFilter.Value.Convert();
-				_delta.Colors[bar] = divergenceColor;
-			}
-		}
+            if (DivergenceBarsFilter != null && DivergenceBarsFilter.Enabled &&
+                (_mode == DeltaVisualMode.Histogram || _mode == DeltaVisualMode.HighLow))
+            {
+                if (hasDivergence)
+                {
+                    var divergenceColor = DivergenceBarsFilter.Value.Convert();
+                    _delta.Colors[bar] = divergenceColor;
+                }
+            }
 
-		if (_lastBar != bar)
-		{
-			_prevDeltaValue = deltaValue;
-			_lastBar = bar;
-		}
+            if (_lastBar != bar)
+            {
+                _prevDeltaValue = deltaValue;
+                _lastBar = bar;
+            }
 
-		if (UpAlert.Enabled && CurrentBar - 1 == bar && _lastBarAlert != bar)
-		{
-			var alertValue = UpAlert.Value;
+            // === Alerts + price signals ===
+            var tick = InstrumentInfo?.TickSize ?? 1m;
+            var offset = tick * _priceSignalOffsetTicks;
 
-			if ((deltaValue >= alertValue && _prevDeltaValue < alertValue) || (deltaValue <= alertValue && _prevDeltaValue > alertValue))
-			{
-				_lastBarAlert = bar;
-				AddAlert(AlertFile, InstrumentInfo.Instrument, $"Delta reached {alertValue} filter", AlertBGColor, AlertForeColor);
-			}
-		}
+            if (UpAlert.Enabled && CurrentBar - 1 == bar && _lastBarAlert != bar)
+            {
+                var alertValue = UpAlert.Value;
 
-		if (DownAlert.Enabled && CurrentBar - 1 == bar && _lastBarNegativeAlert != bar)
-		{
-			var negativeAlertValue = DownAlert.Value;
+                if ((deltaValue >= alertValue && _prevDeltaValue < alertValue) ||
+                    (deltaValue <= alertValue && _prevDeltaValue > alertValue))
+                {
+                    _lastBarAlert = bar;
+                    AddAlert(AlertFile, InstrumentInfo.Instrument, $"Delta reached {alertValue} filter", AlertBGColor, AlertForeColor);
 
-			if ((deltaValue >= negativeAlertValue && _prevDeltaValue < negativeAlertValue) ||
-			    (deltaValue <= negativeAlertValue && _prevDeltaValue > negativeAlertValue))
-			{
-				_lastBarNegativeAlert = bar;
-				AddAlert(AlertFile, InstrumentInfo.Instrument, $"Delta reached {negativeAlertValue} filter", AlertBGColor, AlertForeColor);
-			}
-		}
+                    if (ShowPriceSignals)
+                        _priceSignalUp[bar] = GetCandle(bar).High + offset;
+                }
+            }
 
-		_prevDeltaValue = deltaValue;
+            if (DownAlert.Enabled && CurrentBar - 1 == bar && _lastBarNegativeAlert != bar)
+            {
+                var negativeAlertValue = DownAlert.Value;
 
-		if (Absorption.Enabled)
-		{
-			decimal deltaOpen, deltaClose, deltaHigh, deltaLow;
+                if ((deltaValue >= negativeAlertValue && _prevDeltaValue < negativeAlertValue) ||
+                    (deltaValue <= negativeAlertValue && _prevDeltaValue > negativeAlertValue))
+                {
+                    _lastBarNegativeAlert = bar;
+                    AddAlert(AlertFile, InstrumentInfo.Instrument, $"Delta reached {negativeAlertValue} filter", AlertBGColor, AlertForeColor);
 
-			if (MinimizedMode)
-			{
-				deltaClose = _delta[bar];
-				deltaHigh = _diapasonHigh[bar];
-				deltaLow = _diapasonLow[bar];
-				deltaOpen = 0;
-			}
-			else
-			{
-				deltaOpen = _candles[bar].Open;
-				deltaClose = _candles[bar].Close;
-				deltaHigh = _candles[bar].High;
-				deltaLow = _candles[bar].Low;
-			}
+                    if (ShowPriceSignals)
+                        _priceSignalDown[bar] = GetCandle(bar).Low - offset;
+                }
+            }
 
-			decimal upperTail, lowerTail;
+            _prevDeltaValue = deltaValue;
 
-			if (deltaClose > deltaOpen)
-			{
-				upperTail = deltaHigh - deltaClose;
-				lowerTail = deltaOpen - deltaLow;
-			}
-			else
-			{
-				upperTail = deltaHigh - deltaOpen;
-				lowerTail = deltaClose - deltaLow;
-			}
+            // --- Price signals (historical & RT) ---
+            _priceSignalUp[bar] = 0;
+            _priceSignalDown[bar] = 0;
 
-			if (upperTail > lowerTail && upperTail > Absorption.Value)
-			{
-				var c = new Candle();
-				var center = deltaHigh - upperTail / 2;
-				c.Open = center + 10;
-				c.Close = center - 10;
-				c.High = center + 12;
-				c.Low = center - 12;
-				_absorptionCandles[bar] = c;
-			}
-			else if (lowerTail > upperTail && lowerTail > Absorption.Value)
-			{
-				var c = new Candle();
-				var center = deltaLow + lowerTail / 2;
-				c.Open = center - 10;
-				c.Close = center + 10;
-				c.High = center + 12m;
-				c.Low = center - 12m;
-				_absorptionCandles[bar] = c;
-			}
-			else
-				_absorptionCandles[bar] = new Candle();
-		}
-		else
-			_absorptionCandles[bar] = new Candle();
+            if (ShowPriceSignals)
+            {
+                // Choose thresholds: alerts if enabled, otherwise major lines
+                var upThreshold = UpAlert.Enabled ? UpAlert.Value : UpMajorLevel;
+                var downThreshold = DownAlert.Enabled ? DownAlert.Value : DownMajorLevel;
 
-		if (!ShowCurrentValues)
-			return;
+                bool placeUp = false;
+                bool placeDn = false;
 
-		_currentValues[bar] = MinimizedMode ? absDelta : deltaValue;
+                // Exceeded threshold (historical friendly)
+                if (deltaValue >= upThreshold)
+                    placeUp = true;
 
-		_currentValues.Colors[bar] = deltaValue > 0
-			? _upColor
-			: deltaValue < 0
-				? _downColor
-				: _neutralColor;
-	}
-
-	#endregion
-
-	#region Private methods
+                if (deltaValue <= downThreshold)
+                    placeDn = true;
 
 
-	private int GetMinWidth(RenderContext context, int startBar, int endBar)
-	{
-		var maxLength = 0;
+                if (placeUp)
+                    _priceSignalUp[bar] = GetCandle(bar).High + offset;
 
-		for (var i = startBar; i <= endBar; i++)
-		{
-			decimal value;
+                if (placeDn)
+                    _priceSignalDown[bar] = GetCandle(bar).Low - offset;
+            }
 
-			if (MinimizedMode)
-			{
-				value = _candles[i].Close > _candles[i].Open
-					? _candles[i].Close
-					: -_candles[i].Open;
-			}
-			else
-				value = _candles[i].Close;
+            // Absorption dots in delta panel
+            if (Absorption.Enabled)
+            {
+                decimal deltaOpen, deltaClose, deltaHigh, deltaLow;
 
-			var length = $"{value:0.#####}".Length;
+                if (MinimizedMode)
+                {
+                    deltaClose = _delta[bar];
+                    deltaHigh = _diapasonHigh[bar];
+                    deltaLow = _diapasonLow[bar];
+                    deltaOpen = 0;
+                }
+                else
+                {
+                    deltaOpen = _candles[bar].Open;
+                    deltaClose = _candles[bar].Close;
+                    deltaHigh = _candles[bar].High;
+                    deltaLow = _candles[bar].Low;
+                }
 
-			if (length > maxLength)
-				maxLength = length;
-		}
+                decimal upperTail, lowerTail;
 
-		var sampleStr = "";
+                if (deltaClose > deltaOpen)
+                {
+                    upperTail = deltaHigh - deltaClose;
+                    lowerTail = deltaOpen - deltaLow;
+                }
+                else
+                {
+                    upperTail = deltaHigh - deltaOpen;
+                    lowerTail = deltaClose - deltaLow;
+                }
 
-		for (var i = 0; i < maxLength; i++)
-			sampleStr += '0';
+                if (upperTail > lowerTail && upperTail > Absorption.Value)
+                {
+                    var c = new Candle();
+                    var center = deltaHigh - upperTail / 2;
+                    c.Open = center + 10;
+                    c.Close = center - 10;
+                    c.High = center + 12;
+                    c.Low = center - 12;
+                    _absorptionCandles[bar] = c;
+                }
+                else if (lowerTail > upperTail && lowerTail > Absorption.Value)
+                {
+                    var c = new Candle();
+                    var center = deltaLow + lowerTail / 2;
+                    c.Open = center - 10;
+                    c.Close = center + 10;
+                    c.High = center + 12m;
+                    c.Low = center - 12m;
+                    _absorptionCandles[bar] = c;
+                }
+                else
+                    _absorptionCandles[bar] = new Candle();
+            }
+            else
+                _absorptionCandles[bar] = new Candle();
 
-		return context.MeasureString(sampleStr, Font.RenderObject).Width;
-	}
+            // Current values on axis
+            if (ShowCurrentValues)
+            {
+                _currentValues[bar] = MinimizedMode ? absDelta : deltaValue;
 
-	#endregion
+                _currentValues.Colors[bar] = deltaValue > 0
+                    ? _upColor
+                    : deltaValue < 0
+                        ? _downColor
+                        : _neutralColor;
+            }
 
-	#region Event handlers
+            // --- Threshold constant lines per bar ---
+            if (ShowThresholdLines)
+            {
+                _upMajor[bar] = UpMajorLevel;
+                _upMinor[bar] = UpMinorLevel;
+                _dnMinor[bar] = DownMinorLevel;
+                _dnMajor[bar] = DownMajorLevel;
 
-	private void OnDivergenceFilterChanged(object sender, PropertyChangedEventArgs e)
-	{
+                _upMajor.VisualType = _upMinor.VisualType = _dnMinor.VisualType = _dnMajor.VisualType = VisualMode.Line;
+            }
+            else
+            {
+                _upMajor.VisualType = _upMinor.VisualType = _dnMinor.VisualType = _dnMajor.VisualType = VisualMode.Hide;
+            }
+        }
+
+        #endregion
+
+        #region Private methods
+
+
+        private int GetMinWidth(RenderContext context, int startBar, int endBar)
+        {
+            var maxLength = 0;
+
+            for (var i = startBar; i <= endBar; i++)
+            {
+                decimal value;
+
+                if (MinimizedMode)
+                {
+                    value = _candles[i].Close > _candles[i].Open
+                        ? _candles[i].Close
+                        : -_candles[i].Open;
+                }
+                else
+                    value = _candles[i].Close;
+
+                var length = $"{value:0.#####}".Length;
+
+                if (length > maxLength)
+                    maxLength = length;
+            }
+
+            var sampleStr = "";
+
+            for (var i = 0; i < maxLength; i++)
+                sampleStr += '0';
+
+            return context.MeasureString(sampleStr, Font.RenderObject).Width;
+        }
+
+        #endregion
+
+        #region Event handlers
+
+        private void OnDivergenceFilterChanged(object sender, PropertyChangedEventArgs e)
+        {
 		if (e.PropertyName == nameof(Indicators.FilterColor.Enabled))
-			ApplyDivergenceColorsToCurrentMode();
+                ApplyDivergenceColorsToCurrentMode();
 
-		UpdateDivergenceCandlesVisibility();
+            UpdateDivergenceCandlesVisibility();
 
-		RecalculateValues();
+            RecalculateValues();
 
-		RedrawChart();
-	}
+            RedrawChart();
+        }
 
-	private void OnAbsorptionFilterChanged(object sender, PropertyChangedEventArgs e)
-	{
-		RecalculateValues();
-		RedrawChart();
-	}
+        private void OnAbsorptionFilterChanged(object sender, PropertyChangedEventArgs e)
+        {
+            RecalculateValues();
+            RedrawChart();
+        }
 
-	private void ApplyDivergenceColorsToCurrentMode()
-	{
-		if (_divergenceBarsFilter?.Enabled != true)
-		{
-			for (var i = 0; i < CurrentBar; i++)
-			{
-				var actualDelta = GetCandle(i).Delta;
-				var defaultColor = actualDelta > 0 ? _upColor : _downColor;
-				_delta.Colors[i] = defaultColor;
-			}
+        private void ApplyDivergenceColorsToCurrentMode()
+        {
+            if (_divergenceBarsFilter?.Enabled != true)
+            {
+                for (var i = 0; i < CurrentBar; i++)
+                {
+                    var actualDelta = GetCandle(i).Delta;
+                    var defaultColor = actualDelta > 0 ? _upColor : _downColor;
+                    _delta.Colors[i] = defaultColor;
+                }
 
-			return;
-		}
+                return;
+            }
 
-		var divergenceColor = _divergenceBarsFilter.Value.Convert();
+            var divergenceColor = _divergenceBarsFilter.Value.Convert();
 
-		for (var i = 0; i < CurrentBar; i++)
-		{
-			if (_divergenceBars.TryGetValue(i, out var hasDivergence) && hasDivergence)
-			{
-				if (_mode == DeltaVisualMode.Histogram || _mode == DeltaVisualMode.HighLow)
-					_delta.Colors[i] = divergenceColor;
-			}
-			else
-			{
-				var actualDelta = GetCandle(i).Delta;
-				var defaultColor = actualDelta > 0 ? _upColor : _downColor;
-				_delta.Colors[i] = defaultColor;
-			}
-		}
-	}
+            for (var i = 0; i < CurrentBar; i++)
+            {
+                if (_divergenceBars.TryGetValue(i, out var hasDivergence) && hasDivergence)
+                {
+                    if (_mode == DeltaVisualMode.Histogram || _mode == DeltaVisualMode.HighLow)
+                        _delta.Colors[i] = divergenceColor;
+                }
+                else
+                {
+                    var actualDelta = GetCandle(i).Delta;
+                    var defaultColor = actualDelta > 0 ? _upColor : _downColor;
+                    _delta.Colors[i] = defaultColor;
+                }
+            }
+        }
 
-	private void UpdateDivergenceCandlesVisibility()
-	{
-		if (DivergenceBarsFilter != null && (_mode == DeltaVisualMode.Candles || _mode == DeltaVisualMode.Bars))
-		{
-			var divergenceColor = DivergenceBarsFilter.Value;
-			_divergenceCandles.Visible = DivergenceBarsFilter.Enabled;
-			_divergenceCandles.UpCandleColor = divergenceColor;
-			_divergenceCandles.DownCandleColor = divergenceColor;
-			_divergenceCandles.BorderColor = divergenceColor;
-			_divergenceCandles.Mode = _mode == DeltaVisualMode.Candles ? CandleVisualMode.Candles : CandleVisualMode.Bars;
+        private void UpdateDivergenceCandlesVisibility()
+        {
+            if (DivergenceBarsFilter != null && (_mode == DeltaVisualMode.Candles || _mode == DeltaVisualMode.Bars))
+            {
+                var divergenceColor = DivergenceBarsFilter.Value;
+                _divergenceCandles.Visible = DivergenceBarsFilter.Enabled;
+                _divergenceCandles.UpCandleColor = divergenceColor;
+                _divergenceCandles.DownCandleColor = divergenceColor;
+                _divergenceCandles.BorderColor = divergenceColor;
+                _divergenceCandles.Mode = _mode == DeltaVisualMode.Candles ? CandleVisualMode.Candles : CandleVisualMode.Bars;
 
-			_divergenceDownCandles.Visible = DivergenceBarsFilter.Enabled && MinimizedMode;
-			_divergenceDownCandles.UpCandleColor = divergenceColor;
-			_divergenceDownCandles.DownCandleColor = divergenceColor;
-			_divergenceDownCandles.BorderColor = divergenceColor;
-			_divergenceDownCandles.Mode = _mode == DeltaVisualMode.Candles ? CandleVisualMode.Candles : CandleVisualMode.Bars;
-		}
-		else
-		{
-			_divergenceCandles.Visible = false;
-			_divergenceDownCandles.Visible = false;
-		}
-	}
+                _divergenceDownCandles.Visible = DivergenceBarsFilter.Enabled && MinimizedMode;
+                _divergenceDownCandles.UpCandleColor = divergenceColor;
+                _divergenceDownCandles.DownCandleColor = divergenceColor;
+                _divergenceDownCandles.BorderColor = divergenceColor;
+                _divergenceDownCandles.Mode = _mode == DeltaVisualMode.Candles ? CandleVisualMode.Candles : CandleVisualMode.Bars;
+            }
+            else
+            {
+                _divergenceCandles.Visible = false;
+                _divergenceDownCandles.Visible = false;
+            }
+        }
 
-	#endregion
-}
+        #endregion
+    }


### PR DESCRIPTION
### Summary
This PR adds two visual features to the Delta indicator:
1) Up/Down triangle signals on the price pane (with UI params, colors, and safe bounds).
2) Horizontal threshold lines on the Delta panel, toggleable via UI.

### Details
- Price signals:
  - New series: _priceSignalUp, _priceSignalDown
  - UI: ShowPriceSignals, PriceSignalOffsetTicks, PriceSignalSize,
        PriceSignalUpColor, PriceSignalDownColor
  - Rendering: filled triangles within PriceChartContainer (Top/Bottom)

- Threshold lines:
  - UI: ShowThresholdLines, UpMajorLevel, UpMinorLevel, DownMinorLevel, DownMajorLevel
  - Rendering: switch VisualType Line/Hide for _upMajor/_upMinor/_dnMinor/_dnMajor

- Cleanup:
  - Remove obsolete `_absorptionThreshold` (FilterInt `_absorption` already covers it)

### Why
- Compact and readable price-panel cues aligned with Delta events.
- Configurable thresholds to highlight significant up/down levels in the Delta panel.

### Testing
- Toggle ShowPriceSignals and ShowThresholdLines; verify expected visibility.
- Change triangle size, colors, and offset; markers update accordingly.
- Confirm triangles do not render outside price pane (Top/Bottom guards).
- Validate that per-bar clearing avoids ghost markers after signal changes.

### Screenshot
<img width="1175" height="1404" alt="image" src="https://github.com/user-attachments/assets/e9e2091f-df47-4d8d-a035-c441d537c9a0" />


### Risks
Low. Changes are localized to UI metadata and rendering; existing calculations remain intact.