### PR TITLE
Feature/ohlc plus lvn bands (stacked on top #115)

### DIFF
--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -1248,17 +1248,23 @@ public class OHLCPlus : Indicator
     {
         if (!levelSettings.Enabled || !_levels.TryGetValue(levelKey, out var level) || !level.IsValid)
             return;
-            
+
+        // --- Calculate actual label width for better positioning ---
+        var (prefix, suffix) = SplitKey(levelKey);
+        var levelText = ResolveLevelText(suffix, levelSettings);
+        var displayLabel = BuildDisplayLabel(prefix, levelText);
+        // ----------------------------------------------------
+
         // Validate price is reasonable
         if (level.Price <= 0)
             return;
 
         var y = ChartInfo.GetYByPrice(level.Price, false);
-        
+
         // Check if price is visible on chart
         if (y < 0 || y > ChartInfo.PriceChartContainer.Region.Height)
             return;
-            
+
         var chartWidth = ChartInfo.PriceChartContainer.Region.Width;
         var currentBarX = ChartInfo.GetXByBar(CurrentBar - 1);
         var barWidth = (int)ChartInfo.PriceChartContainer.BarsWidth;
@@ -1274,10 +1280,6 @@ public class OHLCPlus : Indicator
                 // If label is at bar position, start line after the label to avoid overlap
                 if (levelSettings.LabelPosition == LabelPosition.Bar)
                 {
-                    // Calculate actual label width for better positioning
-                    var (prefix, suffix) = SplitKey(levelKey);
-                    var levelText = ResolveLevelText(suffix, levelSettings);
-                    var displayLabel = BuildDisplayLabel(prefix, levelText);
                     var labelSize = context.MeasureString(displayLabel, _font);
                     var labelStartX = currentBarRightX + 5;
                     var lineStartX = labelStartX + labelSize.Width + 4; // 4px padding

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -1046,7 +1046,7 @@ public class OHLCPlus : Indicator
     [Range(0, 10)]
     public int HVNGapToleranceTicks { get; set; } = 1;
 
-    // Overlap tolerance in ticks: if a price falls within ±N ticks of another already drawn, it is hidden.
+    // Overlap tolerance in ticks: if a price falls within ï¿½N ticks of another already drawn, it is hidden.
     [Display(GroupName = "HVN Settings", Name = "Occlusion tolerance (ticks)", Order = 30)]
     [Range(0, 10)]
     public int HVNOcclusionTicks { get; set; } = 1;
@@ -1102,62 +1102,6 @@ public class OHLCPlus : Indicator
     [Display(GroupName = "Labels", Name = "VAL", Order = 100)]
     public string VALLabel { get; set; } = "VAL";
 
-    #endregion
-
-    #region Color scheme
-    // Strategy selector
-    [Display(GroupName = "Colors", Name = "Mode", Order = 5)]
-    public ColorMode ColorMode { get; set; } = ColorMode.PerLineSettings;
-
-    // --- Palette by PERIOD (used when ColorMode == ByPeriod)
-    [Display(GroupName = "Colors ï¿½ By Period", Name = "Current Day", Order = 10)]
-    public CrossColor PeriodColorCurrentDay { get; set; } = System.Drawing.Color.Orange.Convert();
-
-    [Display(GroupName = "Colors ï¿½ By Period", Name = "Previous Day", Order = 11)]
-    public CrossColor PeriodColorPrevDay { get; set; } = System.Drawing.Color.Gray.Convert();
-
-    [Display(GroupName = "Colors ï¿½ By Period", Name = "Current Week", Order = 12)]
-    public CrossColor PeriodColorCurrentWeek { get; set; } = System.Drawing.Color.SteelBlue.Convert();
-
-    [Display(GroupName = "Colors ï¿½ By Period", Name = "Previous Week", Order = 13)]
-    public CrossColor PeriodColorPrevWeek { get; set; } = System.Drawing.Color.MediumPurple.Convert();
-
-    [Display(GroupName = "Colors ï¿½ By Period", Name = "Current Month", Order = 14)]
-    public CrossColor PeriodColorCurrentMonth { get; set; } = System.Drawing.Color.Teal.Convert();
-
-    [Display(GroupName = "Colors ï¿½ By Period", Name = "Previous Month", Order = 15)]
-    public CrossColor PeriodColorPrevMonth { get; set; } = System.Drawing.Color.DarkSlateGray.Convert();
-
-    [Display(GroupName = "Colors ï¿½ By Period", Name = "Contract", Order = 16)]
-    public CrossColor PeriodColorContract { get; set; } = System.Drawing.Color.DodgerBlue.Convert();
-
-    // --- Palette by LEVEL TYPE (used when ColorMode == ByLevel)
-    [Display(GroupName = "Colors ï¿½ By Level", Name = "Open", Order = 110)]
-    public CrossColor LevelColorOpen { get; set; } = System.Drawing.Color.Orange.Convert();
-
-    [Display(GroupName = "Colors ï¿½ By Level", Name = "High", Order = 120)]
-    public CrossColor LevelColorHigh { get; set; } = System.Drawing.Color.Green.Convert();
-
-    [Display(GroupName = "Colors ï¿½ By Level", Name = "Low", Order = 130)]
-    public CrossColor LevelColorLow { get; set; } = System.Drawing.Color.Red.Convert();
-
-    [Display(GroupName = "Colors ï¿½ By Level", Name = "Close", Order = 140)]
-    public CrossColor LevelColorClose { get; set; } = System.Drawing.Color.Gray.Convert();
-
-    [Display(GroupName = "Colors ï¿½ By Level", Name = "Equilibrium (EQ)", Order = 150)]
-    public CrossColor LevelColorEQ { get; set; } = System.Drawing.Color.Yellow.Convert();
-
-    [Display(GroupName = "Colors ï¿½ By Level", Name = "POC", Order = 160)]
-    public CrossColor LevelColorPOC { get; set; } = System.Drawing.Color.Orange.Convert();
-
-    [Display(GroupName = "Colors ï¿½ By Level", Name = "VWAP", Order = 170)]
-    public CrossColor LevelColorVWAP { get; set; } = System.Drawing.Color.SteelBlue.Convert();
-
-    [Display(GroupName = "Colors ï¿½ By Level", Name = "VAH", Order = 180)]
-    public CrossColor LevelColorVAH { get; set; } = System.Drawing.Color.Purple.Convert();
-
-    [Display(GroupName = "Colors ï¿½ By Level", Name = "VAL", Order = 190)]
-    public CrossColor LevelColorVAL { get; set; } = System.Drawing.Color.Purple.Convert();
     #endregion
 
     #region Color scheme

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -1042,53 +1042,53 @@ public class OHLCPlus : Indicator
     public ColorMode ColorMode { get; set; } = ColorMode.PerLineSettings;
 
     // --- Palette by PERIOD (used when ColorMode == ByPeriod)
-    [Display(GroupName = "Colors — By Period", Name = "Current Day", Order = 10)]
+    [Display(GroupName = "Colors - By Period", Name = "Current Day", Order = 10)]
     public CrossColor PeriodColorCurrentDay { get; set; } = System.Drawing.Color.OrangeRed.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Previous Day", Order = 11)]
+    [Display(GroupName = "Colors - By Period", Name = "Previous Day", Order = 11)]
     public CrossColor PeriodColorPrevDay { get; set; } = System.Drawing.Color.SaddleBrown.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Current Week", Order = 12)]
+    [Display(GroupName = "Colors - By Period", Name = "Current Week", Order = 12)]
     public CrossColor PeriodColorCurrentWeek { get; set; } = System.Drawing.Color.DeepSkyBlue.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Previous Week", Order = 13)]
+    [Display(GroupName = "Colors - By Period", Name = "Previous Week", Order = 13)]
     public CrossColor PeriodColorPrevWeek { get; set; } = System.Drawing.Color.DarkSlateBlue.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Current Month", Order = 14)]
+    [Display(GroupName = "Colors - By Period", Name = "Current Month", Order = 14)]
     public CrossColor PeriodColorCurrentMonth { get; set; } = System.Drawing.Color.MediumSeaGreen.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Previous Month", Order = 15)]
+    [Display(GroupName = "Colors - By Period", Name = "Previous Month", Order = 15)]
     public CrossColor PeriodColorPrevMonth { get; set; } = System.Drawing.Color.DarkOliveGreen.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Contract", Order = 16)]
+    [Display(GroupName = "Colors - By Period", Name = "Contract", Order = 16)]
     public CrossColor PeriodColorContract { get; set; } = System.Drawing.Color.Indigo.Convert();
 
     // --- Palette by LEVEL TYPE (used when ColorMode == ByLevel)
-    [Display(GroupName = "Colors — By Level", Name = "Open", Order = 110)]
+    [Display(GroupName = "Colors - By Level", Name = "Open", Order = 110)]
     public CrossColor LevelColorOpen { get; set; } = System.Drawing.Color.DarkGoldenrod.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "High", Order = 120)]
+    [Display(GroupName = "Colors - By Level", Name = "High", Order = 120)]
     public CrossColor LevelColorHigh { get; set; } = System.Drawing.Color.ForestGreen.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "Low", Order = 130)]
+    [Display(GroupName = "Colors - By Level", Name = "Low", Order = 130)]
     public CrossColor LevelColorLow { get; set; } = System.Drawing.Color.Firebrick.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "Close", Order = 140)]
+    [Display(GroupName = "Colors - By Level", Name = "Close", Order = 140)]
     public CrossColor LevelColorClose { get; set; } = System.Drawing.Color.DimGray.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "Equilibrium (EQ)", Order = 150)]
+    [Display(GroupName = "Colors - By Level", Name = "Equilibrium (EQ)", Order = 150)]
     public CrossColor LevelColorEQ { get; set; } = System.Drawing.Color.DarkKhaki.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "POC", Order = 160)]
+    [Display(GroupName = "Colors - By Level", Name = "POC", Order = 160)]
     public CrossColor LevelColorPOC { get; set; } = System.Drawing.Color.OrangeRed.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "VWAP", Order = 170)]
+    [Display(GroupName = "Colors - By Level", Name = "VWAP", Order = 170)]
     public CrossColor LevelColorVWAP { get; set; } = System.Drawing.Color.DodgerBlue.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "VAH", Order = 180)]
+    [Display(GroupName = "Colors - By Level", Name = "VAH", Order = 180)]
     public CrossColor LevelColorVAH { get; set; } = System.Drawing.Color.CornflowerBlue.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "VAL", Order = 190)]
+    [Display(GroupName = "Colors - By Level", Name = "VAL", Order = 190)]
     public CrossColor LevelColorVAL { get; set; } = System.Drawing.Color.RoyalBlue.Convert();
     #endregion
 
@@ -1680,7 +1680,7 @@ public class OHLCPlus : Indicator
             }
         }
 
-        // Visual-only changes → redraw
+        // Visual-only changes -> redraw
         if (e.PropertyName == nameof(LevelSettings.Color)
             || e.PropertyName == nameof(LevelSettings.OverrideColorInSchemes)
             || e.PropertyName == nameof(LevelSettings.LineStyle)

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -958,21 +958,54 @@ public class OHLCPlus : Indicator
 
     #endregion
 
+    #region Prefix Settings
+    // Display-only prefixes (do not affect storage keys)
+    [Display(GroupName = "Prefixes", Name = "Current Day", Order = 10)]
+    public string PrefixCurrentDay { get; set; } = "d";
+
+    [Display(GroupName = "Prefixes", Name = "Previous Day", Order = 20)]
+    public string PrefixPrevDay { get; set; } = "p";
+
+    [Display(GroupName = "Prefixes", Name = "Current Week", Order = 30)]
+    public string PrefixCurrentWeek { get; set; } = "w";
+
+    [Display(GroupName = "Prefixes", Name = "Previous Week", Order = 40)]
+    public string PrefixPrevWeek { get; set; } = "pw";
+
+    [Display(GroupName = "Prefixes", Name = "Current Month", Order = 50)]
+    public string PrefixCurrentMonth { get; set; } = "m";
+
+    [Display(GroupName = "Prefixes", Name = "Previous Month", Order = 60)]
+    public string PrefixPrevMonth { get; set; } = "pm";
+
+    [Display(GroupName = "Prefixes", Name = "Contract", Order = 70)]
+    public string PrefixContract { get; set; } = "c";
+    #endregion
+
     #region Labels Settings
 
     // Template supports {prefix} and {level}
-    [Display(Name = "Label template")]
+    [Display(GroupName = "Labels", Name = "Label template", Order = 10)]
     public string LabelTemplate { get; set; } = "{prefix}{level}";
 
-    [Display(Name = "Open label")] public string OpenLabel { get; set; } = "Open";
-    [Display(Name = "High label")] public string HighLabel { get; set; } = "High";
-    [Display(Name = "Low label")] public string LowLabel { get; set; } = "Low";
-    [Display(Name = "Close label")] public string CloseLabel { get; set; } = "Close";
-    [Display(Name = "Equilibrium label")] public string EqLabel { get; set; } = "EQ";
-    [Display(Name = "POC label")] public string POCLabel { get; set; } = "POC";
-    [Display(Name = "VWAP label")] public string VWAPLabel { get; set; } = "VWAP";
-    [Display(Name = "VAH label")] public string VAHLabel { get; set; } = "VAH";
-    [Display(Name = "VAL label")] public string VALLabel { get; set; } = "VAL";
+    [Display(GroupName = "Labels", Name = "Open", Order = 20)]
+    public string OpenLabel { get; set; } = "Open";
+    [Display(GroupName = "Labels", Name = "High", Order = 30)]
+    public string HighLabel { get; set; } = "High";
+    [Display(GroupName = "Labels", Name = "Low", Order = 40)]
+    public string LowLabel { get; set; } = "Low";
+    [Display(GroupName = "Labels", Name = "Close", Order = 50)]
+    public string CloseLabel { get; set; } = "Close";
+    [Display(GroupName = "Labels", Name = "Equilibrium", Order = 60)]
+    public string EqLabel { get; set; } = "EQ";
+    [Display(GroupName = "Labels", Name = "POC", Order = 70)]
+    public string POCLabel { get; set; } = "POC";
+    [Display(GroupName = "Labels", Name = "VWAP", Order = 80)]
+    public string VWAPLabel { get; set; } = "VWAP";
+    [Display(GroupName = "Labels", Name = "VAH", Order = 90)]
+    public string VAHLabel { get; set; } = "VAH";
+    [Display(GroupName = "Labels", Name = "VAL", Order = 100)]
+    public string VALLabel { get; set; } = "VAL";
 
     #endregion
 
@@ -1046,13 +1079,13 @@ public class OHLCPlus : Indicator
             return;
 
         // Render all levels in groups for better organization
-        RenderLevelGroup(context, "d", DayOpenLevel, DayHighLevel, DayLowLevel, DayCloseLevel, DayEquilibriumLevel, DayPOCLevel, DayVWAPLevel, DayVAHLevel, DayVALLevel);
-        RenderLevelGroup(context, "p", PrevDayOpenLevel, PrevDayHighLevel, PrevDayLowLevel, PrevDayCloseLevel, PrevDayEquilibriumLevel, PrevDayPOCLevel, PrevDayVWAPLevel, PrevDayVAHLevel, PrevDayVALLevel);
-        RenderLevelGroup(context, "w", WeekOpenLevel, WeekHighLevel, WeekLowLevel, WeekCloseLevel, WeekEquilibriumLevel, WeekPOCLevel, WeekVWAPLevel, WeekVAHLevel, WeekVALLevel);
-        RenderLevelGroup(context, "pw", PrevWeekOpenLevel, PrevWeekHighLevel, PrevWeekLowLevel, PrevWeekCloseLevel, PrevWeekEquilibriumLevel, PrevWeekPOCLevel, PrevWeekVWAPLevel, PrevWeekVAHLevel, PrevWeekVALLevel);
-        RenderLevelGroup(context, "m", MonthOpenLevel, MonthHighLevel, MonthLowLevel, MonthCloseLevel, MonthEquilibriumLevel, MonthPOCLevel, MonthVWAPLevel, MonthVAHLevel, MonthVALLevel);
-        RenderLevelGroup(context, "pm", PrevMonthOpenLevel, PrevMonthHighLevel, PrevMonthLowLevel, PrevMonthCloseLevel, PrevMonthEquilibriumLevel, PrevMonthPOCLevel, PrevMonthVWAPLevel, PrevMonthVAHLevel, PrevMonthVALLevel);
-        RenderLevelGroup(context, "c", ContractOpenLevel, ContractHighLevel, ContractLowLevel, ContractCloseLevel, ContractEquilibriumLevel, ContractPOCLevel, ContractVWAPLevel, ContractVAHLevel, ContractVALLevel);
+        RenderLevelGroup(context, storagePrefix: "d", displayPrefix: PrefixCurrentDay, DayOpenLevel, DayHighLevel, DayLowLevel, DayCloseLevel, DayEquilibriumLevel, DayPOCLevel, DayVWAPLevel, DayVAHLevel, DayVALLevel);
+        RenderLevelGroup(context, storagePrefix: "p", displayPrefix: PrefixPrevDay, PrevDayOpenLevel, PrevDayHighLevel, PrevDayLowLevel, PrevDayCloseLevel, PrevDayEquilibriumLevel, PrevDayPOCLevel, PrevDayVWAPLevel, PrevDayVAHLevel, PrevDayVALLevel);
+        RenderLevelGroup(context, storagePrefix: "w", displayPrefix: PrefixCurrentWeek, WeekOpenLevel, WeekHighLevel, WeekLowLevel, WeekCloseLevel, WeekEquilibriumLevel, WeekPOCLevel, WeekVWAPLevel, WeekVAHLevel, WeekVALLevel);
+        RenderLevelGroup(context, storagePrefix: "pw", displayPrefix: PrefixPrevWeek, PrevWeekOpenLevel, PrevWeekHighLevel, PrevWeekLowLevel, PrevWeekCloseLevel, PrevWeekEquilibriumLevel, PrevWeekPOCLevel, PrevWeekVWAPLevel, PrevWeekVAHLevel, PrevWeekVALLevel);
+        RenderLevelGroup(context, storagePrefix: "m", displayPrefix: PrefixCurrentMonth, MonthOpenLevel, MonthHighLevel, MonthLowLevel, MonthCloseLevel, MonthEquilibriumLevel, MonthPOCLevel, MonthVWAPLevel, MonthVAHLevel, MonthVALLevel);
+        RenderLevelGroup(context, storagePrefix: "pm", displayPrefix: PrefixPrevMonth, PrevMonthOpenLevel, PrevMonthHighLevel, PrevMonthLowLevel, PrevMonthCloseLevel, PrevMonthEquilibriumLevel, PrevMonthPOCLevel, PrevMonthVWAPLevel, PrevMonthVAHLevel, PrevMonthVALLevel);
+        RenderLevelGroup(context, storagePrefix: "c", displayPrefix: PrefixContract, ContractOpenLevel, ContractHighLevel, ContractLowLevel, ContractCloseLevel, ContractEquilibriumLevel, ContractPOCLevel, ContractVWAPLevel, ContractVAHLevel, ContractVALLevel);
     }
 
     #endregion
@@ -1244,6 +1277,20 @@ public class OHLCPlus : Indicator
         _ => FixedProfilePeriods.CurrentDay
     };
 
+    // Maps the canonical storage prefix ("d", "p", "w", "pw", "m", "pm", "c")
+    // to the user-configurable display prefix for visual labels.
+    private string DisplayPrefixFor(string storagePrefix) => storagePrefix switch
+    {
+        "d" => PrefixCurrentDay,
+        "p" => PrefixPrevDay,
+        "w" => PrefixCurrentWeek,
+        "pw" => PrefixPrevWeek,
+        "m" => PrefixCurrentMonth,
+        "pm" => PrefixPrevMonth,
+        "c" => PrefixContract,
+        _ => storagePrefix ?? string.Empty
+    };
+
     private void RenderLevel(RenderContext context, string levelKey, LevelSettings levelSettings)
     {
         if (!levelSettings.Enabled || !_levels.TryGetValue(levelKey, out var level) || !level.IsValid)
@@ -1252,7 +1299,7 @@ public class OHLCPlus : Indicator
         // --- Calculate actual label width for better positioning ---
         var (prefix, suffix) = SplitKey(levelKey);
         var levelText = ResolveLevelText(suffix, levelSettings);
-        var displayLabel = BuildDisplayLabel(prefix, levelText);
+        var displayLabel = BuildDisplayLabel(DisplayPrefixFor(prefix), levelText);
         // ----------------------------------------------------
 
         // Validate price is reasonable

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -126,6 +126,7 @@ public class LevelSettings : NotifiableObject
 
     private string _overrideLabel = string.Empty;
 
+    // If set, this replaces the ENTIRE visual label (ignores template/prefix/suffix)
     [Display(Name = "Override label (optional)")]
     public string OverrideLabel
     {
@@ -1311,10 +1312,20 @@ public class OHLCPlus : Indicator
         if (!levelSettings.Enabled || !_levels.TryGetValue(levelKey, out var level) || !level.IsValid)
             return;
 
-        // --- Calculate actual label width for better positioning ---
+        // --- Calculate actual label ---
+
         var (prefix, suffix) = SplitKey(levelKey);
-        var levelText = ResolveLevelText(suffix, levelSettings);
-        var displayLabel = BuildDisplayLabel(DisplayPrefixFor(prefix), levelText);
+        // If an override label is provided for this LevelSettings, use it as-is
+        string displayLabel;
+        if (!string.IsNullOrWhiteSpace(levelSettings.OverrideLabel))
+        {
+            displayLabel = levelSettings.OverrideLabel;
+        }
+        else
+        {
+            var levelText = ResolveLevelText(suffix);
+            displayLabel = BuildDisplayLabel(DisplayPrefixFor(prefix), levelText);
+        }
         // ----------------------------------------------------
 
         // Validate price is reasonable
@@ -1343,9 +1354,6 @@ public class OHLCPlus : Indicator
                 if (levelSettings.LabelPosition == LabelPosition.Bar)
                 {
                     // Calculate actual label width for better positioning
-                    var (prefix, suffix) = SplitKey(levelKey);
-                    var levelText = ResolveLevelText(suffix, levelSettings);
-                    var displayLabel = BuildDisplayLabel(prefix, levelText);
                     var labelSize = context.MeasureString(displayLabel, _font);
                     var labelStartX = currentBarRightX + 5;
                     var lineStartX = labelStartX + labelSize.Width + 4; // 4px padding
@@ -1567,11 +1575,8 @@ public class OHLCPlus : Indicator
         return ("", key);
     }
 
-    private string ResolveLevelText(string suffix, LevelSettings ls)
+    private string ResolveLevelText(string suffix)
     {
-        if (!string.IsNullOrWhiteSpace(ls?.OverrideLabel))
-            return ls.OverrideLabel;
-
         return suffix switch
         {
             "Open" => OpenLabel,

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -281,17 +281,20 @@ public class OHLCPlus : Indicator
     private string? _scopedDisplayPrefix = null;
 
     // HVN prices by period
-    private readonly Dictionary<FixedProfilePeriods, List<HVNBand>> _hvnBands = new();
+    private readonly Dictionary<FixedProfilePeriods, List<VolumeNodeBand>> _hvnBands = new();
 
-    private static readonly FixedProfilePeriods[] _hvnPriorityOrder = new[]
+    // LVN prices by period
+    private readonly Dictionary<FixedProfilePeriods, List<VolumeNodeBand>> _lvnBands = new();
+
+    private static readonly FixedProfilePeriods[] _nodePriorityOrder = new[]
     {
-    FixedProfilePeriods.Contract,
-    FixedProfilePeriods.LastMonth,
-    FixedProfilePeriods.CurrentMonth,
-    FixedProfilePeriods.LastWeek,
-    FixedProfilePeriods.CurrentWeek,
+    FixedProfilePeriods.CurrentDay,
     FixedProfilePeriods.LastDay,
-    FixedProfilePeriods.CurrentDay
+    FixedProfilePeriods.CurrentWeek,
+    FixedProfilePeriods.LastWeek,
+    FixedProfilePeriods.CurrentMonth,
+    FixedProfilePeriods.LastMonth,
+    FixedProfilePeriods.Contract
     };
 
     // 2) Classifications for mapping (storagePrefix, suffix) -> style lookup
@@ -517,11 +520,36 @@ public class OHLCPlus : Indicator
         lineType: LineType.Bar
     );
 
+    private bool _dayHVNEnabled;
     [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentDay), Name = "Enable HVN", Order = 90)]
-    public bool DayHVNEnabled { get; set; } = false;
+    public bool DayHVNEnabled
+    {
+        get => _dayHVNEnabled;
+        set
+        {
+            if (_dayHVNEnabled == value) return;
+            _dayHVNEnabled = value;
+            RefreshData();
+        }
+    }
 
-    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentDay), Name = "HVN Color", Order = 95)]
+    private bool _dayLVNEnabled;
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentDay), Name = "Enable LVN", Order = 92)]
+    public bool DayLVNEnabled
+    {
+        get => _dayLVNEnabled;
+        set
+        {
+            if (_dayLVNEnabled == value) return;
+            _dayLVNEnabled = value;
+            RefreshData();
+        }
+    }
+
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentDay), Name = "VN Color", Order = 95)]
     public CrossColor DayHVNColor { get; set; } = System.Drawing.Color.FromArgb(140, 30, 144, 255).Convert(); // semi-transparent blue/violet
+
+
 
     #endregion
 
@@ -626,10 +654,33 @@ public class OHLCPlus : Indicator
         lineType: LineType.Bar
     );
 
+    private bool _prevdayHVNEnabled;
     [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousDay), Name = "Enable HVN", Order = 90)]
-    public bool PrevDayHVNEnabled { get; set; } = false;
+    public bool PrevDayHVNEnabled
+    {
+        get => _prevdayHVNEnabled;
+        set
+        {
+            if (_prevdayHVNEnabled == value) return;
+            _prevdayHVNEnabled = value;
+            RefreshData();
+        }
+    }
 
-    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousDay), Name = "HVN Color", Order = 95)]
+    private bool _prevdayLVNEnabled;
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousDay), Name = "Enable LVN", Order = 92)]
+    public bool PrevDayLVNEnabled
+    {
+        get => _prevdayLVNEnabled;
+        set
+        {
+            if (_prevdayLVNEnabled == value) return;
+            _prevdayLVNEnabled = value;
+            RefreshData();
+        }
+    }
+
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousDay), Name = "VN Color", Order = 95)]
     public CrossColor PrevDayHVNColor { get; set; } = System.Drawing.Color.FromArgb(140, 255, 140, 0).Convert(); // semi-transparent amber.
 
     #endregion
@@ -735,9 +786,33 @@ public class OHLCPlus : Indicator
         lineType: LineType.Bar
     );
 
+    private bool _WeekHVNEnabled;
     [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentWeek), Name = "Enable HVN", Order = 90)]
-    public bool WeekHVNEnabled { get; set; } = false;
-    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentWeek), Name = "HVN Color", Order = 95)]
+    public bool WeekHVNEnabled
+    {
+        get => _WeekHVNEnabled;
+        set
+        {
+            if (_WeekHVNEnabled == value) return;
+            _WeekHVNEnabled = value;
+            RefreshData();
+        }
+    }
+
+    private bool _WeekLVNEnabled;
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentWeek), Name = "Enable LVN", Order = 92)]
+    public bool WeekLVNEnabled
+    {
+        get => _WeekLVNEnabled;
+        set
+        {
+            if (_WeekLVNEnabled == value) return;
+            _WeekLVNEnabled = value;
+            RefreshData();
+        }
+    }
+
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentWeek), Name = "VN Color", Order = 95)]
     public CrossColor WeekHVNColor { get; set; } = System.Drawing.Color.FromArgb(140, 70, 130, 180).Convert(); // steel-ish
 
     #endregion
@@ -843,10 +918,35 @@ public class OHLCPlus : Indicator
         lineType: LineType.Bar
     );
 
+    private bool _prevWeekHVNEnabled;
     [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousWeek), Name = "Enable HVN", Order = 90)]
-    public bool PrevWeekHVNEnabled { get; set; } = false;
-    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousWeek), Name = "HVN Color", Order = 95)]
+    public bool PrevWeekHVNEnabled
+    {
+        get => _prevWeekHVNEnabled;
+        set
+        {
+            if (_prevWeekHVNEnabled == value) return;
+            _prevWeekHVNEnabled = value;
+            RefreshData();
+        }
+    }
+
+    private bool _prevWeekLVNEnabled;
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousWeek), Name = "Enable LVN", Order = 92)]
+    public bool PrevWeekLVNEnabled
+    {
+        get => _prevWeekLVNEnabled;
+        set
+        {
+            if (_prevWeekLVNEnabled == value) return;
+            _prevWeekLVNEnabled = value;
+            RefreshData();
+        }
+    }
+
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousWeek), Name = "VN Color", Order = 95)]
     public CrossColor PrevWeekHVNColor { get; set; } = System.Drawing.Color.FromArgb(140, 186, 85, 211).Convert(); // mediumPurple
+
 
     #endregion
 
@@ -951,9 +1051,33 @@ public class OHLCPlus : Indicator
         lineType: LineType.Bar
     );
 
+    private bool _monthHVNEnabled;
     [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentMonth), Name = "Enable HVN", Order = 90)]
-    public bool MonthHVNEnabled { get; set; } = false;
-    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentMonth), Name = "HVN Color", Order = 95)]
+    public bool MonthHVNEnabled
+    {
+        get => _monthHVNEnabled;
+        set
+        {
+            if (_monthHVNEnabled == value) return;
+            _monthHVNEnabled = value;
+            RefreshData();
+        }
+    }
+
+    private bool _monthLVNEnabled;
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentMonth), Name = "Enable LVN", Order = 92)]
+    public bool MonthLVNEnabled
+    {
+        get => _monthLVNEnabled;
+        set
+        {
+            if (_monthLVNEnabled == value) return;
+            _monthLVNEnabled = value;
+            RefreshData();
+        }
+    }
+
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentMonth), Name = "VN Color", Order = 95)]
     public CrossColor MonthHVNColor { get; set; } = System.Drawing.Color.FromArgb(140, 0, 128, 128).Convert(); // teal
 
     #endregion
@@ -1059,9 +1183,33 @@ public class OHLCPlus : Indicator
         lineType: LineType.Bar
     );
 
+    private bool _prevMonthHVNEnabled;
     [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousMonth), Name = "Enable HVN", Order = 90)]
-    public bool PrevMonthHVNEnabled { get; set; } = false;
-    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousMonth), Name = "HVN Color", Order = 95)]
+    public bool PrevMonthHVNEnabled
+    {
+        get => _prevMonthHVNEnabled;
+        set
+        {
+            if (_prevMonthHVNEnabled == value) return;
+            _prevMonthHVNEnabled = value;
+            RefreshData();
+        }
+    }
+
+    private bool _prevMonthLVNEnabled;
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousMonth), Name = "Enable LVN", Order = 92)]
+    public bool PrevMonthLVNEnabled
+    {
+        get => _prevMonthLVNEnabled;
+        set
+        {
+            if (_prevMonthLVNEnabled == value) return;
+            _prevMonthLVNEnabled = value;
+            RefreshData();
+        }
+    }
+
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousMonth), Name = "VN Color", Order = 95)]
     public CrossColor PrevMonthHVNColor { get; set; } = System.Drawing.Color.FromArgb(140, 47, 79, 79).Convert(); // darkslategray
 
     #endregion
@@ -1167,26 +1315,188 @@ public class OHLCPlus : Indicator
         lineType: LineType.Bar
     );
 
+    private bool _contractHVNEnabled;
     [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Contract), Name = "Enable HVN", Order = 90)]
-    public bool ContractHVNEnabled { get; set; } = false;
-    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Contract), Name = "HVN Color", Order = 95)]
+    public bool ContractHVNEnabled
+    {
+        get => _contractHVNEnabled;
+        set
+        {
+            if (_contractHVNEnabled == value) return;
+            _contractHVNEnabled = value;
+            RefreshData();
+        }
+    }
+
+    private bool _contractLVNEnabled;
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Contract), Name = "Enable LVN", Order = 92)]
+    public bool ContractLVNEnabled
+    {
+        get => _contractLVNEnabled;
+        set
+        {
+            if (_contractLVNEnabled == value) return;
+            _contractLVNEnabled = value;
+            RefreshData();
+        }
+    }
+
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Contract), Name = "VN Color", Order = 95)]
     public CrossColor ContractHVNColor { get; set; } = System.Drawing.Color.FromArgb(140, 30, 144, 255).Convert(); // dodgerblue
 
     #endregion
 
     #region HVN Settings
+    private int _hvnThresholdPct = 80;
     [Display(GroupName = "HVN Settings", Name = "Threshold (% of POC volume)", Order = 10)]
     [Range(1, 99)]
-    public int HVNThresholdPct { get; set; } = 80;
+    public int HVNThresholdPct
+    {
+        get => _hvnThresholdPct;
+        set
+        {
+            if (_hvnThresholdPct == value) return;
+            _hvnThresholdPct = value;
+            RefreshData();
+        }
+    }
 
+    private int _hvnGapToleranceTicks = 1;
     [Display(GroupName = "HVN Settings", Name = "Gap tolerance (ticks)", Order = 20)]
     [Range(0, 10)]
-    public int HVNGapToleranceTicks { get; set; } = 1;
+    public int HVNGapToleranceTicks
+    {
+        get => _hvnGapToleranceTicks;
+        set
+        {
+            if (_hvnGapToleranceTicks == value) return;
+            _hvnGapToleranceTicks = value;
+            RefreshData();
+        }
+    }
 
-    // Overlap tolerance in ticks: if a price falls within �N ticks of another already drawn, it is hidden.
-    [Display(GroupName = "HVN Settings", Name = "Occlusion tolerance (ticks)", Order = 30)]
+    private int _hvnOcclusionTicks = 1;
+    // Overlap tolerance in ticks: if a price falls within N ticks of another already drawn, it is hidden.
+    [Display(GroupName = "HVN Settings", Name = "Occlusion tolerance (ticks)", Order = 30)]
     [Range(0, 10)]
-    public int HVNOcclusionTicks { get; set; } = 1;
+    public int HVNOcclusionTicks
+    {
+        get => _hvnOcclusionTicks;
+        set
+        {
+            if (_hvnOcclusionTicks == value) return;
+            _hvnOcclusionTicks = value;
+            RefreshData();
+        }
+    }
+
+    #endregion
+
+    #region LVN Settings
+
+    private int _lvnThresholdPct = 20;
+    [Display(GroupName = "LVN Settings", Name = "Threshold (% of POC volume)", Order = 10)]
+    [Range(1, 50)]
+    [Description("Bands of volume BELOW this percentage of POC volume will be marked as LVNs (voids).")]
+    public int LVNThresholdPct
+    {
+        get => _lvnThresholdPct;
+        set
+        {
+            if (_lvnThresholdPct == value) return;
+            _lvnThresholdPct = value;
+            RefreshData();
+        }
+    }
+
+    private int _lvnGapToleranceTicks = 2;
+    [Display(GroupName = "LVN Settings", Name = "Gap tolerance (ticks)", Order = 20)]
+    [Range(0, 10)]
+    [Description("How many non-LVN ticks are allowed inside a void before splitting it.")]
+    public int LVNGapToleranceTicks
+    {
+        get => _lvnGapToleranceTicks;
+        set
+        {
+            if (_lvnGapToleranceTicks == value) return;
+            _lvnGapToleranceTicks = value;
+            RefreshData();
+        }
+    }
+
+    private LineDashStyle _lvnBorderStyle = LineDashStyle.Dot;
+    [Display(GroupName = "LVN Settings", Name = "LVN Border Style", Order = 30)]
+    [Description("Line style for the LVN void border.")]
+    public LineDashStyle LVNBorderStyle
+    {
+        get => _lvnBorderStyle;
+        set
+        {
+            if (_lvnBorderStyle == value) return;
+            _lvnBorderStyle = value;
+            RefreshData();
+        }
+    }
+
+    private int _lvnBorderWidth = 1;
+    [Display(GroupName = "LVN Settings", Name = "LVN Border Width", Order = 40)]
+    [Range(1, 5)]
+    [Description("Line width for the LVN void border.")]
+    public int LVNBorderWidth
+    {
+        get => _lvnBorderWidth;
+        set
+        {
+            if (_lvnBorderWidth == value) return;
+            _lvnBorderWidth = value;
+            RefreshData();
+        }
+    }
+
+    private int _minPocVolForLVN = 500;
+    [Display(GroupName = "LVN Settings", Name = "Min POC Vol for LVN", Order = 50)]
+    [Range(1, 10000)]
+    [Description("Do not calculate LVNs for a period until its POC Volume is above this threshold. Prevents noise at the start of a new period.")]
+    public int MinPocVolForLVN
+    {
+        get => _minPocVolForLVN;
+        set
+        {
+            if (_minPocVolForLVN == value) return;
+            _minPocVolForLVN = value;
+            RefreshData();
+        }
+    }
+
+    private int _lvnTailFilter_MinTicks = 3;
+    [Display(GroupName = "LVN Settings", Name = "Tail Filter - Min Ticks", Order = 60)]
+    [Range(0, 20)]
+    [Description("MINIMUM number of ticks to filter from H/L. Always active.")]
+    public int LVNTailFilter_MinTicks
+    {
+        get => _lvnTailFilter_MinTicks;
+        set
+        {
+            if (_lvnTailFilter_MinTicks == value) return;
+            _lvnTailFilter_MinTicks = value;
+            RefreshData();
+        }
+    }
+
+    private int _lvnTailFilter_Pct = 10;
+    [Display(GroupName = "LVN Settings", Name = "Tail Filter - Pct of Range", Order = 61)]
+    [Range(0, 50)]
+    [Description("Adaptive filter. Uses this % of the H/L range if it's larger than 'Min Ticks'. (0 = disabled).")]
+    public int LVNTailFilter_Pct
+    {
+        get => _lvnTailFilter_Pct;
+        set
+        {
+            if (_lvnTailFilter_Pct == value) return;
+            _lvnTailFilter_Pct = value;
+            RefreshData();
+        }
+    }
 
     #endregion
 
@@ -1358,7 +1668,7 @@ public class OHLCPlus : Indicator
     {
         _profileCandles[period] = fixedProfileOriginScale;
         UpdateLevels(period, fixedProfileOriginScale);
-        UpdateHVNs(period, fixedProfileOriginScale);
+        UpdateVolumeNodes(period, fixedProfileOriginScale);
         RedrawChart();
     }
 
@@ -1457,7 +1767,7 @@ public class OHLCPlus : Indicator
 
 
         // 3) HVN rects (kept after levels as in your current codebase)
-        RenderAllHVNsWithPriority(context);
+        RenderAllVolumeNodes(context);
     }
 
 
@@ -1472,7 +1782,10 @@ public class OHLCPlus : Indicator
         void UpdateIf(FixedProfilePeriods p)
         {
             if (IsNeeded(p) && _profileCandles.TryGetValue(p, out var candle) && candle is not null)
+            {
                 UpdateLevels(p, candle);
+                UpdateVolumeNodes(p, candle);
+            }
         }
 
         UpdateIf(FixedProfilePeriods.CurrentDay);
@@ -1497,11 +1810,10 @@ public class OHLCPlus : Indicator
         if (_needContract) RequestProfileForPeriod(FixedProfilePeriods.Contract);
     }
 
-    private void RequestProfileForPeriod(FixedProfilePeriods period, bool force = true)
+    private void RequestProfileForPeriod(FixedProfilePeriods period)
     {
-        if (!force && _profileCandles.TryGetValue(period, out var candle) && candle is not null)
+        if (_profileCandles.TryGetValue(period, out var candle) && candle is not null)
         {
-            RedrawChart();
             return;
         }
 
@@ -1550,48 +1862,49 @@ public class OHLCPlus : Indicator
     private bool NeedsDayData()
     {
         return DayOpenLevel.Enabled || DayHighLevel.Enabled || DayLowLevel.Enabled || DayCloseLevel.Enabled ||
-               DayEquilibriumLevel.Enabled || DayPOCLevel.Enabled || DayVWAPLevel.Enabled || DayVAHLevel.Enabled || DayVALLevel.Enabled || DayHVNEnabled;
+               DayEquilibriumLevel.Enabled || DayPOCLevel.Enabled || DayVWAPLevel.Enabled || DayVAHLevel.Enabled || DayVALLevel.Enabled || DayHVNEnabled || DayLVNEnabled;
     }
 
     private bool NeedsPrevDayData()
     {
         return PrevDayOpenLevel.Enabled || PrevDayHighLevel.Enabled || PrevDayLowLevel.Enabled || PrevDayCloseLevel.Enabled ||
-               PrevDayEquilibriumLevel.Enabled || PrevDayPOCLevel.Enabled || PrevDayVWAPLevel.Enabled || PrevDayVAHLevel.Enabled || PrevDayVALLevel.Enabled || PrevDayHVNEnabled;
+               PrevDayEquilibriumLevel.Enabled || PrevDayPOCLevel.Enabled || PrevDayVWAPLevel.Enabled || PrevDayVAHLevel.Enabled || PrevDayVALLevel.Enabled || PrevDayHVNEnabled || PrevDayLVNEnabled;
     }
 
     private bool NeedsWeekData()
     {
         return WeekOpenLevel.Enabled || WeekHighLevel.Enabled || WeekLowLevel.Enabled || WeekCloseLevel.Enabled ||
-               WeekEquilibriumLevel.Enabled || WeekPOCLevel.Enabled || WeekVWAPLevel.Enabled || WeekVAHLevel.Enabled || WeekVALLevel.Enabled || WeekHVNEnabled;
+               WeekEquilibriumLevel.Enabled || WeekPOCLevel.Enabled || WeekVWAPLevel.Enabled || WeekVAHLevel.Enabled || WeekVALLevel.Enabled || WeekHVNEnabled || WeekLVNEnabled;
     }
 
     private bool NeedsPrevWeekData()
     {
         return PrevWeekOpenLevel.Enabled || PrevWeekHighLevel.Enabled || PrevWeekLowLevel.Enabled || PrevWeekCloseLevel.Enabled ||
-               PrevWeekEquilibriumLevel.Enabled || PrevWeekPOCLevel.Enabled || PrevWeekVWAPLevel.Enabled || PrevWeekVAHLevel.Enabled || PrevWeekVALLevel.Enabled || PrevWeekHVNEnabled;
+               PrevWeekEquilibriumLevel.Enabled || PrevWeekPOCLevel.Enabled || PrevWeekVWAPLevel.Enabled || PrevWeekVAHLevel.Enabled || PrevWeekVALLevel.Enabled || PrevWeekHVNEnabled || PrevWeekLVNEnabled;
     }
 
     private bool NeedsMonthData()
     {
         return MonthOpenLevel.Enabled || MonthHighLevel.Enabled || MonthLowLevel.Enabled || MonthCloseLevel.Enabled ||
-               MonthEquilibriumLevel.Enabled || MonthPOCLevel.Enabled || MonthVWAPLevel.Enabled || MonthVAHLevel.Enabled || MonthVALLevel.Enabled || MonthHVNEnabled;
+               MonthEquilibriumLevel.Enabled || MonthPOCLevel.Enabled || MonthVWAPLevel.Enabled || MonthVAHLevel.Enabled || MonthVALLevel.Enabled || MonthHVNEnabled || MonthLVNEnabled;
     }
 
     private bool NeedsPrevMonthData()
     {
         return PrevMonthOpenLevel.Enabled || PrevMonthHighLevel.Enabled || PrevMonthLowLevel.Enabled || PrevMonthCloseLevel.Enabled ||
-               PrevMonthEquilibriumLevel.Enabled || PrevMonthPOCLevel.Enabled || PrevMonthVWAPLevel.Enabled || PrevMonthVAHLevel.Enabled || PrevMonthVALLevel.Enabled || PrevMonthHVNEnabled;
+               PrevMonthEquilibriumLevel.Enabled || PrevMonthPOCLevel.Enabled || PrevMonthVWAPLevel.Enabled || PrevMonthVAHLevel.Enabled || PrevMonthVALLevel.Enabled || PrevMonthHVNEnabled || PrevMonthLVNEnabled;
     }
 
     private bool NeedsContractData()
     {
         return ContractOpenLevel.Enabled || ContractHighLevel.Enabled || ContractLowLevel.Enabled || ContractCloseLevel.Enabled ||
-               ContractEquilibriumLevel.Enabled || ContractPOCLevel.Enabled || ContractVWAPLevel.Enabled || ContractVAHLevel.Enabled || ContractVALLevel.Enabled || ContractHVNEnabled;
+               ContractEquilibriumLevel.Enabled || ContractPOCLevel.Enabled || ContractVWAPLevel.Enabled || ContractVAHLevel.Enabled || ContractVALLevel.Enabled || ContractHVNEnabled || ContractLVNEnabled;
     }
 
     private void UpdateLevels(FixedProfilePeriods period, IndicatorCandle candle)
     {
-        if (candle == null) return;
+        if (candle == null) 
+            return;
 
         var keys = _keys[period];
 
@@ -2039,7 +2352,7 @@ public class OHLCPlus : Indicator
                 RecalcNeedFor(period);
 
                 if (ls.Enabled && IsNeeded(period))
-                    RequestProfileForPeriod(period, force: false);
+                    RequestProfileForPeriod(period);
                 else
                     RedrawChart();
             }
@@ -2108,149 +2421,243 @@ public class OHLCPlus : Indicator
                        .Replace("{level}", levelText ?? string.Empty);
     }
 
-    private void UpdateHVNs(FixedProfilePeriods period, IndicatorCandle candle)
+    /// <summary>
+    /// Calculates BOTH bands (HVN and LVN) in a single pass over the profile for maximum efficiency.
+    /// </summary>
+    private void UpdateVolumeNodes(FixedProfilePeriods period, IndicatorCandle candle)
     {
         if (candle == null)
             return;
 
-        if (!_hvnBands.TryGetValue(period, out var bands))
+        // --- Setup HVN ---
+        if (!_hvnBands.TryGetValue(period, out var hvnBands))
         {
-            bands = new List<HVNBand>();
-            _hvnBands[period] = bands;
+            hvnBands = new List<VolumeNodeBand>();
+            _hvnBands[period] = hvnBands;
         }
         else
         {
-            bands.Clear();
+            hvnBands.Clear();
         }
 
-        var poc = candle.MaxVolumePriceInfo;
-        if (poc == null || poc.Volume <= 0)
-            return;
+        // --- Setup LVN ---
+        if (!_lvnBands.TryGetValue(period, out var lvnBands))
+        {
+            lvnBands = new List<VolumeNodeBand>();
+            _lvnBands[period] = lvnBands;
+        }
+        else
+        {
+            lvnBands.Clear();
+        }
 
-        var cutoff = poc.Volume * (HVNThresholdPct / 100m);
-
-        // Materialize and sort by ascending price
-        var levelsEnum = candle.GetAllPriceLevels();
+        // 1. Get ALL price levels FIRST.
+        var levelsEnum = candle.GetAllPriceLevels();
         if (levelsEnum == null)
             return;
 
-        var levels = levelsEnum.OrderBy(l => l.Price).ToList();
+        // 2. Materialize the list and order it by PRICE (we will need it this way for the loop)
+        var levels = levelsEnum.OrderBy(l => l.Price).ToList();
         if (levels.Count == 0)
             return;
+
+        var poc = candle.MaxVolumePriceInfo;
+
+        // 4. If it's null (because the API didn't calculate it), WE CALCULATE IT MANUALLY
+        if (poc == null)
+        {
+            // Use 'var' to avoid 'using' issues
+            var maxVolumeLevel = (dynamic)null; // Initialize as dynamic/null
+            foreach (var level in levels) // Use the 'levels' list we already have
+            {
+                if (maxVolumeLevel == null || level.Volume > maxVolumeLevel.Volume)
+                {
+                    maxVolumeLevel = level;
+                }
+            }
+            poc = maxVolumeLevel; // Assign the manually calculated POC
+        }
+        if (poc == null || poc.Volume <= 0)
+            return;
+
+        // --- Cutoffs ---
+        var hvnCutoff = poc.Volume * (HVNThresholdPct / 100m);
+        var lvnCutoff = 0m; // Initialized to 0
 
         var tick = InstrumentInfo.TickSize;
         if (tick <= 0m)
             return;
 
-        // Current run state (a "band" of contiguous HVN ticks allowing small gaps)
-        decimal? runStart = null;   // current band start (price)
-        decimal lastPriceInRun = 0; // last visited price
-        int gapLeft = 0;            // remaining tolerated gaps inside a band
+        // --- State for HVN ---
+        decimal? hvnRunStart = null;
+        decimal hvnLastPriceInRun = 0;
+        int hvnGapLeft = 0;
+
+        // --- State for LVN ---
+        decimal? lvnRunStart = null;
+        decimal lvnLastPriceInRun = 0;
+        int lvnGapLeft = 0;
+
+        // --- APPLY LVN NOISE FILTER ---
+        // Check if the profile is mature enough to calculate LVNs
+        bool lvnEnabledForPeriod = poc.Volume >= MinPocVolForLVN;
+        if (lvnEnabledForPeriod)
+        {
+            lvnCutoff = poc.Volume * (LVNThresholdPct / 100m);
+        }
+        // If not enabled, lvnCutoff remains 0, so 'isLow' (v <= 0) will always be false.
 
         bool IsNextTick(decimal prev, decimal next)
-            => Math.Abs(next - prev) <= tick * 1.0000001m; // tiny tolerance
+          => Math.Abs(next - prev) <= tick * 1.0000001m;
 
-        for (int i = 0; i < levels.Count; i++)
+        // --- SINGLE LOOP ---
+        for (int i = 0; i < levels.Count; i++)
         {
             var p = levels[i].Price;
-            var v = levels[i].Volume; // Si Volume no es decimal, castea a decimal
+            var v = levels[i].Volume;
 
-            bool isHigh = v >= cutoff;
+            bool isHigh = v >= hvnCutoff;
+            // 'isLow' is only true if:
+            // 1. The profile is mature (lvnEnabledForPeriod == true)
+            // 2. The volume is low (v <= lvnCutoff)
+            // 3. We are NOT at the exact H/L of the period
 
-            if (runStart == null)
+            // --- START: Hybrid Tail Filter Logic ---
+
+            // 1. Calculate the percentage filter in ticks (rounded down)
+            var rangeInTicks = (candle.High - candle.Low) / tick;
+            var pctFilterInTicks = (int)(rangeInTicks * (LVNTailFilter_Pct / 100m));
+
+            // 2. Use the MAXIMUM of the % filter and the Minimum Ticks filter
+            var effectiveFilterTicks = Math.Max(LVNTailFilter_MinTicks, pctFilterInTicks);
+
+            // 3. Calculate the final filter in price
+            var tailFilterAmount = effectiveFilterTicks * tick;
+
+            // --- END: Filter Logic ---
+
+            bool isLow = lvnEnabledForPeriod &&
+             (v <= lvnCutoff) &&
+             (p < (candle.High - tailFilterAmount) && p > (candle.Low + tailFilterAmount));
+
+            // ----- STATE MACHINE LOGIC FOR HVN -----
+            bool hvnContiguous = (hvnRunStart != null) && IsNextTick(hvnLastPriceInRun, p);
+
+            if (hvnRunStart == null)
             {
-                // No open band: only start when level is above cutoff
                 if (isHigh)
                 {
-                    runStart = p;
-                    lastPriceInRun = p;
-                    gapLeft = HVNGapToleranceTicks;
+                    hvnRunStart = p;
+                    hvnLastPriceInRun = p;
+                    hvnGapLeft = HVNGapToleranceTicks;
                 }
-                continue;
             }
-
-            // There is an open band: check contiguity by tick
-            bool contiguous = IsNextTick(lastPriceInRun, p);
-
-            if (!contiguous)
+            else if (!hvnContiguous)
             {
-                // We jumped several ticks -> close previous band
-                bands.Add(new HVNBand { Low = runStart.Value, High = lastPriceInRun });
-                runStart = null;
-
-
+                hvnBands.Add(new VolumeNodeBand { Low = hvnRunStart.Value, High = hvnLastPriceInRun });
+                hvnRunStart = isHigh ? p : null;
                 if (isHigh)
                 {
-                    runStart = p;
-                    lastPriceInRun = p;
-                    gapLeft = HVNGapToleranceTicks;
+                    hvnLastPriceInRun = p;
+                    hvnGapLeft = HVNGapToleranceTicks;
                 }
-                continue;
             }
-
-            // Contiguous by tick
-            if (isHigh)
+            else if (isHigh)
             {
-                lastPriceInRun = p;
-                gapLeft = HVNGapToleranceTicks; // reset tolerance when back to "high" zone
+                hvnLastPriceInRun = p;
+                hvnGapLeft = HVNGapToleranceTicks;
             }
             else
             {
-                if (gapLeft > 0)
+                if (hvnGapLeft > 0)
                 {
-                    gapLeft--;
-                    lastPriceInRun = p; // keep band continuity
+                    hvnGapLeft--;
+                    hvnLastPriceInRun = p;
                 }
                 else
                 {
-                    // Tolerance exhausted: close band at last "high" tick
-                    var end = lastPriceInRun;
-
-                    // If previous tick was low, step back one tick
-                    if (i > 0 && levels[i - 1].Volume < cutoff)
+                    var end = hvnLastPriceInRun;
+                    if (i > 0 && levels[i - 1].Volume < hvnCutoff)
                         end -= tick;
+                    if (end >= hvnRunStart.Value)
+                        hvnBands.Add(new VolumeNodeBand { Low = hvnRunStart.Value, High = end });
+                    hvnRunStart = null;
+                }
+            }
 
-                    if (end >= runStart.Value)
-                        bands.Add(new HVNBand { Low = runStart.Value, High = end });
+            // ----- STATE MACHINE LOGIC FOR LVN -----
+            bool lvnContiguous = (lvnRunStart != null) && IsNextTick(lvnLastPriceInRun, p);
 
-                    runStart = null;
-
-                    // Start a new band with this point if it's high
-                    if (isHigh)
-                    {
-                        runStart = p;
-                        lastPriceInRun = p;
-                        gapLeft = HVNGapToleranceTicks;
-                    }
+            if (lvnRunStart == null)
+            {
+                if (isLow)
+                {
+                    lvnRunStart = p;
+                    lvnLastPriceInRun = p;
+                    lvnGapLeft = LVNGapToleranceTicks;
+                }
+            }
+            else if (!lvnContiguous)
+            {
+                lvnBands.Add(new VolumeNodeBand { Low = lvnRunStart.Value, High = lvnLastPriceInRun });
+                lvnRunStart = isLow ? p : null;
+                if (isLow)
+                {
+                    lvnLastPriceInRun = p;
+                    lvnGapLeft = LVNGapToleranceTicks;
+                }
+            }
+            else if (isLow)
+            {
+                lvnLastPriceInRun = p;
+                lvnGapLeft = LVNGapToleranceTicks;
+            }
+            else
+            {
+                if (lvnGapLeft > 0)
+                {
+                    lvnGapLeft--;
+                    lvnLastPriceInRun = p;
+                }
+                else
+                {
+                    var end = lvnLastPriceInRun;
+                    if (i > 0 && levels[i - 1].Volume > lvnCutoff)
+                        end -= tick;
+                    if (end >= lvnRunStart.Value)
+                        lvnBands.Add(new VolumeNodeBand { Low = lvnRunStart.Value, High = end });
+                    lvnRunStart = null;
                 }
             }
         }
 
-        // Close trailing band if any
-        if (runStart != null && lastPriceInRun >= runStart.Value)
-            bands.Add(new HVNBand { Low = runStart.Value, High = lastPriceInRun });
+        // --- Close final bands ---
+        if (hvnRunStart != null && hvnLastPriceInRun >= hvnRunStart.Value)
+            hvnBands.Add(new VolumeNodeBand { Low = hvnRunStart.Value, High = hvnLastPriceInRun });
 
-        // Optional: filter very small bands
-        // bands.RemoveAll(b => (b.High - b.Low) < tick);
+        if (lvnRunStart != null && lvnLastPriceInRun >= lvnRunStart.Value)
+            lvnBands.Add(new VolumeNodeBand { Low = lvnRunStart.Value, High = lvnLastPriceInRun });
     }
 
-    private sealed class HVNBand
+    private sealed class VolumeNodeBand
     {
         public decimal Low { get; init; }
         public decimal High { get; init; }
     }
 
-    private void RenderAllHVNsWithPriority(RenderContext ctx)
+    private void RenderAllVolumeNodes(RenderContext ctx)
     {
         var tick = InstrumentInfo?.TickSize ?? 0m;
         if (tick <= 0) return;
 
-        // ranges already claimed by higher-priority periods (stored already expanded)
+        // The occlusion list is shared across all layers
         var claimed = new List<(decimal Lo, decimal Hi)>();
 
-        foreach (var period in _hvnPriorityOrder)
+        // --- LAYER 1: RENDER ALL HVNs (SOLID) ---
+        // (Using the priority order we defined: CurrentDay first)
+        foreach (var period in _nodePriorityOrder)
         {
-            var (enabled, color) = period switch
+            var (hvnEnabled, hvnColor) = period switch
             {
                 FixedProfilePeriods.CurrentDay => (DayHVNEnabled, DayHVNColor),
                 FixedProfilePeriods.LastDay => (PrevDayHVNEnabled, PrevDayHVNColor),
@@ -2262,27 +2669,74 @@ public class OHLCPlus : Indicator
                 _ => (false, CrossColors.Transparent)
             };
 
-            if (!enabled) continue;
-            if (!_hvnBands.TryGetValue(period, out var bands) || bands.Count == 0) continue;
-
-            foreach (var band in bands)
+            if (hvnEnabled && _hvnBands.TryGetValue(period, out var hvnBands) && hvnBands.Count > 0)
             {
-                // compute the remaining (non-occluded) parts of this band
-                var leftovers = SubtractClaimed(band, claimed, tick);
-                foreach (var piece in leftovers)
+                foreach (var band in hvnBands)
                 {
-                    RenderBand(ctx, piece, color);
-                    // claim with occlusion tolerance
-                    claimed.Add((
+                    var leftovers = SubtractClaimed(band, claimed, tick);
+                    foreach (var piece in leftovers)
+                    {
+                        RenderHVNBand(ctx, piece, hvnColor);
+                        claimed.Add((
+                          piece.Low - HVNOcclusionTicks * tick,
+                          piece.High + HVNOcclusionTicks * tick
+                        ));
+                    }
+                }
+            }
+        }
+
+        // --- LAYER 2: RENDER ALL LVNs (VOIDS) ---
+        // (The 'claimed' list already contains all HVNs)
+        foreach (var period in _nodePriorityOrder)
+        {
+            // Re-get the period color (needed for LVN)
+            var (_, hvnColor) = period switch // We only need the color
+            {
+                FixedProfilePeriods.CurrentDay => (DayHVNEnabled, DayHVNColor),
+                FixedProfilePeriods.LastDay => (PrevDayHVNEnabled, PrevDayHVNColor),
+                FixedProfilePeriods.CurrentWeek => (WeekHVNEnabled, WeekHVNColor),
+                FixedProfilePeriods.LastWeek => (PrevWeekHVNEnabled, PrevWeekHVNColor),
+                FixedProfilePeriods.CurrentMonth => (MonthHVNEnabled, MonthHVNColor),
+                FixedProfilePeriods.LastMonth => (PrevMonthHVNEnabled, PrevMonthHVNColor),
+                FixedProfilePeriods.Contract => (ContractHVNEnabled, ContractHVNColor),
+                _ => (false, CrossColors.Transparent)
+            };
+
+            var lvnEnabled = period switch
+            {
+                FixedProfilePeriods.CurrentDay => DayLVNEnabled,
+                FixedProfilePeriods.LastDay => PrevDayLVNEnabled,
+                FixedProfilePeriods.CurrentWeek => WeekLVNEnabled,
+                FixedProfilePeriods.LastWeek => PrevWeekLVNEnabled,
+                FixedProfilePeriods.CurrentMonth => MonthLVNEnabled,
+                FixedProfilePeriods.LastMonth => PrevMonthLVNEnabled,
+                FixedProfilePeriods.Contract => ContractLVNEnabled,
+                _ => false
+            };
+
+            if (lvnEnabled && _lvnBands.TryGetValue(period, out var lvnBands) && lvnBands.Count > 0)
+            {
+                foreach (var band in lvnBands)
+                {
+                    // Here's the magic: the LVN is "cut" by the already drawn HVNs
+                    var leftovers = SubtractClaimed(band, claimed, tick);
+                    foreach (var piece in leftovers)
+                    {
+                        RenderLVNBand(ctx, piece, hvnColor, LVNBorderWidth, LVNBorderStyle);
+
+                        // LVNs also claim space to occlude lower-priority LVNs
+                        claimed.Add((
                         piece.Low - HVNOcclusionTicks * tick,
                         piece.High + HVNOcclusionTicks * tick
-                    ));
+                        ));
+                    }
                 }
             }
         }
     }
 
-    private void RenderBand(RenderContext ctx, HVNBand band, CrossColor crossColor)
+    private void RenderHVNBand(RenderContext ctx, VolumeNodeBand band, CrossColor crossColor)
     {
         if (band.Low <= 0 || band.High <= 0) return;
 
@@ -2305,9 +2759,45 @@ public class OHLCPlus : Indicator
         ctx.FillRectangle(crossColor.Convert(), rect);
     }
 
+    private void RenderLVNBand(RenderContext ctx, VolumeNodeBand band, CrossColor color, int borderWidth, LineDashStyle borderStyle)
+    {
+        if (band.Low <= 0 || band.High <= 0) return;
+
+        var yHigh = ChartInfo.GetYByPrice(band.High, false);
+        var yLow = ChartInfo.GetYByPrice(band.Low, false);
+        var top = Math.Min(yHigh, yLow);
+        var bottom = Math.Max(yHigh, yLow);
+
+        if (bottom < 0 || top > ChartInfo.PriceChartContainer.Region.Height)
+            return;
+
+        var w = ChartInfo.PriceChartContainer.Region.Width;
+        var drawTop = Math.Max(0, top);
+        var drawBot = Math.Min(ChartInfo.PriceChartContainer.Region.Height, bottom);
+        var drawH = Math.Max(1, drawBot - drawTop + 1);
+        var rect = new System.Drawing.Rectangle(0, drawTop, w, drawH);
+
+        // --- 1. "Ghost" Fill ---
+        // We use the period's color but with a very low alpha
+        var fillColor = GhostColor(color, 20); // 20 out of 255 is ~8% opacity
+        ctx.FillRectangle(fillColor.Convert(), rect);
+
+        // --- 2. Border ---
+        // We draw the border on top of the fill.
+        // We use the original color (with its medium opacity) for the border.
+        var pen = new PenSettings
+        {
+            Color = color,
+            Width = borderWidth,
+            LineDashStyle = borderStyle
+        }.RenderObject;
+
+        ctx.DrawRectangle(pen, rect);
+    }
+
     // Split a band by subtracting previously-claimed ranges (already expanded by occlusion tolerance).
     // Returns the list of remaining sub-bands aligned to the tick grid.
-    private List<HVNBand> SubtractClaimed(HVNBand band, List<(decimal Lo, decimal Hi)> claimed, decimal tick)
+    private List<VolumeNodeBand> SubtractClaimed(VolumeNodeBand band, List<(decimal Lo, decimal Hi)> claimed, decimal tick)
     {
         // work list as simple (Lo, Hi) intervals
         var segments = new List<(decimal Lo, decimal Hi)> { (band.Low, band.High) };
@@ -2340,7 +2830,7 @@ public class OHLCPlus : Indicator
 
         return segments
             .Where(seg => seg.Hi >= seg.Lo)
-            .Select(seg => new HVNBand { Low = seg.Lo, High = seg.Hi })
+            .Select(seg => new VolumeNodeBand { Low = seg.Lo, High = seg.Hi })
             .ToList();
     }
 
@@ -2383,6 +2873,26 @@ public class OHLCPlus : Indicator
 
         style = null!;
         return false;
+    }
+
+    private CrossColor GhostColor(CrossColor color, int alpha = 40)
+    {
+        // Creates a new System.Drawing.Color with the modified Alpha
+        return System.Drawing.Color.FromArgb(alpha, color.R, color.G, color.B).Convert();
+    }
+
+    private void RefreshData()
+    {
+        RecalcAllNeeds();
+
+        // Force the request so ATAS recalculates the profile
+        // (necessary if we NOW need the POC and didn't before)
+        RequestProfiles();
+
+        // Update from cache (for already loaded profiles)
+        UpdateAllNeededLevelsFromCache();
+
+        RedrawChart();
     }
 
     #endregion

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -1374,20 +1374,18 @@ public class OHLCPlus : Indicator
     }
 
 
-// Resolve the color respecting the precedence (per-line override > scheme > per-line default)
-    private CrossColor ResolveColor(FixedProfilePeriods period, string suffix, LevelSettings ls)
+    // Resolve the color respecting the precedence (per-line override > scheme > per-line default)
+    private CrossColor ResolveColor(string storagePrefix, string suffix, LevelSettings ls)
     {
-        if (ls != null && ls.UsePerLineColor)
-            return ls.Color; // per-line override wins
-
-        switch (ColorMode) // TODO: enum you introduce for the color feature
+        switch (ColorMode)
         {
             case ColorMode.ByPeriod:
-                return ResolvePeriodPalette(period);
+                return ResolvePeriodPalette(storagePrefix);
             case ColorMode.ByLevel:
                 return ResolveLevelPalette(suffix);
+            case ColorMode.PerLineSettings:
             default:
-                return ls?.Color ?? CrossColors.White;
+                return ls?.Color ?? CrossColors.White; // color propio de la línea (comportamiento por defecto)
         }
     }
 
@@ -1396,33 +1394,31 @@ public class OHLCPlus : Indicator
         => new PenSettings { Color = color, Width = ls.Width, LineDashStyle = ls.LineStyle }.RenderObject;
 
     // Palette resolvers
-    private CrossColor ResolvePeriodPalette(FixedProfilePeriods period)
-        => period switch
-        {
-            FixedProfilePeriods.CurrentDay   => PeriodColorCurrentDay,
-            FixedProfilePeriods.LastDay      => PeriodColorPrevDay,
-            FixedProfilePeriods.CurrentWeek  => PeriodColorCurrentWeek,
-            FixedProfilePeriods.LastWeek     => PeriodColorPrevWeek,
-            FixedProfilePeriods.CurrentMonth => PeriodColorCurrentMonth,
-            FixedProfilePeriods.LastMonth    => PeriodColorPrevMonth,
-            FixedProfilePeriods.Contract     => PeriodColorContract,
-            _                                => CrossColors.White
-        };
+    private CrossColor ResolvePeriodPalette(string storagePrefix) => storagePrefix switch
+    {
+        "d" => PeriodColorCurrentDay,
+        "p" => PeriodColorPrevDay,
+        "w" => PeriodColorCurrentWeek,
+        "pw" => PeriodColorPrevWeek,
+        "m" => PeriodColorCurrentMonth,
+        "pm" => PeriodColorPrevMonth,
+        "c" => PeriodColorContract,
+        _ => CrossColors.White
+    };
 
-    private CrossColor ResolveLevelPalette(string suffix)
-        => suffix switch
-        {
-            "Open"  => LevelColorOpen,
-            "High"  => LevelColorHigh,
-            "Low"   => LevelColorLow,
-            "Close" => LevelColorClose,
-            "EQ"    => LevelColorEQ,
-            "POC"   => LevelColorPOC,
-            "VWAP"  => LevelColorVWAP,
-            "VAH"   => LevelColorVAH,
-            "VAL"   => LevelColorVAL,
-            _       => CrossColors.White
-        };
+    private CrossColor ResolveLevelPalette(string suffix) => suffix switch
+    {
+        "Open" => LevelColorOpen,
+        "High" => LevelColorHigh,
+        "Low" => LevelColorLow,
+        "Close" => LevelColorClose,
+        "EQ" => LevelColorEQ,
+        "POC" => LevelColorPOC,
+        "VWAP" => LevelColorVWAP,
+        "VAH" => LevelColorVAH,
+        "VAL" => LevelColorVAL,
+        _ => CrossColors.White
+    };
 
     private void RenderLevel(RenderContext context, string levelKey, LevelSettings levelSettings)
     {

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -233,6 +233,10 @@ public class OHLCPlus : Indicator
     private bool _needPrevMonth;
     private bool _needContract;
 
+    // Scoped display-prefix override for the current group render
+    private string? _scopedStoragePrefix = null;
+    private string? _scopedDisplayPrefix = null;
+
     #endregion
 
     #region Properties
@@ -1279,17 +1283,28 @@ public class OHLCPlus : Indicator
 
     // Maps the canonical storage prefix ("d", "p", "w", "pw", "m", "pm", "c")
     // to the user-configurable display prefix for visual labels.
-    private string DisplayPrefixFor(string storagePrefix) => storagePrefix switch
+    // NEW: respects a scoped override set by RenderLevelGroup.
+    private string DisplayPrefixFor(string storagePrefix)
     {
-        "d" => PrefixCurrentDay,
-        "p" => PrefixPrevDay,
-        "w" => PrefixCurrentWeek,
-        "pw" => PrefixPrevWeek,
-        "m" => PrefixCurrentMonth,
-        "pm" => PrefixPrevMonth,
-        "c" => PrefixContract,
-        _ => storagePrefix ?? string.Empty
-    };
+        // Scoped override: only applies while a group with this storagePrefix is rendering
+        if (!string.IsNullOrEmpty(_scopedStoragePrefix) &&
+            string.Equals(storagePrefix, _scopedStoragePrefix, StringComparison.Ordinal) &&
+            !string.IsNullOrEmpty(_scopedDisplayPrefix))
+            return _scopedDisplayPrefix!;
+
+        return storagePrefix switch
+        {
+            "d" => PrefixCurrentDay,
+            "p" => PrefixPrevDay,
+            "w" => PrefixCurrentWeek,
+            "pw" => PrefixPrevWeek,
+            "m" => PrefixCurrentMonth,
+            "pm" => PrefixPrevMonth,
+            "c" => PrefixContract,
+            _ => storagePrefix ?? string.Empty
+        };
+    }
+
 
     private void RenderLevel(RenderContext context, string levelKey, LevelSettings levelSettings)
     {
@@ -1427,22 +1442,38 @@ public class OHLCPlus : Indicator
         context.DrawString(text, _font, textColor, textRect, format);
     }
 
-    private void RenderLevelGroup(RenderContext context, string prefix,
-      LevelSettings openLevel, LevelSettings highLevel, LevelSettings lowLevel, LevelSettings closeLevel,
-      LevelSettings eqLevel, LevelSettings pocLevel, LevelSettings vwapLevel, LevelSettings vahLevel, LevelSettings valLevel)
+    private void RenderLevelGroup(RenderContext context, string storagePrefix, string displayPrefix, // NEW: user-configurable display prefix (UI)
+    LevelSettings openLevel, LevelSettings highLevel, LevelSettings lowLevel, LevelSettings closeLevel,
+    LevelSettings eqLevel, LevelSettings pocLevel, LevelSettings vwapLevel, LevelSettings vahLevel, LevelSettings valLevel)
     {
-        var keys = _keys[PeriodFromPrefix(prefix)];
-        // 0 Open, 1 High, 2 Low, 3 Close, 4 EQ, 5 POC, 6 VWAP, 7 VAH, 8 VAL
+        // Activate scoped override for this group render
+        _scopedStoragePrefix = storagePrefix;
+        _scopedDisplayPrefix = displayPrefix;
 
-        RenderLevel(context, keys[0], openLevel);
-        RenderLevel(context, keys[1], highLevel);
-        RenderLevel(context, keys[2], lowLevel);
-        RenderLevel(context, keys[3], closeLevel);
-        RenderLevel(context, keys[4], eqLevel);
-        RenderLevel(context, keys[5], pocLevel);
-        RenderLevel(context, keys[6], vwapLevel);
-        RenderLevel(context, keys[7], vahLevel);
-        RenderLevel(context, keys[8], valLevel);
+        try
+        {
+            var levels = new[]
+            {
+            ("Open", openLevel),
+            ("High", highLevel),
+            ("Low", lowLevel),
+            ("Close", closeLevel),
+            ("EQ", eqLevel),
+            ("POC", pocLevel),
+            ("VWAP", vwapLevel),
+            ("VAH", vahLevel),
+            ("VAL", valLevel)
+        };
+
+            foreach (var (suffix, levelSettings) in levels)
+                RenderLevel(context, $"{storagePrefix}{suffix}", levelSettings);
+        }
+        finally
+        {
+            // Always clear the override after finishing this group
+            _scopedStoragePrefix = null;
+            _scopedDisplayPrefix = null;
+        }
     }
 
     #endregion

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -261,6 +261,20 @@ public class OHLCPlus : Indicator
     private string? _scopedStoragePrefix = null;
     private string? _scopedDisplayPrefix = null;
 
+    // HVN prices by period
+    private readonly Dictionary<FixedProfilePeriods, List<HVNBand>> _hvnBands = new();
+
+    private static readonly FixedProfilePeriods[] _hvnPriorityOrder = new[]
+    {
+    FixedProfilePeriods.Contract,
+    FixedProfilePeriods.LastMonth,
+    FixedProfilePeriods.CurrentMonth,
+    FixedProfilePeriods.LastWeek,
+    FixedProfilePeriods.CurrentWeek,
+    FixedProfilePeriods.LastDay,
+    FixedProfilePeriods.CurrentDay
+    };
+
     #endregion
 
     #region Properties

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -1032,53 +1032,53 @@ public class OHLCPlus : Indicator
 
     // --- Palette by PERIOD (used when ColorMode == ByPeriod)
     [Display(GroupName = "Colors — By Period", Name = "Current Day", Order = 10)]
-    public CrossColor PeriodColorCurrentDay { get; set; } = System.Drawing.Color.Orange.Convert();
+    public CrossColor PeriodColorCurrentDay { get; set; } = System.Drawing.Color.OrangeRed.Convert();
 
     [Display(GroupName = "Colors — By Period", Name = "Previous Day", Order = 11)]
-    public CrossColor PeriodColorPrevDay { get; set; } = System.Drawing.Color.Gray.Convert();
+    public CrossColor PeriodColorPrevDay { get; set; } = System.Drawing.Color.SaddleBrown.Convert();
 
     [Display(GroupName = "Colors — By Period", Name = "Current Week", Order = 12)]
-    public CrossColor PeriodColorCurrentWeek { get; set; } = System.Drawing.Color.SteelBlue.Convert();
+    public CrossColor PeriodColorCurrentWeek { get; set; } = System.Drawing.Color.DeepSkyBlue.Convert();
 
     [Display(GroupName = "Colors — By Period", Name = "Previous Week", Order = 13)]
-    public CrossColor PeriodColorPrevWeek { get; set; } = System.Drawing.Color.MediumPurple.Convert();
+    public CrossColor PeriodColorPrevWeek { get; set; } = System.Drawing.Color.DarkSlateBlue.Convert();
 
     [Display(GroupName = "Colors — By Period", Name = "Current Month", Order = 14)]
-    public CrossColor PeriodColorCurrentMonth { get; set; } = System.Drawing.Color.Teal.Convert();
+    public CrossColor PeriodColorCurrentMonth { get; set; } = System.Drawing.Color.MediumSeaGreen.Convert();
 
     [Display(GroupName = "Colors — By Period", Name = "Previous Month", Order = 15)]
-    public CrossColor PeriodColorPrevMonth { get; set; } = System.Drawing.Color.DarkSlateGray.Convert();
+    public CrossColor PeriodColorPrevMonth { get; set; } = System.Drawing.Color.DarkOliveGreen.Convert();
 
     [Display(GroupName = "Colors — By Period", Name = "Contract", Order = 16)]
-    public CrossColor PeriodColorContract { get; set; } = System.Drawing.Color.DodgerBlue.Convert();
+    public CrossColor PeriodColorContract { get; set; } = System.Drawing.Color.Indigo.Convert();
 
     // --- Palette by LEVEL TYPE (used when ColorMode == ByLevel)
     [Display(GroupName = "Colors — By Level", Name = "Open", Order = 110)]
-    public CrossColor LevelColorOpen { get; set; } = System.Drawing.Color.Orange.Convert();
+    public CrossColor LevelColorOpen { get; set; } = System.Drawing.Color.DarkGoldenrod.Convert();
 
     [Display(GroupName = "Colors — By Level", Name = "High", Order = 120)]
-    public CrossColor LevelColorHigh { get; set; } = System.Drawing.Color.Green.Convert();
+    public CrossColor LevelColorHigh { get; set; } = System.Drawing.Color.ForestGreen.Convert();
 
     [Display(GroupName = "Colors — By Level", Name = "Low", Order = 130)]
-    public CrossColor LevelColorLow { get; set; } = System.Drawing.Color.Red.Convert();
+    public CrossColor LevelColorLow { get; set; } = System.Drawing.Color.Firebrick.Convert();
 
     [Display(GroupName = "Colors — By Level", Name = "Close", Order = 140)]
-    public CrossColor LevelColorClose { get; set; } = System.Drawing.Color.Gray.Convert();
+    public CrossColor LevelColorClose { get; set; } = System.Drawing.Color.DimGray.Convert();
 
     [Display(GroupName = "Colors — By Level", Name = "Equilibrium (EQ)", Order = 150)]
-    public CrossColor LevelColorEQ { get; set; } = System.Drawing.Color.Yellow.Convert();
+    public CrossColor LevelColorEQ { get; set; } = System.Drawing.Color.DarkKhaki.Convert();
 
     [Display(GroupName = "Colors — By Level", Name = "POC", Order = 160)]
-    public CrossColor LevelColorPOC { get; set; } = System.Drawing.Color.Orange.Convert();
+    public CrossColor LevelColorPOC { get; set; } = System.Drawing.Color.OrangeRed.Convert();
 
     [Display(GroupName = "Colors — By Level", Name = "VWAP", Order = 170)]
-    public CrossColor LevelColorVWAP { get; set; } = System.Drawing.Color.SteelBlue.Convert();
+    public CrossColor LevelColorVWAP { get; set; } = System.Drawing.Color.DodgerBlue.Convert();
 
     [Display(GroupName = "Colors — By Level", Name = "VAH", Order = 180)]
-    public CrossColor LevelColorVAH { get; set; } = System.Drawing.Color.Purple.Convert();
+    public CrossColor LevelColorVAH { get; set; } = System.Drawing.Color.CornflowerBlue.Convert();
 
     [Display(GroupName = "Colors — By Level", Name = "VAL", Order = 190)]
-    public CrossColor LevelColorVAL { get; set; } = System.Drawing.Color.Purple.Convert();
+    public CrossColor LevelColorVAL { get; set; } = System.Drawing.Color.RoyalBlue.Convert();
     #endregion
 
     #endregion

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -11,6 +11,7 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Drawing;
 using System.Runtime.CompilerServices;
+using System.Linq;
 
 public enum LabelPosition
 {
@@ -365,6 +366,12 @@ public class OHLCPlus : Indicator
         lineType: LineType.Bar
     );
 
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentDay), Name = "Enable HVN", Order = 90)]
+    public bool DayHVNEnabled { get; set; } = false;
+
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentDay), Name = "HVN Color", Order = 95)]
+    public CrossColor DayHVNColor { get; set; } = System.Drawing.Color.FromArgb(140, 30, 144, 255).Convert(); // semi-transparent blue/violet
+
     #endregion
 
     #region Prev.Day Settings
@@ -467,6 +474,12 @@ public class OHLCPlus : Indicator
         labelPosition: LabelPosition.Bar,
         lineType: LineType.Bar
     );
+
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousDay), Name = "Enable HVN", Order = 90)]
+    public bool PrevDayHVNEnabled { get; set; } = false;
+
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousDay), Name = "HVN Color", Order = 95)]
+    public CrossColor PrevDayHVNColor { get; set; } = System.Drawing.Color.FromArgb(140, 255, 140, 0).Convert(); // semi-transparent amber.
 
     #endregion
 
@@ -571,6 +584,11 @@ public class OHLCPlus : Indicator
         lineType: LineType.Bar
     );
 
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentWeek), Name = "Enable HVN", Order = 90)]
+    public bool WeekHVNEnabled { get; set; } = false;
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentWeek), Name = "HVN Color", Order = 95)]
+    public CrossColor WeekHVNColor { get; set; } = System.Drawing.Color.FromArgb(140, 70, 130, 180).Convert(); // steel-ish
+
     #endregion
 
     #region Prev.Week Settings
@@ -673,6 +691,11 @@ public class OHLCPlus : Indicator
         labelPosition: LabelPosition.Bar,
         lineType: LineType.Bar
     );
+
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousWeek), Name = "Enable HVN", Order = 90)]
+    public bool PrevWeekHVNEnabled { get; set; } = false;
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousWeek), Name = "HVN Color", Order = 95)]
+    public CrossColor PrevWeekHVNColor { get; set; } = System.Drawing.Color.FromArgb(140, 186, 85, 211).Convert(); // mediumPurple
 
     #endregion
 
@@ -777,6 +800,11 @@ public class OHLCPlus : Indicator
         lineType: LineType.Bar
     );
 
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentMonth), Name = "Enable HVN", Order = 90)]
+    public bool MonthHVNEnabled { get; set; } = false;
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.CurrentMonth), Name = "HVN Color", Order = 95)]
+    public CrossColor MonthHVNColor { get; set; } = System.Drawing.Color.FromArgb(140, 0, 128, 128).Convert(); // teal
+
     #endregion
 
     #region Prev.Month Settings
@@ -880,6 +908,11 @@ public class OHLCPlus : Indicator
         lineType: LineType.Bar
     );
 
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousMonth), Name = "Enable HVN", Order = 90)]
+    public bool PrevMonthHVNEnabled { get; set; } = false;
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.PreviousMonth), Name = "HVN Color", Order = 95)]
+    public CrossColor PrevMonthHVNColor { get; set; } = System.Drawing.Color.FromArgb(140, 47, 79, 79).Convert(); // darkslategray
+
     #endregion
 
     #region Contract Settings
@@ -982,6 +1015,27 @@ public class OHLCPlus : Indicator
         labelPosition: LabelPosition.Bar,
         lineType: LineType.Bar
     );
+
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Contract), Name = "Enable HVN", Order = 90)]
+    public bool ContractHVNEnabled { get; set; } = false;
+    [Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Contract), Name = "HVN Color", Order = 95)]
+    public CrossColor ContractHVNColor { get; set; } = System.Drawing.Color.FromArgb(140, 30, 144, 255).Convert(); // dodgerblue
+
+    #endregion
+
+    #region HVN Settings
+    [Display(GroupName = "HVN Settings", Name = "Threshold (% of POC volume)", Order = 10)]
+    [Range(1, 99)]
+    public int HVNThresholdPct { get; set; } = 80;
+
+    [Display(GroupName = "HVN Settings", Name = "Gap tolerance (ticks)", Order = 20)]
+    [Range(0, 10)]
+    public int HVNGapToleranceTicks { get; set; } = 1;
+
+    // Overlap tolerance in ticks: if a price falls within ±N ticks of another already drawn, it is hidden.
+    [Display(GroupName = "HVN Settings", Name = "Occlusion tolerance (ticks)", Order = 30)]
+    [Range(0, 10)]
+    public int HVNOcclusionTicks { get; set; } = 1;
 
     #endregion
 
@@ -1209,6 +1263,7 @@ public class OHLCPlus : Indicator
     {
         _profileCandles[period] = fixedProfileOriginScale;
         UpdateLevels(period, fixedProfileOriginScale);
+        UpdateHVNs(period, fixedProfileOriginScale);
         RedrawChart();
     }
 
@@ -1225,6 +1280,9 @@ public class OHLCPlus : Indicator
         RenderLevelGroup(context, storagePrefix: "m", displayPrefix: PrefixCurrentMonth, MonthOpenLevel, MonthHighLevel, MonthLowLevel, MonthCloseLevel, MonthEquilibriumLevel, MonthPOCLevel, MonthVWAPLevel, MonthVAHLevel, MonthVALLevel);
         RenderLevelGroup(context, storagePrefix: "pm", displayPrefix: PrefixPrevMonth, PrevMonthOpenLevel, PrevMonthHighLevel, PrevMonthLowLevel, PrevMonthCloseLevel, PrevMonthEquilibriumLevel, PrevMonthPOCLevel, PrevMonthVWAPLevel, PrevMonthVAHLevel, PrevMonthVALLevel);
         RenderLevelGroup(context, storagePrefix: "c", displayPrefix: PrefixContract, ContractOpenLevel, ContractHighLevel, ContractLowLevel, ContractCloseLevel, ContractEquilibriumLevel, ContractPOCLevel, ContractVWAPLevel, ContractVAHLevel, ContractVALLevel);
+
+        // HVN rects
+        RenderAllHVNsWithPriority(context);
     }
 
     #endregion
@@ -1316,43 +1374,43 @@ public class OHLCPlus : Indicator
     private bool NeedsDayData()
     {
         return DayOpenLevel.Enabled || DayHighLevel.Enabled || DayLowLevel.Enabled || DayCloseLevel.Enabled ||
-               DayEquilibriumLevel.Enabled || DayPOCLevel.Enabled || DayVWAPLevel.Enabled || DayVAHLevel.Enabled || DayVALLevel.Enabled;
+               DayEquilibriumLevel.Enabled || DayPOCLevel.Enabled || DayVWAPLevel.Enabled || DayVAHLevel.Enabled || DayVALLevel.Enabled || DayHVNEnabled;
     }
 
     private bool NeedsPrevDayData()
     {
         return PrevDayOpenLevel.Enabled || PrevDayHighLevel.Enabled || PrevDayLowLevel.Enabled || PrevDayCloseLevel.Enabled ||
-               PrevDayEquilibriumLevel.Enabled || PrevDayPOCLevel.Enabled || PrevDayVWAPLevel.Enabled || PrevDayVAHLevel.Enabled || PrevDayVALLevel.Enabled;
+               PrevDayEquilibriumLevel.Enabled || PrevDayPOCLevel.Enabled || PrevDayVWAPLevel.Enabled || PrevDayVAHLevel.Enabled || PrevDayVALLevel.Enabled || PrevDayHVNEnabled;
     }
 
     private bool NeedsWeekData()
     {
         return WeekOpenLevel.Enabled || WeekHighLevel.Enabled || WeekLowLevel.Enabled || WeekCloseLevel.Enabled ||
-               WeekEquilibriumLevel.Enabled || WeekPOCLevel.Enabled || WeekVWAPLevel.Enabled || WeekVAHLevel.Enabled || WeekVALLevel.Enabled;
+               WeekEquilibriumLevel.Enabled || WeekPOCLevel.Enabled || WeekVWAPLevel.Enabled || WeekVAHLevel.Enabled || WeekVALLevel.Enabled || WeekHVNEnabled;
     }
 
     private bool NeedsPrevWeekData()
     {
         return PrevWeekOpenLevel.Enabled || PrevWeekHighLevel.Enabled || PrevWeekLowLevel.Enabled || PrevWeekCloseLevel.Enabled ||
-               PrevWeekEquilibriumLevel.Enabled || PrevWeekPOCLevel.Enabled || PrevWeekVWAPLevel.Enabled || PrevWeekVAHLevel.Enabled || PrevWeekVALLevel.Enabled;
+               PrevWeekEquilibriumLevel.Enabled || PrevWeekPOCLevel.Enabled || PrevWeekVWAPLevel.Enabled || PrevWeekVAHLevel.Enabled || PrevWeekVALLevel.Enabled || PrevWeekHVNEnabled;
     }
 
     private bool NeedsMonthData()
     {
         return MonthOpenLevel.Enabled || MonthHighLevel.Enabled || MonthLowLevel.Enabled || MonthCloseLevel.Enabled ||
-               MonthEquilibriumLevel.Enabled || MonthPOCLevel.Enabled || MonthVWAPLevel.Enabled || MonthVAHLevel.Enabled || MonthVALLevel.Enabled;
+               MonthEquilibriumLevel.Enabled || MonthPOCLevel.Enabled || MonthVWAPLevel.Enabled || MonthVAHLevel.Enabled || MonthVALLevel.Enabled || MonthHVNEnabled;
     }
 
     private bool NeedsPrevMonthData()
     {
         return PrevMonthOpenLevel.Enabled || PrevMonthHighLevel.Enabled || PrevMonthLowLevel.Enabled || PrevMonthCloseLevel.Enabled ||
-               PrevMonthEquilibriumLevel.Enabled || PrevMonthPOCLevel.Enabled || PrevMonthVWAPLevel.Enabled || PrevMonthVAHLevel.Enabled || PrevMonthVALLevel.Enabled;
+               PrevMonthEquilibriumLevel.Enabled || PrevMonthPOCLevel.Enabled || PrevMonthVWAPLevel.Enabled || PrevMonthVAHLevel.Enabled || PrevMonthVALLevel.Enabled || PrevMonthHVNEnabled;
     }
 
     private bool NeedsContractData()
     {
         return ContractOpenLevel.Enabled || ContractHighLevel.Enabled || ContractLowLevel.Enabled || ContractCloseLevel.Enabled ||
-               ContractEquilibriumLevel.Enabled || ContractPOCLevel.Enabled || ContractVWAPLevel.Enabled || ContractVAHLevel.Enabled || ContractVALLevel.Enabled;
+               ContractEquilibriumLevel.Enabled || ContractPOCLevel.Enabled || ContractVWAPLevel.Enabled || ContractVAHLevel.Enabled || ContractVALLevel.Enabled || ContractHVNEnabled;
     }
 
     private void UpdateLevels(FixedProfilePeriods period, IndicatorCandle candle)
@@ -1797,7 +1855,244 @@ public class OHLCPlus : Indicator
                        .Replace("{level}", levelText ?? string.Empty);
     }
 
+    private void UpdateHVNs(FixedProfilePeriods period, IndicatorCandle candle)
+    {
+        if (candle == null)
+            return;
+
+        if (!_hvnBands.TryGetValue(period, out var bands))
+        {
+            bands = new List<HVNBand>();
+            _hvnBands[period] = bands;
+        }
+        else
+        {
+            bands.Clear();
+        }
+
+        var poc = candle.MaxVolumePriceInfo;
+        if (poc == null || poc.Volume <= 0)
+            return;
+
+        var cutoff = poc.Volume * (HVNThresholdPct / 100m);
+
+        // Materialize and sort by ascending price
+        var levelsEnum = candle.GetAllPriceLevels();
+        if (levelsEnum == null)
+            return;
+
+        var levels = levelsEnum.OrderBy(l => l.Price).ToList();
+        if (levels.Count == 0)
+            return;
+
+        var tick = InstrumentInfo.TickSize;
+        if (tick <= 0m)
+            return;
+
+        // Current run state (a "band" of contiguous HVN ticks allowing small gaps)
+        decimal? runStart = null;   // current band start (price)
+        decimal lastPriceInRun = 0; // last visited price
+        int gapLeft = 0;            // remaining tolerated gaps inside a band
+
+        bool IsNextTick(decimal prev, decimal next)
+            => Math.Abs(next - prev) <= tick * 1.0000001m; // tiny tolerance
+
+        for (int i = 0; i < levels.Count; i++)
+        {
+            var p = levels[i].Price;
+            var v = levels[i].Volume; // Si Volume no es decimal, castea a decimal
+
+            bool isHigh = v >= cutoff;
+
+            if (runStart == null)
+            {
+                // No open band: only start when level is above cutoff
+                if (isHigh)
+                {
+                    runStart = p;
+                    lastPriceInRun = p;
+                    gapLeft = HVNGapToleranceTicks;
+                }
+                continue;
+            }
+
+            // There is an open band: check contiguity by tick
+            bool contiguous = IsNextTick(lastPriceInRun, p);
+
+            if (!contiguous)
+            {
+                // We jumped several ticks -> close previous band
+                bands.Add(new HVNBand { Low = runStart.Value, High = lastPriceInRun });
+                runStart = null;
+
+                
+                if (isHigh)
+                {
+                    runStart = p;
+                    lastPriceInRun = p;
+                    gapLeft = HVNGapToleranceTicks; 
+                }
+                continue;
+            }
+
+            // Contiguous by tick
+            if (isHigh)
+            {
+                lastPriceInRun = p;
+                gapLeft = HVNGapToleranceTicks; // reset tolerance when back to "high" zone
+            }
+            else
+            {
+                if (gapLeft > 0)
+                {
+                    gapLeft--;
+                    lastPriceInRun = p; // keep band continuity
+                }
+                else
+                {
+                    // Tolerance exhausted: close band at last "high" tick
+                    var end = lastPriceInRun;
+
+                    // If previous tick was low, step back one tick
+                    if (i > 0 && levels[i - 1].Volume < cutoff)
+                        end -= tick;
+
+                    if (end >= runStart.Value)
+                        bands.Add(new HVNBand { Low = runStart.Value, High = end });
+
+                    runStart = null;
+
+                    // Start a new band with this point if it's high
+                    if (isHigh)
+                    {
+                        runStart = p;
+                        lastPriceInRun = p;
+                        gapLeft = HVNGapToleranceTicks;
+                    }
+                }
+            }
+        }
+
+        // Close trailing band if any
+        if (runStart != null && lastPriceInRun >= runStart.Value)
+            bands.Add(new HVNBand { Low = runStart.Value, High = lastPriceInRun });
+
+        // Optional: filter very small bands
+        // bands.RemoveAll(b => (b.High - b.Low) < tick);
+    }
+
+    private sealed class HVNBand
+    {
+        public decimal Low { get; init; }  
+        public decimal High { get; init; }
+    }
+
+    private void RenderAllHVNsWithPriority(RenderContext ctx)
+    {
+        var tick = InstrumentInfo?.TickSize ?? 0m;
+        if (tick <= 0) return;
+
+        // ranges already claimed by higher-priority periods (stored already expanded)
+        var claimed = new List<(decimal Lo, decimal Hi)>();
+
+        foreach (var period in _hvnPriorityOrder)
+        {
+            var (enabled, color) = period switch
+            {
+                FixedProfilePeriods.CurrentDay => (DayHVNEnabled, DayHVNColor),
+                FixedProfilePeriods.LastDay => (PrevDayHVNEnabled, PrevDayHVNColor),
+                FixedProfilePeriods.CurrentWeek => (WeekHVNEnabled, WeekHVNColor),
+                FixedProfilePeriods.LastWeek => (PrevWeekHVNEnabled, PrevWeekHVNColor),
+                FixedProfilePeriods.CurrentMonth => (MonthHVNEnabled, MonthHVNColor),
+                FixedProfilePeriods.LastMonth => (PrevMonthHVNEnabled, PrevMonthHVNColor),
+                FixedProfilePeriods.Contract => (ContractHVNEnabled, ContractHVNColor),
+                _ => (false, CrossColors.Transparent)
+            };
+
+            if (!enabled) continue;
+            if (!_hvnBands.TryGetValue(period, out var bands) || bands.Count == 0) continue;
+
+            foreach (var band in bands)
+            {
+                // compute the remaining (non-occluded) parts of this band
+                var leftovers = SubtractClaimed(band, claimed, tick);
+                foreach (var piece in leftovers)
+                {
+                    RenderBand(ctx, piece, color);
+                    // claim with occlusion tolerance
+                    claimed.Add((
+                        piece.Low - HVNOcclusionTicks * tick,
+                        piece.High + HVNOcclusionTicks * tick
+                    ));
+                }
+            }
+        }
+    }
+
+    private void RenderBand(RenderContext ctx, HVNBand band, CrossColor crossColor)
+    {
+        if (band.Low <= 0 || band.High <= 0) return;
+
+        var yHigh = ChartInfo.GetYByPrice(band.High, false);
+        var yLow = ChartInfo.GetYByPrice(band.Low, false);
+
+        var top = Math.Min(yHigh, yLow);
+        var bottom = Math.Max(yHigh, yLow);
+
+        // Only if visible
+        if (bottom < 0 || top > ChartInfo.PriceChartContainer.Region.Height)
+            return;
+
+        var w = ChartInfo.PriceChartContainer.Region.Width;
+        var drawTop = Math.Max(0, top);
+        var drawBot = Math.Min(ChartInfo.PriceChartContainer.Region.Height, bottom);
+        var drawH = Math.Max(1, drawBot - drawTop + 1);
+
+        var rect = new System.Drawing.Rectangle(0, drawTop, w, drawH);
+        ctx.FillRectangle(crossColor.Convert(), rect);
+    }
+
+    // Split a band by subtracting previously-claimed ranges (already expanded by occlusion tolerance).
+    // Returns the list of remaining sub-bands aligned to the tick grid.
+    private List<HVNBand> SubtractClaimed(HVNBand band, List<(decimal Lo, decimal Hi)> claimed, decimal tick)
+    {
+        // work list as simple (Lo, Hi) intervals
+        var segments = new List<(decimal Lo, decimal Hi)> { (band.Low, band.High) };
+
+        foreach (var r in claimed)
+        {
+            var next = new List<(decimal Lo, decimal Hi)>();
+
+            foreach (var s in segments)
+            {
+                // no overlap
+                if (r.Hi < s.Lo || r.Lo > s.Hi)
+                {
+                    next.Add(s);
+                    continue;
+                }
+
     #endregion
+                // overlap -> split into left/right remainders (if any), keeping tick alignment
+                if (r.Lo > s.Lo)
+                    next.Add((s.Lo, Math.Min(s.Hi, r.Lo - tick)));
+
+                if (r.Hi < s.Hi)
+                    next.Add((Math.Max(s.Lo, r.Hi + tick), s.Hi));
+            }
+
+            segments = next;
+            if (segments.Count == 0)
+                break;
+        }
+
+        return segments
+            .Where(seg => seg.Hi >= seg.Lo)
+            .Select(seg => new HVNBand { Low = seg.Lo, High = seg.Hi })
+            .ToList();
+    }
+
+
 
     #endregion
 }

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -1,4 +1,4 @@
-namespace ATAS.Indicators.Technical;
+ï»¿namespace ATAS.Indicators.Technical;
 
 using OFT.Localization;
 using OFT.Rendering.Context;
@@ -145,6 +145,16 @@ public class LevelSettings : NotifiableObject
         set => SetField(ref _overrideLabel, value);
     }
 
+    private bool _overrideColorInSchemes;
+
+    [Display(GroupName = "Colors", Name = "Override color in scheme modes")]
+    [Description("If enabled, this line will use its own Color even when ColorMode is ByPeriod or ByLevel.")]
+    public bool OverrideColorInSchemes
+    {
+        get => _overrideColorInSchemes;
+        set => SetField(ref _overrideColorInSchemes, value);
+    }
+
     [Browsable(false)]
     public RenderPen RenderPen => new PenSettings { Color = Color, Width = Width, LineDashStyle = LineStyle }.RenderObject;
 
@@ -170,6 +180,7 @@ public class LevelSettings : NotifiableObject
         ShowPrice = showPrice;
         LabelPosition = labelPosition;
         LineType = lineType;
+        OverrideColorInSchemes = false;
     }
 
     #endregion
@@ -1031,53 +1042,53 @@ public class OHLCPlus : Indicator
     public ColorMode ColorMode { get; set; } = ColorMode.PerLineSettings;
 
     // --- Palette by PERIOD (used when ColorMode == ByPeriod)
-    [Display(GroupName = "Colors — By Period", Name = "Current Day", Order = 10)]
+    [Display(GroupName = "Colors â€” By Period", Name = "Current Day", Order = 10)]
     public CrossColor PeriodColorCurrentDay { get; set; } = System.Drawing.Color.OrangeRed.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Previous Day", Order = 11)]
+    [Display(GroupName = "Colors â€” By Period", Name = "Previous Day", Order = 11)]
     public CrossColor PeriodColorPrevDay { get; set; } = System.Drawing.Color.SaddleBrown.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Current Week", Order = 12)]
+    [Display(GroupName = "Colors â€” By Period", Name = "Current Week", Order = 12)]
     public CrossColor PeriodColorCurrentWeek { get; set; } = System.Drawing.Color.DeepSkyBlue.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Previous Week", Order = 13)]
+    [Display(GroupName = "Colors â€” By Period", Name = "Previous Week", Order = 13)]
     public CrossColor PeriodColorPrevWeek { get; set; } = System.Drawing.Color.DarkSlateBlue.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Current Month", Order = 14)]
+    [Display(GroupName = "Colors â€” By Period", Name = "Current Month", Order = 14)]
     public CrossColor PeriodColorCurrentMonth { get; set; } = System.Drawing.Color.MediumSeaGreen.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Previous Month", Order = 15)]
+    [Display(GroupName = "Colors â€” By Period", Name = "Previous Month", Order = 15)]
     public CrossColor PeriodColorPrevMonth { get; set; } = System.Drawing.Color.DarkOliveGreen.Convert();
 
-    [Display(GroupName = "Colors — By Period", Name = "Contract", Order = 16)]
+    [Display(GroupName = "Colors â€” By Period", Name = "Contract", Order = 16)]
     public CrossColor PeriodColorContract { get; set; } = System.Drawing.Color.Indigo.Convert();
 
     // --- Palette by LEVEL TYPE (used when ColorMode == ByLevel)
-    [Display(GroupName = "Colors — By Level", Name = "Open", Order = 110)]
+    [Display(GroupName = "Colors â€” By Level", Name = "Open", Order = 110)]
     public CrossColor LevelColorOpen { get; set; } = System.Drawing.Color.DarkGoldenrod.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "High", Order = 120)]
+    [Display(GroupName = "Colors â€” By Level", Name = "High", Order = 120)]
     public CrossColor LevelColorHigh { get; set; } = System.Drawing.Color.ForestGreen.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "Low", Order = 130)]
+    [Display(GroupName = "Colors â€” By Level", Name = "Low", Order = 130)]
     public CrossColor LevelColorLow { get; set; } = System.Drawing.Color.Firebrick.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "Close", Order = 140)]
+    [Display(GroupName = "Colors â€” By Level", Name = "Close", Order = 140)]
     public CrossColor LevelColorClose { get; set; } = System.Drawing.Color.DimGray.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "Equilibrium (EQ)", Order = 150)]
+    [Display(GroupName = "Colors â€” By Level", Name = "Equilibrium (EQ)", Order = 150)]
     public CrossColor LevelColorEQ { get; set; } = System.Drawing.Color.DarkKhaki.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "POC", Order = 160)]
+    [Display(GroupName = "Colors â€” By Level", Name = "POC", Order = 160)]
     public CrossColor LevelColorPOC { get; set; } = System.Drawing.Color.OrangeRed.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "VWAP", Order = 170)]
+    [Display(GroupName = "Colors â€” By Level", Name = "VWAP", Order = 170)]
     public CrossColor LevelColorVWAP { get; set; } = System.Drawing.Color.DodgerBlue.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "VAH", Order = 180)]
+    [Display(GroupName = "Colors â€” By Level", Name = "VAH", Order = 180)]
     public CrossColor LevelColorVAH { get; set; } = System.Drawing.Color.CornflowerBlue.Convert();
 
-    [Display(GroupName = "Colors — By Level", Name = "VAL", Order = 190)]
+    [Display(GroupName = "Colors â€” By Level", Name = "VAL", Order = 190)]
     public CrossColor LevelColorVAL { get; set; } = System.Drawing.Color.RoyalBlue.Convert();
     #endregion
 
@@ -1377,6 +1388,11 @@ public class OHLCPlus : Indicator
     // Resolve the color respecting the precedence (per-line override > scheme > per-line default)
     private CrossColor ResolveColor(string storagePrefix, string suffix, LevelSettings ls)
     {
+        // 1) Per-line hard override
+        if (ls?.OverrideColorInSchemes == true)
+            return ls.Color;
+
+        // 2) Scheme color (when active)
         switch (ColorMode)
         {
             case ColorMode.ByPeriod:
@@ -1385,7 +1401,7 @@ public class OHLCPlus : Indicator
                 return ResolveLevelPalette(suffix);
             case ColorMode.PerLineSettings:
             default:
-                return ls?.Color ?? CrossColors.White; // color propio de la línea (comportamiento por defecto)
+                return ls?.Color ?? CrossColors.White; // line's own color (default behavior)
         }
     }
 
@@ -1663,6 +1679,18 @@ public class OHLCPlus : Indicator
                     RedrawChart();
             }
         }
+
+        // Visual-only changes â†’ redraw
+        if (e.PropertyName == nameof(LevelSettings.Color)
+            || e.PropertyName == nameof(LevelSettings.OverrideColorInSchemes)
+            || e.PropertyName == nameof(LevelSettings.LineStyle)
+            || e.PropertyName == nameof(LevelSettings.Width)
+            || e.PropertyName == nameof(LevelSettings.LabelPosition)
+            || e.PropertyName == nameof(LevelSettings.ShowPrice)
+            || e.PropertyName == nameof(LevelSettings.OverrideLabel))
+        {
+            RedrawChart();
+        }
     }
 
     private bool IsNeeded(FixedProfilePeriods period)
@@ -1682,7 +1710,7 @@ public class OHLCPlus : Indicator
 
     private static (string Prefix, string Suffix) SplitKey(string key)
     {
-        // Sufijos conocidos ordenados por longitud para evitar colisiones
+        // Known suffixes ordered by length to avoid collisions
         foreach (var s in new[] { "Close", "Open", "High", "Low", "VWAP", "POC", "VAH", "VAL", "EQ" })
             if (key.EndsWith(s, StringComparison.Ordinal))
                 return (key.Substring(0, key.Length - s.Length), s);

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -158,6 +158,23 @@ public class LevelSettings : NotifiableObject
         set => SetField(ref _overrideColorInSchemes, value);
     }
 
+    private bool _overrideWidthInSchemes;
+    
+    [Display(GroupName = "Colors", Name = "Override width in scheme modes")]
+    public bool OverrideWidthInSchemes
+    {
+        get => _overrideWidthInSchemes;
+        set => SetField(ref _overrideWidthInSchemes, value);
+    }
+
+    private bool _overrideStyleInSchemes;
+    [Display(GroupName = "Colors", Name = "Override line style in scheme modes")]
+    public bool OverrideStyleInSchemes
+    {
+        get => _overrideStyleInSchemes;
+        set => SetField(ref _overrideStyleInSchemes, value);
+    }
+
     [Browsable(false)]
     public RenderPen RenderPen => new PenSettings { Color = Color, Width = Width, LineDashStyle = LineStyle }.RenderObject;
 
@@ -1242,16 +1259,6 @@ public class OHLCPlus : Indicator
 
     [Display(GroupName = "Colors - By Level", Name = "VAL", Order = 190)]
     public CrossColor LevelColorVAL { get; set; } = System.Drawing.Color.Purple.Convert();
-
-    [Display(GroupName = "Colors - Semantic", Name = "Override Color", Order = 210)]
-    public bool SemanticOverrideColor { get; set; } = true;
-
-    [Display(GroupName = "Colors - Semantic", Name = "Override Width", Order = 220)]
-    public bool SemanticOverrideWidth { get; set; } = true;
-
-    [Display(GroupName = "Colors - Semantic", Name = "Override Line Style", Order = 230)]
-    public bool SemanticOverrideStyle { get; set; } = true;
-
     #endregion
 
     #endregion
@@ -1629,13 +1636,27 @@ public class OHLCPlus : Indicator
 
         if (ColorMode == ColorMode.SemanticMatrix && TryGetSemanticStyle(prefix, suffix, out var vs))
         {
-            // Use semantic style (override width & dash too)
-            color = vs.Color;
-            renderPen = new PenSettings { Color = color, Width = vs.Width, LineDashStyle = vs.Style }.RenderObject;
+            // Color: per-line override > semantic matrix
+            var effColor = levelSettings.OverrideColorInSchemes
+                ? levelSettings.Color
+                : vs.Color;
+
+            // Width: per-line override > semantic matrix
+            var effWidth = levelSettings.OverrideWidthInSchemes
+                ? levelSettings.Width
+                : vs.Width;
+
+            // Style: per-line override > semantic matrix
+            var effStyle = levelSettings.OverrideStyleInSchemes
+                ? levelSettings.LineStyle
+                : vs.Style;
+
+            color = effColor;
+            renderPen = new PenSettings { Color = effColor, Width = effWidth, LineDashStyle = effStyle }.RenderObject;
         }
         else
         {
-            // Fallback to existing modes (PerLineSettings / ByPeriod / ByLevel)
+            // Existing modes: PerLineSettings / ByPeriod / ByLevel
             color = ResolveColor(prefix, suffix, levelSettings);
             renderPen = BuildPen(levelSettings, color);
         }
@@ -1866,7 +1887,9 @@ public class OHLCPlus : Indicator
             || e.PropertyName == nameof(LevelSettings.Width)
             || e.PropertyName == nameof(LevelSettings.LabelPosition)
             || e.PropertyName == nameof(LevelSettings.ShowPrice)
-            || e.PropertyName == nameof(LevelSettings.OverrideLabel))
+            || e.PropertyName == nameof(LevelSettings.OverrideLabel)
+            || e.PropertyName == nameof(LevelSettings.OverrideWidthInSchemes)
+            || e.PropertyName == nameof(LevelSettings.OverrideStyleInSchemes))
         {
             RedrawChart();
         }
@@ -2197,53 +2220,6 @@ public class OHLCPlus : Indicator
         return false;
     }
 
-
-
-    #region SubscribeAllLevels
-
-    private sealed class RefEqComparer : IEqualityComparer<object>
-    {
-        public static readonly RefEqComparer Instance = new();
-        public new bool Equals(object x, object y) => ReferenceEquals(x, y);
-        public int GetHashCode(object obj) => RuntimeHelpers.GetHashCode(obj);
-    }
-
-    private readonly HashSet<LevelSettings> _subscribedLevels = new(RefEqComparer.Instance);
-
-    private void SubscribeAllLevels()
-    {
-        foreach (var ls in EnumerateAllLevelSettings())
-            TrySubscribe(ls);
-    }
-
-    private IEnumerable<LevelSettings> EnumerateAllLevelSettings()
-    {
-        var flags = System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public;
-        foreach (var pi in GetType().GetProperties(flags))
-        {
-            if (pi.PropertyType != typeof(LevelSettings) || !pi.CanRead)
-                continue;
-
-            if (pi.GetValue(this) is LevelSettings ls)
-                yield return ls;
-        }
-    }
-
-    private void TrySubscribe(LevelSettings? ls)
-    {
-        if (ls is null) return;
-        if (_subscribedLevels.Add(ls))
-            ls.PropertyChanged += OnLevelSettingsChanged;
-    }
-
-    private void OnLevelSettingsChanged(object? sender, PropertyChangedEventArgs e)
-    {
-        if (e.PropertyName == nameof(LevelSettings.Enabled))
-        {
-            RedrawChart();
-            return;
-        }
-    }
     #endregion
 
 

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -39,6 +39,17 @@ public enum LineType
     Full = 2
 }
 
+// How colors are chosen at render time
+public enum ColorMode
+{
+    // Use the color in each LevelSettings (current behavior)
+    PerLineSettings = 0,
+    // Override by timeframe (Day/PrevDay/Week/...)
+    ByPeriod = 1,
+    // Override by level type (Open/High/Low/Close/EQ/POC/VWAP/VAH/VAL)
+    ByLevel = 2
+}
+
 public abstract class NotifiableObject : INotifyPropertyChanged
 {
     public event PropertyChangedEventHandler? PropertyChanged;
@@ -1014,6 +1025,62 @@ public class OHLCPlus : Indicator
 
     #endregion
 
+    #region Color scheme
+    // Strategy selector
+    [Display(GroupName = "Colors", Name = "Mode", Order = 5)]
+    public ColorMode ColorMode { get; set; } = ColorMode.PerLineSettings;
+
+    // --- Palette by PERIOD (used when ColorMode == ByPeriod)
+    [Display(GroupName = "Colors — By Period", Name = "Current Day", Order = 10)]
+    public CrossColor PeriodColorCurrentDay { get; set; } = System.Drawing.Color.Orange.Convert();
+
+    [Display(GroupName = "Colors — By Period", Name = "Previous Day", Order = 11)]
+    public CrossColor PeriodColorPrevDay { get; set; } = System.Drawing.Color.Gray.Convert();
+
+    [Display(GroupName = "Colors — By Period", Name = "Current Week", Order = 12)]
+    public CrossColor PeriodColorCurrentWeek { get; set; } = System.Drawing.Color.SteelBlue.Convert();
+
+    [Display(GroupName = "Colors — By Period", Name = "Previous Week", Order = 13)]
+    public CrossColor PeriodColorPrevWeek { get; set; } = System.Drawing.Color.MediumPurple.Convert();
+
+    [Display(GroupName = "Colors — By Period", Name = "Current Month", Order = 14)]
+    public CrossColor PeriodColorCurrentMonth { get; set; } = System.Drawing.Color.Teal.Convert();
+
+    [Display(GroupName = "Colors — By Period", Name = "Previous Month", Order = 15)]
+    public CrossColor PeriodColorPrevMonth { get; set; } = System.Drawing.Color.DarkSlateGray.Convert();
+
+    [Display(GroupName = "Colors — By Period", Name = "Contract", Order = 16)]
+    public CrossColor PeriodColorContract { get; set; } = System.Drawing.Color.DodgerBlue.Convert();
+
+    // --- Palette by LEVEL TYPE (used when ColorMode == ByLevel)
+    [Display(GroupName = "Colors — By Level", Name = "Open", Order = 110)]
+    public CrossColor LevelColorOpen { get; set; } = System.Drawing.Color.Orange.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "High", Order = 120)]
+    public CrossColor LevelColorHigh { get; set; } = System.Drawing.Color.Green.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "Low", Order = 130)]
+    public CrossColor LevelColorLow { get; set; } = System.Drawing.Color.Red.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "Close", Order = 140)]
+    public CrossColor LevelColorClose { get; set; } = System.Drawing.Color.Gray.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "Equilibrium (EQ)", Order = 150)]
+    public CrossColor LevelColorEQ { get; set; } = System.Drawing.Color.Yellow.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "POC", Order = 160)]
+    public CrossColor LevelColorPOC { get; set; } = System.Drawing.Color.Orange.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "VWAP", Order = 170)]
+    public CrossColor LevelColorVWAP { get; set; } = System.Drawing.Color.SteelBlue.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "VAH", Order = 180)]
+    public CrossColor LevelColorVAH { get; set; } = System.Drawing.Color.Purple.Convert();
+
+    [Display(GroupName = "Colors — By Level", Name = "VAL", Order = 190)]
+    public CrossColor LevelColorVAL { get; set; } = System.Drawing.Color.Purple.Convert();
+    #endregion
+
     #endregion
 
     #region Constructor
@@ -1307,6 +1374,56 @@ public class OHLCPlus : Indicator
     }
 
 
+// Resolve the color respecting the precedence (per-line override > scheme > per-line default)
+    private CrossColor ResolveColor(FixedProfilePeriods period, string suffix, LevelSettings ls)
+    {
+        if (ls != null && ls.UsePerLineColor)
+            return ls.Color; // per-line override wins
+
+        switch (ColorMode) // TODO: enum you introduce for the color feature
+        {
+            case ColorMode.ByPeriod:
+                return ResolvePeriodPalette(period);
+            case ColorMode.ByLevel:
+                return ResolveLevelPalette(suffix);
+            default:
+                return ls?.Color ?? CrossColors.White;
+        }
+    }
+
+    // Build a pen using the resolved color (do not rely on ls.RenderPen anymore when schemes are active)
+    private RenderPen BuildPen(LevelSettings ls, CrossColor color)
+        => new PenSettings { Color = color, Width = ls.Width, LineDashStyle = ls.LineStyle }.RenderObject;
+
+    // Palette resolvers
+    private CrossColor ResolvePeriodPalette(FixedProfilePeriods period)
+        => period switch
+        {
+            FixedProfilePeriods.CurrentDay   => PeriodColorCurrentDay,
+            FixedProfilePeriods.LastDay      => PeriodColorPrevDay,
+            FixedProfilePeriods.CurrentWeek  => PeriodColorCurrentWeek,
+            FixedProfilePeriods.LastWeek     => PeriodColorPrevWeek,
+            FixedProfilePeriods.CurrentMonth => PeriodColorCurrentMonth,
+            FixedProfilePeriods.LastMonth    => PeriodColorPrevMonth,
+            FixedProfilePeriods.Contract     => PeriodColorContract,
+            _                                => CrossColors.White
+        };
+
+    private CrossColor ResolveLevelPalette(string suffix)
+        => suffix switch
+        {
+            "Open"  => LevelColorOpen,
+            "High"  => LevelColorHigh,
+            "Low"   => LevelColorLow,
+            "Close" => LevelColorClose,
+            "EQ"    => LevelColorEQ,
+            "POC"   => LevelColorPOC,
+            "VWAP"  => LevelColorVWAP,
+            "VAH"   => LevelColorVAH,
+            "VAL"   => LevelColorVAL,
+            _       => CrossColors.White
+        };
+
     private void RenderLevel(RenderContext context, string levelKey, LevelSettings levelSettings)
     {
         if (!levelSettings.Enabled || !_levels.TryGetValue(levelKey, out var level) || !level.IsValid)
@@ -1328,6 +1445,10 @@ public class OHLCPlus : Indicator
         }
         // ----------------------------------------------------
 
+        // NEW: resolve color & pen
+        var color = ResolveColor(prefix, suffix, levelSettings);
+        var renderPen = BuildPen(levelSettings, color);
+
         // Validate price is reasonable
         if (level.Price <= 0)
             return;
@@ -1343,8 +1464,6 @@ public class OHLCPlus : Indicator
         var barWidth = (int)ChartInfo.PriceChartContainer.BarsWidth;
         var currentBarRightX = currentBarX + barWidth;
 
-        // Get pen from LevelSettings
-        var renderPen = levelSettings.RenderPen;
 
         // Draw line first (if LineType != None)
         switch (levelSettings.LineType)
@@ -1376,7 +1495,7 @@ public class OHLCPlus : Indicator
         // Draw price label (if ShowPrice == true)
         if (levelSettings.ShowPrice)
         {
-            DrawPriceLabel(context, level.Price, y, renderPen, levelSettings);
+            DrawPriceLabel(context, level.Price, y, renderPen, color);
         }
 
         // Draw text label (if LabelPosition != None)
@@ -1400,12 +1519,11 @@ public class OHLCPlus : Indicator
         }
     }
 
-    private void DrawPriceLabel(RenderContext context, decimal price, int y, RenderPen pen, LevelSettings levelSettings)
+    private void DrawPriceLabel(RenderContext context, decimal price, int y, RenderPen pen, CrossColor backgroundColor)
     {
         var priceText = string.Format(ChartInfo.StringFormat, price);
 
         // Calculate contrasting text color based on background color
-        var backgroundColor = levelSettings.Color;
         var textColor = GetContrastingColor(backgroundColor);
 
         this.DrawLabelOnPriceAxis(context, priceText, y, _axisFont, backgroundColor.Convert(), textColor.Convert());

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -1280,6 +1280,11 @@ public class OHLCPlus : Indicator
                 // If label is at bar position, start line after the label to avoid overlap
                 if (levelSettings.LabelPosition == LabelPosition.Bar)
                 {
+                    // Calculate actual label width for better positioning
+                    var (prefix, suffix) = SplitKey(levelKey);
+                    var levelText = ResolveLevelText(suffix, levelSettings);
+                    var displayLabel = BuildDisplayLabel(prefix, levelText);
+                    var labelSize = context.MeasureString(displayLabel, _font);
                     var labelSize = context.MeasureString(displayLabel, _font);
                     var labelStartX = currentBarRightX + 5;
                     var lineStartX = labelStartX + labelSize.Width + 4; // 4px padding

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -375,6 +375,42 @@ public class OHLCPlus : Indicator
     {(LevelKind.Low,  PeriodKind.Contract),     new(CTealCyan(), 2, LineDashStyle.Dot)},
     };
 
+    // ===================== LABEL LAYOUT: fields & helpers =====================
+
+    // Occupancy of already placed label rects (per frame)
+    private readonly List<Rectangle> _occupiedLabelRects = new();
+
+    // Horizontal probing config (pixels)
+    private const int LabelHStep = 10;        // horizontal step per probe
+    private const int LabelHMaxShift = 120;  // max horizontal travel allowed
+
+    // Vertical fallback (Y nudges) when X corridor is full
+    private const int LabelYNudgeStep = 8;
+    private const int LabelYNudgeMax = 24;
+
+    // Request to draw a text label; enqueued during RenderLevel and committed at the end of OnRender
+    private sealed class LabelDrawRequest
+    {
+        public string Text = string.Empty;
+        public Rectangle Desired;      // base rect including border padding
+        public int MinX;               // left bound for horizontal movement
+        public int MaxX;               // right bound for horizontal movement
+        public int Dir;                // +1 probe right, -1 probe left
+        public bool AlignRight;        // right-aligned text?
+        public int Priority;           // higher wins
+        public RenderPen Pen = null!;
+
+        // NEW: info to draw/crop the line after placing the label
+        public bool DeferLine;            // true => draw line after label
+        public LineType LineType;         // which line to draw
+        public LabelPosition LabelPos;    // left/right/bar
+        public int Y;                     // line Y
+        public int CurrentBarRightX;      // for LineType.Bar
+        public int ChartWidth;            // for LineType.Full
+    }
+
+    // Per-frame queue for label requests
+    private readonly List<LabelDrawRequest> _labelQueue = new();
 
     #endregion
 
@@ -1331,7 +1367,11 @@ public class OHLCPlus : Indicator
         if (ChartInfo is null || InstrumentInfo is null)
             return;
 
-        // Render all levels in groups for better organization
+        // Start a fresh label batch for this frame
+        _occupiedLabelRects.Clear();
+        _labelQueue.Clear();
+
+        // 1) Render lines & price labels; RenderLevel will ENQUEUE text labels instead of drawing them
         RenderLevelGroup(context, storagePrefix: "d", displayPrefix: PrefixCurrentDay, DayOpenLevel, DayHighLevel, DayLowLevel, DayCloseLevel, DayEquilibriumLevel, DayPOCLevel, DayVWAPLevel, DayVAHLevel, DayVALLevel);
         RenderLevelGroup(context, storagePrefix: "p", displayPrefix: PrefixPrevDay, PrevDayOpenLevel, PrevDayHighLevel, PrevDayLowLevel, PrevDayCloseLevel, PrevDayEquilibriumLevel, PrevDayPOCLevel, PrevDayVWAPLevel, PrevDayVAHLevel, PrevDayVALLevel);
         RenderLevelGroup(context, storagePrefix: "w", displayPrefix: PrefixCurrentWeek, WeekOpenLevel, WeekHighLevel, WeekLowLevel, WeekCloseLevel, WeekEquilibriumLevel, WeekPOCLevel, WeekVWAPLevel, WeekVAHLevel, WeekVALLevel);
@@ -1340,9 +1380,86 @@ public class OHLCPlus : Indicator
         RenderLevelGroup(context, storagePrefix: "pm", displayPrefix: PrefixPrevMonth, PrevMonthOpenLevel, PrevMonthHighLevel, PrevMonthLowLevel, PrevMonthCloseLevel, PrevMonthEquilibriumLevel, PrevMonthPOCLevel, PrevMonthVWAPLevel, PrevMonthVAHLevel, PrevMonthVALLevel);
         RenderLevelGroup(context, storagePrefix: "c", displayPrefix: PrefixContract, ContractOpenLevel, ContractHighLevel, ContractLowLevel, ContractCloseLevel, ContractEquilibriumLevel, ContractPOCLevel, ContractVWAPLevel, ContractVAHLevel, ContractVALLevel);
 
-        // HVN rects
+        // 2) Commit text labels: place by priority; try X, then Y fallbacks; draw line cropped
+        if (_labelQueue.Count > 0)
+        {
+            foreach (var req in _labelQueue.OrderByDescending(r => r.Priority))
+            {
+                Rectangle placed;
+
+                // Try base X corridor first
+                bool ok = TryPlaceLabelHorizontal(req.Desired, req.MinX, req.MaxX, req.Dir, out placed);
+
+                // If failed, try small Y nudges (up/down) and retry X per nudge
+                if (!ok)
+                {
+                    for (int dy = LabelYNudgeStep; dy <= LabelYNudgeMax && !ok; dy += LabelYNudgeStep)
+                    {
+                        // Up
+                        var up = new Rectangle(req.Desired.X, req.Desired.Y - dy, req.Desired.Width, req.Desired.Height);
+                        ok = TryPlaceLabelHorizontal(up, req.MinX, req.MaxX, req.Dir, out placed);
+                        if (ok) break;
+
+                        // Down
+                        var dn = new Rectangle(req.Desired.X, req.Desired.Y + dy, req.Desired.Width, req.Desired.Height);
+                        ok = TryPlaceLabelHorizontal(dn, req.MinX, req.MaxX, req.Dir, out placed);
+                    }
+                }
+
+                if (ok)
+                {
+                    // Draw the text (reconstruimos el anchor x/y desde el rect)
+                    DrawTextLabelCore(context, req.Text, placed, req.Pen, req.AlignRight);
+
+                    // Draw/crop the line now that we know the label position
+                    if (req.DeferLine && req.LineType != LineType.None)
+                    {
+                        int left = 0;
+                        int right = req.ChartWidth;
+
+                        if (req.LineType == LineType.Bar)
+                        {
+                            left = req.CurrentBarRightX;
+                            if (req.LabelPos == LabelPosition.Bar)
+                                left = Math.Max(left, LineStartAfter(placed)); // start after label
+                        }
+                        else if (req.LineType == LineType.Full)
+                        {
+                            if (req.LabelPos == LabelPosition.Left)
+                                left = Math.Max(left, LineStartAfter(placed));
+                            else if (req.LabelPos == LabelPosition.Right)
+                                right = Math.Min(right, LineEndBefore(placed));
+                        }
+
+                        if (right > left)
+                            context.DrawLine(req.Pen, left, req.Y, right, req.Y);
+                    }
+                }
+                else
+                {
+                    // No slot -> optionally draw the original (uncropped) line so no level disappears
+                    if (req.DeferLine && req.LineType != LineType.None)
+                    {
+                        switch (req.LineType)
+                        {
+                            case LineType.Bar:
+                                context.DrawLine(req.Pen, req.CurrentBarRightX, req.Y, req.ChartWidth, req.Y);
+                                break;
+                            case LineType.Full:
+                                context.DrawLine(req.Pen, 0, req.Y, req.ChartWidth, req.Y);
+                                break;
+                        }
+                    }
+                    // Text label is dropped (lowest priority loses)
+                }
+            }
+        }
+
+
+        // 3) HVN rects (kept after levels as in your current codebase)
         RenderAllHVNsWithPriority(context);
     }
+
 
     #endregion
 
@@ -1676,58 +1793,106 @@ public class OHLCPlus : Indicator
         var barWidth = (int)ChartInfo.PriceChartContainer.BarsWidth;
         var currentBarRightX = currentBarX + barWidth;
 
+        // --- Decide if we defer the line (only when there will be a label)
+        bool willHaveTextLabel = levelSettings.LabelPosition != LabelPosition.None;
+        bool deferLine = willHaveTextLabel && levelSettings.LineType != LineType.None;
 
-        // Draw line first (if LineType != None)
-        switch (levelSettings.LineType)
+        // Draw line now only if not deferring (no cropping case)
+        if (!deferLine)
         {
-            case LineType.Bar:
-                // If label is at bar position, start line after the label to avoid overlap
-                if (levelSettings.LabelPosition == LabelPosition.Bar)
-                {
-                    // Calculate actual label width for better positioning
-                    var labelSize = context.MeasureString(displayLabel, _font);
-                    var labelStartX = currentBarRightX + 5;
-                    var lineStartX = labelStartX + labelSize.Width + 4; // 4px padding
-                    context.DrawLine(renderPen, lineStartX, y, chartWidth, y);
-                }
-                else
-                {
-                    // Normal bar line from right edge of bar to price axis
+            // Draw line first (if LineType != None)
+            switch (levelSettings.LineType)
+            {   // If label is at bar position, start line after the label to avoid overlap
+                case LineType.Bar:
                     context.DrawLine(renderPen, currentBarRightX, y, chartWidth, y);
-                }
-                break;
-            case LineType.Full:
-                context.DrawLine(renderPen, 0, y, chartWidth, y);
-                break;
-            case LineType.None:
-                // No line to draw
-                break;
+                    break;
+                case LineType.Full:
+                    context.DrawLine(renderPen, 0, y, chartWidth, y);
+                    break;
+                case LineType.None:
+                    break;
+            }
         }
 
-        // Draw price label (if ShowPrice == true)
+        // Price label (unchanged)
         if (levelSettings.ShowPrice)
-        {
             DrawPriceLabel(context, level.Price, y, renderPen, color);
-        }
 
-        // Draw text label (if LabelPosition != None)
-        switch (levelSettings.LabelPosition)
+        // --- Text label: enqueue (and pass line info if deferLine == true)
+        if (willHaveTextLabel)
         {
-            case LabelPosition.Bar:
-                var barLabelX = currentBarRightX + 5;
-                DrawTextLabel(context, displayLabel, barLabelX, y, renderPen, false);
-                break;
-            case LabelPosition.Right:
-                var rightLabelX = chartWidth - 5;
-                DrawTextLabel(context, displayLabel, rightLabelX, y, renderPen, true);
-                break;
-            case LabelPosition.Left:
-                var leftLabelX = 5;
-                DrawTextLabel(context, displayLabel, leftLabelX, y, renderPen, false);
-                break;
-            case LabelPosition.None:
-                // No text label to draw
-                break;
+            int anchorX;
+            bool alignRight;
+
+            switch (levelSettings.LabelPosition)
+            {
+                case LabelPosition.Right:
+                    anchorX = chartWidth - 5;
+                    alignRight = true;
+                    break;
+                case LabelPosition.Left:
+                    anchorX = 5;
+                    alignRight = false;
+                    break;
+                case LabelPosition.Bar:
+                default:
+                    // slightly bigger gap from bar: 8 px (was 5)
+                    anchorX = currentBarRightX + 8;
+                    alignRight = false;
+                    break;
+            }
+
+            var size = context.MeasureString(displayLabel, _font);
+            int rectXBase = alignRight ? anchorX - size.Width : anchorX;
+            var desired = new Rectangle(rectXBase - 2, y - size.Height / 2 - 1, size.Width + 4, size.Height + 2);
+
+            // Horizontal corridor & direction
+            int minX, maxX, dir;
+            if (levelSettings.LabelPosition == LabelPosition.Left)
+            {
+                minX = 5 - 2;
+                maxX = minX + LabelHMaxShift;
+                dir = +1; // push right
+            }
+            else if (levelSettings.LabelPosition == LabelPosition.Right)
+            {
+                int rightEdge = chartWidth - 5;
+                minX = rightEdge - size.Width - LabelHMaxShift - 2;
+                maxX = rightEdge - size.Width - 2;
+                if (minX > maxX) minX = maxX;
+                dir = -1; // push left
+            }
+            else // Bar -> can move up to the same bound as "Right"
+            {
+                int rightEdge = chartWidth - 5;
+                minX = anchorX - 2;
+                maxX = rightEdge - size.Width - 2;
+                if (minX > maxX) minX = maxX;
+                dir = +1; // push right
+            }
+
+            var (sprefix, ssuffix) = SplitKey(levelKey);
+            int priority = GetLabelPriority(sprefix, ssuffix);
+
+            _labelQueue.Add(new LabelDrawRequest
+            {
+                Text = displayLabel,
+                Desired = desired,
+                MinX = minX,
+                MaxX = maxX,
+                Dir = dir,
+                AlignRight = (levelSettings.LabelPosition == LabelPosition.Right),
+                Priority = priority,
+                Pen = renderPen,
+
+                // NEW: defer line so we can crop to the final label rect
+                DeferLine = deferLine,
+                LineType = levelSettings.LineType,
+                LabelPos = levelSettings.LabelPosition,
+                Y = y,
+                CurrentBarRightX = currentBarRightX,
+                ChartWidth = chartWidth
+            });
         }
     }
 
@@ -2219,6 +2384,140 @@ public class OHLCPlus : Indicator
         style = null!;
         return false;
     }
+
+    #endregion
+
+    #region label layout helpers
+    /// <summary>
+    /// Assigns label priority (higher = more important) using your rules:
+    /// - POC: previous day/week > current day/week > others
+    /// - VWAP: current day/week > previous day/week > others
+    /// - VAH/VAL: closed (previous) > open (current) > others
+    /// - High/Low: previous day > current day > others
+    /// - Open/Close/EQ: moderate
+    /// </summary>
+    private int GetLabelPriority(string storagePrefix, string suffix)
+    {
+        static bool IsCurrent(string sp) => sp is "d" or "w" or "m";
+        static bool IsPrevious(string sp) => sp is "p" or "pw" or "pm";
+        static bool IsContract(string sp) => sp == "c";
+
+        switch (suffix)
+        {
+            // POC: previous > current > rest
+            case "POC":
+                if (IsPrevious(storagePrefix)) return 95;
+                if (storagePrefix == "d" || storagePrefix == "w") return 80;
+                if (IsCurrent(storagePrefix)) return 70;
+                if (IsContract(storagePrefix)) return 65;
+                return 60;
+
+            // VWAP: current day/week > previous > rest
+            case "VWAP":
+                if (storagePrefix == "d" || storagePrefix == "w") return 90;
+                if (IsPrevious(storagePrefix)) return 75;
+                if (IsCurrent(storagePrefix)) return 65;
+                if (IsContract(storagePrefix)) return 60;
+                return 55;
+
+            // VAH / VAL: closed (previous) > open (current) > rest
+            case "VAH":
+            case "VAL":
+                if (IsPrevious(storagePrefix)) return 85;
+                if (IsCurrent(storagePrefix)) return 70;
+                if (IsContract(storagePrefix)) return 55;
+                return 50;
+
+            // High / Low: previous day > current day > others
+            case "High":
+            case "Low":
+                if (storagePrefix == "p") return 75;
+                if (storagePrefix == "d") return 60;
+                if (storagePrefix == "pw" || storagePrefix == "w") return 55;
+                return 45;
+
+            // Open / Close / EQ: moderate
+            case "Open":
+            case "Close":
+            case "EQ":
+                if (IsPrevious(storagePrefix)) return 60;
+                if (IsCurrent(storagePrefix)) return 55;
+                if (IsContract(storagePrefix)) return 50;
+                return 45;
+
+            default:
+                return 40;
+        }
+    }
+
+    /// <summary>
+    /// Try to place a label rectangle by moving it horizontally in [minX, maxX]
+    /// stepping by LabelHStep in the given direction (dir: +1 right, -1 left).
+    /// Respects already-placed rectangles in _occupiedLabelRects.
+    /// </summary>
+    private bool TryPlaceLabelHorizontal(Rectangle desired, int minX, int maxX, int dir, out Rectangle placed)
+    {
+        // Clamp desired to corridor
+        int baseX = Math.Min(Math.Max(desired.X, minX), maxX);
+        var candidate = new Rectangle(baseX, desired.Y, desired.Width, desired.Height);
+
+        // Helper: test overlap with anything already placed
+        bool Overlaps(Rectangle r) => _occupiedLabelRects.Any(o => o.IntersectsWith(r));
+
+        // 1) Try the base position
+        if (!Overlaps(candidate))
+        {
+            placed = candidate;
+            _occupiedLabelRects.Add(placed);
+            return true;
+        }
+
+        // 2) Probe horizontally within the allowed corridor
+        int maxShift = Math.Min(LabelHMaxShift, Math.Max(0, (dir > 0 ? maxX - baseX : baseX - minX)));
+        for (int shift = LabelHStep; shift <= maxShift; shift += LabelHStep)
+        {
+            int x = baseX + dir * shift;
+            if (x < minX) x = minX;
+            if (x > maxX) x = maxX;
+
+            candidate = new Rectangle(x, desired.Y, desired.Width, desired.Height);
+            if (!Overlaps(candidate))
+            {
+                placed = candidate;
+                _occupiedLabelRects.Add(placed);
+                return true;
+            }
+        }
+
+        placed = Rectangle.Empty;
+        return false; // no slot found -> drop low-priority label
+    }
+
+    /// Renders a text label using the existing DrawTextLabel helper, given a final rectangle.
+    /// This function reconstructs the (x, y) anchor that DrawTextLabel expects from the
+    /// already-placed rectangle, preserving the same padding and alignment.
+
+    private void DrawTextLabelCore(RenderContext context, string text, Rectangle rect, RenderPen pen, bool alignRight)
+    {
+        // Vertical anchor at the rectangle center (DrawTextLabel will center text around `y`)
+        int y = rect.Top + rect.Height / 2;
+
+        // Horizontal anchor reconstructed from the final rectangle, matching DrawTextLabel's padding:
+        // - Left-aligned: x is the left inside edge (rect.Left + 2)
+        // - Right-aligned: x is the right inside edge (rect.Right - 2)
+        int x = alignRight ? rect.Right - 2 : rect.Left + 2;
+
+        // Delegate actual rendering to the existing helper to keep styling consistent
+        DrawTextLabel(context, text, x, y, pen, alignRight);
+    }
+
+    // End X when label is on the right side (leave a tiny padding)
+    private static int LineEndBefore(Rectangle labelRect, int padding = 4)
+        => Math.Max(0, labelRect.Left - padding);
+
+    // Start X when label is on the left/bar side
+    private static int LineStartAfter(Rectangle labelRect, int padding = 4)
+        => labelRect.Right + padding;
 
     #endregion
 

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -124,6 +124,15 @@ public class LevelSettings : NotifiableObject
         set => SetField(ref _labelPosition, value);
     }
 
+    private string _overrideLabel = string.Empty;
+
+    [Display(Name = "Override label (optional)")]
+    public string OverrideLabel
+    {
+        get => _overrideLabel;
+        set => SetField(ref _overrideLabel, value);
+    }
+
     [Browsable(false)]
     public RenderPen RenderPen => new PenSettings { Color = Color, Width = Width, LineDashStyle = LineStyle }.RenderObject;
 
@@ -949,6 +958,24 @@ public class OHLCPlus : Indicator
 
     #endregion
 
+    #region Labels Settings
+
+    // Template supports {prefix} and {level}
+    [Display(Name = "Label template")]
+    public string LabelTemplate { get; set; } = "{prefix}{level}";
+
+    [Display(Name = "Open label")] public string OpenLabel { get; set; } = "Open";
+    [Display(Name = "High label")] public string HighLabel { get; set; } = "High";
+    [Display(Name = "Low label")] public string LowLabel { get; set; } = "Low";
+    [Display(Name = "Close label")] public string CloseLabel { get; set; } = "Close";
+    [Display(Name = "Equilibrium label")] public string EqLabel { get; set; } = "EQ";
+    [Display(Name = "POC label")] public string POCLabel { get; set; } = "POC";
+    [Display(Name = "VWAP label")] public string VWAPLabel { get; set; } = "VWAP";
+    [Display(Name = "VAH label")] public string VAHLabel { get; set; } = "VAH";
+    [Display(Name = "VAL label")] public string VALLabel { get; set; } = "VAL";
+
+    #endregion
+
     #endregion
 
     #region Constructor
@@ -1248,8 +1275,10 @@ public class OHLCPlus : Indicator
                 if (levelSettings.LabelPosition == LabelPosition.Bar)
                 {
                     // Calculate actual label width for better positioning
-                    var labelText = level.Label;
-                    var labelSize = context.MeasureString(labelText, _font);
+                    var (prefix, suffix) = SplitKey(levelKey);
+                    var levelText = ResolveLevelText(suffix, levelSettings);
+                    var displayLabel = BuildDisplayLabel(prefix, levelText);
+                    var labelSize = context.MeasureString(displayLabel, _font);
                     var labelStartX = currentBarRightX + 5;
                     var lineStartX = labelStartX + labelSize.Width + 4; // 4px padding
                     context.DrawLine(renderPen, lineStartX, y, chartWidth, y);
@@ -1279,15 +1308,15 @@ public class OHLCPlus : Indicator
         {
             case LabelPosition.Bar:
                 var barLabelX = currentBarRightX + 5;
-                DrawTextLabel(context, level.Label, barLabelX, y, renderPen, false);
+                DrawTextLabel(context, displayLabel, barLabelX, y, renderPen, false);
                 break;
             case LabelPosition.Right:
                 var rightLabelX = chartWidth - 5;
-                DrawTextLabel(context, level.Label, rightLabelX, y, renderPen, true);
+                DrawTextLabel(context, displayLabel, rightLabelX, y, renderPen, true);
                 break;
             case LabelPosition.Left:
                 var leftLabelX = 5;
-                DrawTextLabel(context, level.Label, leftLabelX, y, renderPen, false);
+                DrawTextLabel(context, displayLabel, leftLabelX, y, renderPen, false);
                 break;
             case LabelPosition.None:
                 // No text label to draw
@@ -1443,6 +1472,42 @@ public class OHLCPlus : Indicator
             FixedProfilePeriods.Contract => _needContract,
             _ => false
         };
+    }
+
+    private static (string Prefix, string Suffix) SplitKey(string key)
+    {
+        // Sufijos conocidos ordenados por longitud para evitar colisiones
+        foreach (var s in new[] { "Close", "Open", "High", "Low", "VWAP", "POC", "VAH", "VAL", "EQ" })
+            if (key.EndsWith(s, StringComparison.Ordinal))
+                return (key.Substring(0, key.Length - s.Length), s);
+        return ("", key);
+    }
+
+    private string ResolveLevelText(string suffix, LevelSettings ls)
+    {
+        if (!string.IsNullOrWhiteSpace(ls?.OverrideLabel))
+            return ls.OverrideLabel;
+
+        return suffix switch
+        {
+            "Open" => OpenLabel,
+            "High" => HighLabel,
+            "Low" => LowLabel,
+            "Close" => CloseLabel,
+            "EQ" => EqLabel,
+            "POC" => POCLabel,
+            "VWAP" => VWAPLabel,
+            "VAH" => VAHLabel,
+            "VAL" => VALLabel,
+            _ => suffix
+        };
+    }
+
+    private string BuildDisplayLabel(string prefix, string levelText)
+    {
+        var template = string.IsNullOrEmpty(LabelTemplate) ? "{prefix}{level}" : LabelTemplate;
+        return template.Replace("{prefix}", prefix ?? string.Empty)
+                       .Replace("{level}", levelText ?? string.Empty);
     }
 
     #endregion

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -1042,6 +1042,62 @@ public class OHLCPlus : Indicator
     public ColorMode ColorMode { get; set; } = ColorMode.PerLineSettings;
 
     // --- Palette by PERIOD (used when ColorMode == ByPeriod)
+    [Display(GroupName = "Colors � By Period", Name = "Current Day", Order = 10)]
+    public CrossColor PeriodColorCurrentDay { get; set; } = System.Drawing.Color.Orange.Convert();
+
+    [Display(GroupName = "Colors � By Period", Name = "Previous Day", Order = 11)]
+    public CrossColor PeriodColorPrevDay { get; set; } = System.Drawing.Color.Gray.Convert();
+
+    [Display(GroupName = "Colors � By Period", Name = "Current Week", Order = 12)]
+    public CrossColor PeriodColorCurrentWeek { get; set; } = System.Drawing.Color.SteelBlue.Convert();
+
+    [Display(GroupName = "Colors � By Period", Name = "Previous Week", Order = 13)]
+    public CrossColor PeriodColorPrevWeek { get; set; } = System.Drawing.Color.MediumPurple.Convert();
+
+    [Display(GroupName = "Colors � By Period", Name = "Current Month", Order = 14)]
+    public CrossColor PeriodColorCurrentMonth { get; set; } = System.Drawing.Color.Teal.Convert();
+
+    [Display(GroupName = "Colors � By Period", Name = "Previous Month", Order = 15)]
+    public CrossColor PeriodColorPrevMonth { get; set; } = System.Drawing.Color.DarkSlateGray.Convert();
+
+    [Display(GroupName = "Colors � By Period", Name = "Contract", Order = 16)]
+    public CrossColor PeriodColorContract { get; set; } = System.Drawing.Color.DodgerBlue.Convert();
+
+    // --- Palette by LEVEL TYPE (used when ColorMode == ByLevel)
+    [Display(GroupName = "Colors � By Level", Name = "Open", Order = 110)]
+    public CrossColor LevelColorOpen { get; set; } = System.Drawing.Color.Orange.Convert();
+
+    [Display(GroupName = "Colors � By Level", Name = "High", Order = 120)]
+    public CrossColor LevelColorHigh { get; set; } = System.Drawing.Color.Green.Convert();
+
+    [Display(GroupName = "Colors � By Level", Name = "Low", Order = 130)]
+    public CrossColor LevelColorLow { get; set; } = System.Drawing.Color.Red.Convert();
+
+    [Display(GroupName = "Colors � By Level", Name = "Close", Order = 140)]
+    public CrossColor LevelColorClose { get; set; } = System.Drawing.Color.Gray.Convert();
+
+    [Display(GroupName = "Colors � By Level", Name = "Equilibrium (EQ)", Order = 150)]
+    public CrossColor LevelColorEQ { get; set; } = System.Drawing.Color.Yellow.Convert();
+
+    [Display(GroupName = "Colors � By Level", Name = "POC", Order = 160)]
+    public CrossColor LevelColorPOC { get; set; } = System.Drawing.Color.Orange.Convert();
+
+    [Display(GroupName = "Colors � By Level", Name = "VWAP", Order = 170)]
+    public CrossColor LevelColorVWAP { get; set; } = System.Drawing.Color.SteelBlue.Convert();
+
+    [Display(GroupName = "Colors � By Level", Name = "VAH", Order = 180)]
+    public CrossColor LevelColorVAH { get; set; } = System.Drawing.Color.Purple.Convert();
+
+    [Display(GroupName = "Colors � By Level", Name = "VAL", Order = 190)]
+    public CrossColor LevelColorVAL { get; set; } = System.Drawing.Color.Purple.Convert();
+    #endregion
+
+    #region Color scheme
+    // Strategy selector
+    [Display(GroupName = "Colors", Name = "Mode", Order = 5)]
+    public ColorMode ColorMode { get; set; } = ColorMode.PerLineSettings;
+
+    // --- Palette by PERIOD (used when ColorMode == ByPeriod)
     [Display(GroupName = "Colors - By Period", Name = "Current Day", Order = 10)]
     public CrossColor PeriodColorCurrentDay { get; set; } = System.Drawing.Color.OrangeRed.Convert();
 

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -16,13 +16,13 @@ public enum LabelPosition
 {
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.None))]
     None = 0,
-    
+
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Bar))]
     Bar = 1,
-    
+
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Right))]
     Right = 2,
-    
+
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Left))]
     Left = 3
 }
@@ -31,10 +31,10 @@ public enum LineType
 {
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.None))]
     None = 0,
-    
+
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.TillBar))]
     Bar = 1,
-    
+
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.FullWidth))]
     Full = 2
 }
@@ -1332,7 +1332,6 @@ public class OHLCPlus : Indicator
                     var levelText = ResolveLevelText(suffix, levelSettings);
                     var displayLabel = BuildDisplayLabel(prefix, levelText);
                     var labelSize = context.MeasureString(displayLabel, _font);
-                    var labelSize = context.MeasureString(displayLabel, _font);
                     var labelStartX = currentBarRightX + 5;
                     var lineStartX = labelStartX + labelSize.Width + 4; // 4px padding
                     context.DrawLine(renderPen, lineStartX, y, chartWidth, y);
@@ -1381,20 +1380,20 @@ public class OHLCPlus : Indicator
     private void DrawPriceLabel(RenderContext context, decimal price, int y, RenderPen pen, LevelSettings levelSettings)
     {
         var priceText = string.Format(ChartInfo.StringFormat, price);
-        
+
         // Calculate contrasting text color based on background color
         var backgroundColor = levelSettings.Color;
         var textColor = GetContrastingColor(backgroundColor);
-        
+
         this.DrawLabelOnPriceAxis(context, priceText, y, _axisFont, backgroundColor.Convert(), textColor.Convert());
     }
-    
+
     private CrossColor GetContrastingColor(CrossColor backgroundColor)
     {
         // Calculate luminance using relative luminance formula
         // See: https://www.w3.org/TR/WCAG20/#relativeluminancedef
         double luminance = (0.299 * backgroundColor.R + 0.587 * backgroundColor.G + 0.114 * backgroundColor.B) / 255;
-        
+
         // If background is dark, use white text; if light, use black text
         if (luminance > 0.5)
         {
@@ -1412,16 +1411,16 @@ public class OHLCPlus : Indicator
     {
         var size = context.MeasureString(text, _font);
         var textColor = ChartInfo.ColorsStore.MouseTextColor;
-        
+
         // Calculate rectangle position based on alignment
         var rectX = alignRight ? x - size.Width : x;
         var rect = new Rectangle(rectX - 2, y - size.Height / 2 - 1, size.Width + 4, size.Height + 2);
-        
+
         // Draw background with border
         var backgroundColor = ChartInfo.ColorsStore.BaseBackgroundColor;
         context.FillRectangle(backgroundColor, rect);
         context.DrawRectangle(pen, rect);
-        
+
         // Draw text
         var textRect = new Rectangle(rectX, y - size.Height / 2, size.Width, size.Height);
         var format = alignRight ? _stringRightFormat : _stringLeftFormat;

--- a/Technical/OHLCPlus.cs
+++ b/Technical/OHLCPlus.cs
@@ -48,7 +48,9 @@ public enum ColorMode
     // Override by timeframe (Day/PrevDay/Week/...)
     ByPeriod = 1,
     // Override by level type (Open/High/Low/Close/EQ/POC/VWAP/VAH/VAL)
-    ByLevel = 2
+    ByLevel = 2,
+    // NEW: applies semantic styles (color, width, style) from _semanticStyles
+    SemanticMatrix = 3
 }
 
 public abstract class NotifiableObject : INotifyPropertyChanged
@@ -274,6 +276,88 @@ public class OHLCPlus : Indicator
     FixedProfilePeriods.LastDay,
     FixedProfilePeriods.CurrentDay
     };
+
+    // 2) Classifications for mapping (storagePrefix, suffix) -> style lookup
+    private enum PeriodKind { CurrentDay, PrevDay, CurrentWeek, PrevWeek, CurrentMonth, PrevMonth, Contract, Other }
+    private enum LevelKind { Open, High, Low, Close, EQ, POC, VWAP, VAH, VAL, Other }
+
+    // 3) Visual style record (already present) and the style matrix
+    private record VisualStyle(CrossColor Color, int Width, LineDashStyle Style);
+
+    // Helper colors tuned for DARK backgrounds (high contrast)
+    private static CrossColor CWhite(int a = 245) => System.Drawing.Color.FromArgb(a, 255, 255, 255).Convert();
+    private static CrossColor CGray(int a = 230) => System.Drawing.Color.FromArgb(a, 180, 180, 190).Convert();
+    private static CrossColor CGrayDim(int a = 210) => System.Drawing.Color.FromArgb(a, 130, 135, 145).Convert();
+    private static CrossColor CViolet(int a = 235) => System.Drawing.Color.FromArgb(a, 168, 85, 247).Convert(); // ≈ #A855F7
+    private static CrossColor CCyan(int a = 240) => System.Drawing.Color.FromArgb(a, 56, 189, 255).Convert(); // ≈ #38BDFF
+    private static CrossColor CTealCyan() => System.Drawing.Color.FromArgb(210, 34, 211, 238).Convert(); // ≈ #22D3EE
+    private static CrossColor VWAPColor() => System.Drawing.ColorTranslator.FromHtml("#FF446EA2").Convert(); // requested
+
+    // NEW: style matrix (LevelKind × PeriodKind) -> VisualStyle
+    private readonly Dictionary<(LevelKind L, PeriodKind P), VisualStyle> _styleMatrix =
+        new Dictionary<(LevelKind, PeriodKind), VisualStyle>
+    {
+    // ---- POC: white; current < previous (dot vs solid, width 2 vs 3)
+    {(LevelKind.POC, PeriodKind.CurrentDay),   new(CWhite(), 2, LineDashStyle.Dot)},
+    {(LevelKind.POC, PeriodKind.PrevDay),     new(CWhite(), 3, LineDashStyle.Solid)},
+    {(LevelKind.POC, PeriodKind.CurrentWeek), new(CWhite(), 2, LineDashStyle.Dot)},
+    {(LevelKind.POC, PeriodKind.PrevWeek),    new(CWhite(), 3, LineDashStyle.Solid)},
+    // Month/Contract lighter reference
+    {(LevelKind.POC, PeriodKind.CurrentMonth),new(CWhite(225), 2, LineDashStyle.Dash)},
+    {(LevelKind.POC, PeriodKind.PrevMonth),   new(CWhite(230), 2, LineDashStyle.Solid)},
+    {(LevelKind.POC, PeriodKind.Contract),    new(CWhite(220), 2, LineDashStyle.Dot)},
+
+    // ---- VWAP: #FF446EA2; current > previous (solid 3 vs dash 2)
+    {(LevelKind.VWAP, PeriodKind.CurrentDay),   new(VWAPColor(), 3, LineDashStyle.Solid)},
+    {(LevelKind.VWAP, PeriodKind.PrevDay),      new(VWAPColor(), 2, LineDashStyle.Dash)},
+    {(LevelKind.VWAP, PeriodKind.CurrentWeek),  new(VWAPColor(), 3, LineDashStyle.Solid)},
+    {(LevelKind.VWAP, PeriodKind.PrevWeek),     new(VWAPColor(), 2, LineDashStyle.Dash)},
+    {(LevelKind.VWAP, PeriodKind.CurrentMonth), new(VWAPColor(), 2, LineDashStyle.Dot)},
+    {(LevelKind.VWAP, PeriodKind.PrevMonth),    new(VWAPColor(), 2, LineDashStyle.Dot)},
+    {(LevelKind.VWAP, PeriodKind.Contract),     new(VWAPColor(), 2, LineDashStyle.Dot)},
+
+    // ---- VAH / VAL (bounds): violet; closed (prev*) > open (current*)
+    {(LevelKind.VAH, PeriodKind.CurrentDay),   new(CViolet(220), 2, LineDashStyle.Dash)},
+    {(LevelKind.VAH, PeriodKind.PrevDay),      new(CViolet(235), 3, LineDashStyle.Solid)},
+    {(LevelKind.VAH, PeriodKind.CurrentWeek),  new(CViolet(220), 2, LineDashStyle.Dash)},
+    {(LevelKind.VAH, PeriodKind.PrevWeek),     new(CViolet(235), 3, LineDashStyle.Solid)},
+    {(LevelKind.VAH, PeriodKind.CurrentMonth), new(CViolet(210), 2, LineDashStyle.Dot)},
+    {(LevelKind.VAH, PeriodKind.PrevMonth),    new(CViolet(220), 2, LineDashStyle.Solid)},
+    {(LevelKind.VAH, PeriodKind.Contract),     new(CViolet(200), 2, LineDashStyle.Dot)},
+
+    {(LevelKind.VAL, PeriodKind.CurrentDay),   new(CViolet(220), 2, LineDashStyle.Dash)},
+    {(LevelKind.VAL, PeriodKind.PrevDay),      new(CViolet(235), 3, LineDashStyle.Solid)},
+    {(LevelKind.VAL, PeriodKind.CurrentWeek),  new(CViolet(220), 2, LineDashStyle.Dash)},
+    {(LevelKind.VAL, PeriodKind.PrevWeek),     new(CViolet(235), 3, LineDashStyle.Solid)},
+    {(LevelKind.VAL, PeriodKind.CurrentMonth), new(CViolet(210), 2, LineDashStyle.Dot)},
+    {(LevelKind.VAL, PeriodKind.PrevMonth),    new(CViolet(220), 2, LineDashStyle.Solid)},
+    {(LevelKind.VAL, PeriodKind.Contract),     new(CViolet(200), 2, LineDashStyle.Dot)},
+
+    // ---- High / Low: current day dotted gray; previous day stronger
+    {(LevelKind.High, PeriodKind.CurrentDay),  new(CGrayDim(), 2, LineDashStyle.Dot)},
+    {(LevelKind.Low,  PeriodKind.CurrentDay),  new(CGrayDim(), 2, LineDashStyle.Dot)},
+    {(LevelKind.High, PeriodKind.PrevDay),     new(CGray(),    3, LineDashStyle.Solid)},
+    {(LevelKind.Low,  PeriodKind.PrevDay),     new(CGray(),    3, LineDashStyle.Solid)},
+
+    // Weeks: mirror the same idea but slightly lighter
+    {(LevelKind.High, PeriodKind.CurrentWeek), new(CGrayDim(205), 2, LineDashStyle.Dash)},
+    {(LevelKind.Low,  PeriodKind.CurrentWeek), new(CGrayDim(205), 2, LineDashStyle.Dash)},
+    {(LevelKind.High, PeriodKind.PrevWeek),    new(CGray(220),    2, LineDashStyle.Solid)},
+    {(LevelKind.Low,  PeriodKind.PrevWeek),    new(CGray(220),    2, LineDashStyle.Solid)},
+
+    // EQ / Close / Open: keep neutral/cool, moderate prominence
+    {(LevelKind.EQ,   PeriodKind.CurrentDay),   new(CCyan(230), 2, LineDashStyle.Dash)},
+    {(LevelKind.EQ,   PeriodKind.PrevDay),      new(CCyan(235), 2, LineDashStyle.Solid)},
+    {(LevelKind.Close,PeriodKind.CurrentDay),   new(CGrayDim(210), 2, LineDashStyle.Dot)},
+    {(LevelKind.Open, PeriodKind.CurrentDay),   new(CGrayDim(210), 2, LineDashStyle.Dot)},
+
+    // Fallback references for higher TF / contract
+    {(LevelKind.High, PeriodKind.CurrentMonth), new(CTealCyan(), 2, LineDashStyle.Dot)},
+    {(LevelKind.Low,  PeriodKind.CurrentMonth), new(CTealCyan(), 2, LineDashStyle.Dot)},
+    {(LevelKind.High, PeriodKind.Contract),     new(CTealCyan(), 2, LineDashStyle.Dot)},
+    {(LevelKind.Low,  PeriodKind.Contract),     new(CTealCyan(), 2, LineDashStyle.Dot)},
+    };
+
 
     #endregion
 
@@ -1157,7 +1241,17 @@ public class OHLCPlus : Indicator
     public CrossColor LevelColorVAH { get; set; } = System.Drawing.Color.CornflowerBlue.Convert();
 
     [Display(GroupName = "Colors - By Level", Name = "VAL", Order = 190)]
-    public CrossColor LevelColorVAL { get; set; } = System.Drawing.Color.RoyalBlue.Convert();
+    public CrossColor LevelColorVAL { get; set; } = System.Drawing.Color.Purple.Convert();
+
+    [Display(GroupName = "Colors - Semantic", Name = "Override Color", Order = 210)]
+    public bool SemanticOverrideColor { get; set; } = true;
+
+    [Display(GroupName = "Colors - Semantic", Name = "Override Width", Order = 220)]
+    public bool SemanticOverrideWidth { get; set; } = true;
+
+    [Display(GroupName = "Colors - Semantic", Name = "Override Line Style", Order = 230)]
+    public bool SemanticOverrideStyle { get; set; } = true;
+
     #endregion
 
     #endregion
@@ -1529,9 +1623,22 @@ public class OHLCPlus : Indicator
         }
         // ----------------------------------------------------
 
-        // NEW: resolve color & pen
-        var color = ResolveColor(prefix, suffix, levelSettings);
-        var renderPen = BuildPen(levelSettings, color);
+        // === NEW: style selection ===
+        CrossColor color;
+        RenderPen renderPen;
+
+        if (ColorMode == ColorMode.SemanticMatrix && TryGetSemanticStyle(prefix, suffix, out var vs))
+        {
+            // Use semantic style (override width & dash too)
+            color = vs.Color;
+            renderPen = new PenSettings { Color = color, Width = vs.Width, LineDashStyle = vs.Style }.RenderObject;
+        }
+        else
+        {
+            // Fallback to existing modes (PerLineSettings / ByPeriod / ByLevel)
+            color = ResolveColor(prefix, suffix, levelSettings);
+            renderPen = BuildPen(levelSettings, color);
+        }
 
         // Validate price is reasonable
         if (level.Price <= 0)
@@ -1883,12 +1990,12 @@ public class OHLCPlus : Indicator
                 bands.Add(new HVNBand { Low = runStart.Value, High = lastPriceInRun });
                 runStart = null;
 
-                
+
                 if (isHigh)
                 {
                     runStart = p;
                     lastPriceInRun = p;
-                    gapLeft = HVNGapToleranceTicks; 
+                    gapLeft = HVNGapToleranceTicks;
                 }
                 continue;
             }
@@ -1941,7 +2048,7 @@ public class OHLCPlus : Indicator
 
     private sealed class HVNBand
     {
-        public decimal Low { get; init; }  
+        public decimal Low { get; init; }
         public decimal High { get; init; }
     }
 
@@ -2030,7 +2137,6 @@ public class OHLCPlus : Indicator
                     continue;
                 }
 
-    #endregion
                 // overlap -> split into left/right remainders (if any), keeping tick alignment
                 if (r.Lo > s.Lo)
                     next.Add((s.Lo, Math.Min(s.Hi, r.Lo - tick)));
@@ -2050,6 +2156,95 @@ public class OHLCPlus : Indicator
             .ToList();
     }
 
+    private static PeriodKind MapPeriod(string storagePrefix) => storagePrefix switch
+    {
+        "d" => PeriodKind.CurrentDay,
+        "p" => PeriodKind.PrevDay,
+        "w" => PeriodKind.CurrentWeek,
+        "pw" => PeriodKind.PrevWeek,
+        "m" => PeriodKind.CurrentMonth,
+        "pm" => PeriodKind.PrevMonth,
+        "c" => PeriodKind.Contract,
+        _ => PeriodKind.Other
+    };
+
+    private static LevelKind MapLevel(string suffix) => suffix switch
+    {
+        "Open" => LevelKind.Open,
+        "High" => LevelKind.High,
+        "Low" => LevelKind.Low,
+        "Close" => LevelKind.Close,
+        "EQ" => LevelKind.EQ,
+        "POC" => LevelKind.POC,
+        "VWAP" => LevelKind.VWAP,
+        "VAH" => LevelKind.VAH,
+        "VAL" => LevelKind.VAL,
+        _ => LevelKind.Other
+    };
+
+    // Returns a VisualStyle for (prefix, suffix) or null if no rule exists
+    private bool TryGetSemanticStyle(string storagePrefix, string suffix, out VisualStyle style)
+    {
+        var key = (MapLevel(suffix), MapPeriod(storagePrefix));
+        if (_styleMatrix.TryGetValue(key, out style))
+            return true;
+
+        key = (LevelKind.Other, MapPeriod(storagePrefix));
+        if (_styleMatrix.TryGetValue(key, out style))
+            return true;
+
+        style = null!;
+        return false;
+    }
+
+
+
+    #region SubscribeAllLevels
+
+    private sealed class RefEqComparer : IEqualityComparer<object>
+    {
+        public static readonly RefEqComparer Instance = new();
+        public new bool Equals(object x, object y) => ReferenceEquals(x, y);
+        public int GetHashCode(object obj) => RuntimeHelpers.GetHashCode(obj);
+    }
+
+    private readonly HashSet<LevelSettings> _subscribedLevels = new(RefEqComparer.Instance);
+
+    private void SubscribeAllLevels()
+    {
+        foreach (var ls in EnumerateAllLevelSettings())
+            TrySubscribe(ls);
+    }
+
+    private IEnumerable<LevelSettings> EnumerateAllLevelSettings()
+    {
+        var flags = System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public;
+        foreach (var pi in GetType().GetProperties(flags))
+        {
+            if (pi.PropertyType != typeof(LevelSettings) || !pi.CanRead)
+                continue;
+
+            if (pi.GetValue(this) is LevelSettings ls)
+                yield return ls;
+        }
+    }
+
+    private void TrySubscribe(LevelSettings? ls)
+    {
+        if (ls is null) return;
+        if (_subscribedLevels.Add(ls))
+            ls.PropertyChanged += OnLevelSettingsChanged;
+    }
+
+    private void OnLevelSettingsChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(LevelSettings.Enabled))
+        {
+            RedrawChart();
+            return;
+        }
+    }
+    #endregion
 
 
     #endregion


### PR DESCRIPTION
## OHLC Plus: Add LVN (Low Volume Node) detection and settings

### 🧩 Overview
This PR introduces **Low Volume Node (LVN)** detection to the OHLC Plus indicator. This feature allows users to visualize "voids" or areas of low liquidity within a profile.

The update includes a new "LVN Settings" group in the UI, a hybrid tail filter for accurate detection, and an efficient calculation pass that now processes both HVNs and LVNs simultaneously.

---

### ⚙️ What’s Changed

#### 1️⃣ New "LVN Settings" Group
A new parameter group has been added to control LVN behavior and appearance:
* **`LVNThresholdPct`**: Marks prices with volume *below* this percentage of POC volume as low-volume.
* **`LVNGapToleranceTicks`**: Allows voids to span small gaps of non-LVN prices.
* **`LVNBorderStyle` & `LVNBorderWidth`**: Customizes the "void" rectangle's border.

#### 2️⃣ Hybrid Tail Filter & Noise Reduction
To improve detection accuracy, two new filtering methods are introduced:
* **`MinPocVolForLVN`**: Prevents LVN calculation until the period's POC volume is mature enough, reducing noise at the start of new sessions.
* **Hybrid Tail Filter** (`LVNTailFilter_MinTicks` & `LVNTailFilter_Pct`): An adaptive filter that ignores the extreme highs and lows (tails) of the profile, preventing false voids from being detected in thin-volume areas.

#### 3️⃣ Unified Volume Node Calculation
* The core `UpdateVolumeNodes` method has been refactored to calculate **both HVN and LVN** in a single, efficient pass over the profile's price levels.
* This removes redundant looping and improves performance by sharing state (like `poc`, `tick`, and the price-level list).

#### 4️⃣ LVN "Void" Rendering
* `RenderAllVolumeNodes` is updated to render LVN bands after HVN bands.
* LVNs are rendered as semi-transparent "ghost" fills (using the period's base color with low opacity) and a customizable border.
* This new rendering layer fully respects the existing occlusion logic: higher-priority HVNs will correctly draw *over* (occlude) LVN voids.

#### 5️⃣ Code Health: Comment Translation
* All internal code comments (Spanish) have been translated to English to improve code clarity and future maintainability.

---

### 🧠 Why This Is Better
* ✅ **Identifies Voids:** Users can now visualize critical low-liquidity areas (voids), which are often targets for price movement.
* ✅ **Accurate Detection:** The new tail filter and `MinPocVolForLVN` setting prevent false positives from session starts and single-tick extremes.
* ✅ **Efficient:** Calculating HVN and LVN in a single pass is highly optimized and minimizes the indicator's computational footprint.
* ✅ **Customizable:** Full control over LVN sensitivity and visual style.

---

### 🧪 Testing Notes
1.  **Enable LVN:** Turn on `DayLVNEnabled` and/or `PrevDayLVNEnabled`.
2.  **Observe Voids:** Confirm that areas with volume below the `LVNThresholdPct` are rendered as semi-transparent rectangles (voids).
3.  **Test Tail Filter:** Check that the absolute high and low ticks of the profile are correctly *excluded* from the LVN calculations.
4.  **Test Min POC Vol:** Set `MinPocVolForLVN` to a very high number (e.g., 50000). At the start of a new day, no LVNs should appear. They should only be drawn *after* the `dPOC` volume exceeds this threshold.
5.  **Test Occlusion:** Enable `DayHVNEnabled` and `DayLVNEnabled`. Confirm that where a high-volume node (solid rect) and a low-volume node (void) overlap, the HVN is drawn on top.
6.  **Test Styling:** Change `LVNBorderStyle` (e.g., to `Dot`) and `LVNBorderWidth`. The rendered void borders should update immediately.

---

### 🧰 Implementation Details
* `UpdateVolumeNodes` now uses a parallel state machine logic (one for `hvnRunStart`, one for `lvnRunStart`) within its main loop over `levels`.
* The hybrid filter `effectiveFilterTicks` is calculated as `Math.Max(LVNTailFilter_MinTicks, pctFilterInTicks)`.
* `RenderAllVolumeNodes` now has two distinct rendering loops: first, it renders all HVNs (populating the `claimed` list), and second, it renders all LVNs (using `SubtractClaimed` against the same `claimed` list).
* `RenderLVNBand` helper created, which uses `GhostColor(color, 20)` for the fill and a new `Pen` for the border.

---

### ⚠️ Compatibility
* No breaking changes. This update is additive and fully backward-compatible.

---

### 🖼️ Screenshots
**Day and previous day LVN and HVN**  

<img width="1818" height="866" alt="image" src="https://github.com/user-attachments/assets/6098e6f4-b3f3-4fba-b9a6-5d150958c66e" />

---

**LVN settings in UI**

<img width="322" height="236" alt="image" src="https://github.com/user-attachments/assets/05b123be-b187-4fab-9350-e5623db1cc60" />
