### PR TITLE
Multi market power custom session history

### DIFF
--- a/Technical/MultiMarketPower.cs
+++ b/Technical/MultiMarketPower.cs
@@ -125,11 +125,14 @@ public class MultiMarketPower : Indicator
     private DateTime _historyEndTime = DateTime.MinValue;
     private bool _pendingRealtimeReplay;
 
+    private CrossColor _spreadPositiveColor = CrossColor.FromArgb(255, 0, 255, 0); // Lime
+    private CrossColor _spreadNegativeColor = CrossColor.FromArgb(255, 255, 0, 0); // Red
+
     #endregion
 
     #region Properties
 
-    [Display(GroupName = "Configuración General", Name = "Modo de Visualización", Order = 5)]
+    [Display(GroupName = "General", Name = "View Mode", Order = 5)]
     public ViewMode Mode
     {
         get => _viewMode;
@@ -139,6 +142,20 @@ public class MultiMarketPower : Indicator
             UpdateVisibility();
             RecalculateValues();
         }
+    }
+
+    [Display(GroupName = "General", Name = "Spread Positive Color", Order = 6)]
+    public CrossColor SpreadPositiveColor
+    {
+        get => _spreadPositiveColor;
+        set { _spreadPositiveColor = value; RedrawChart(); }
+    }
+
+    [Display(GroupName = "General", Name = "Spread Negative Color", Order = 7)]
+    public CrossColor SpreadNegativeColor
+    {
+        get => _spreadNegativeColor;
+        set { _spreadNegativeColor = value; RedrawChart(); }
     }
 
     [Display(GroupName = "Session", Name = "Session Mode", Order = 10)]
@@ -682,7 +699,7 @@ public class MultiMarketPower : Indicator
         var spread = smartMoney - dumbMoney;
 
         _spreadSeries[CurrentBar - 1] = spread;
-        _spreadSeries.Colors[CurrentBar - 1] = spread >= 0 ? System.Drawing.Color.Lime : System.Drawing.Color.Red;
+        _spreadSeries.Colors[CurrentBar - 1] = spread >= 0 ? SpreadPositiveColor.Convert() : SpreadNegativeColor.Convert();
 
         RaiseBarValueChanged(CurrentBar - 1);
 		_lastTrade = trade.MemberwiseClone();
@@ -798,7 +815,7 @@ public class MultiMarketPower : Indicator
         var spread = smartMoney - dumbMoney;
 
         _spreadSeries[barIndex] = spread;
-        _spreadSeries.Colors[barIndex] = spread >= 0 ? System.Drawing.Color.Lime : System.Drawing.Color.Red;
+        _spreadSeries.Colors[CurrentBar - 1] = spread >= 0 ? SpreadPositiveColor.Convert() : SpreadNegativeColor.Convert();
 
         RaiseBarValueChanged(barIndex);
     }
@@ -834,7 +851,7 @@ public class MultiMarketPower : Indicator
         var spread = smartMoney - dumbMoney;
 
         _spreadSeries[CurrentBar - 1] = spread;
-        _spreadSeries.Colors[CurrentBar - 1] = spread >= 0 ? System.Drawing.Color.Lime : System.Drawing.Color.Red;
+        _spreadSeries.Colors[CurrentBar - 1] = spread >= 0 ? SpreadPositiveColor.Convert() : SpreadNegativeColor.Convert();
     }
 
 	private bool IsFiltered(decimal minFilter, decimal maxFilter, decimal volume)
@@ -922,7 +939,7 @@ public class MultiMarketPower : Indicator
         var spread = smartMoney - dumbMoney;
 
         _spreadSeries[bar] = spread;
-        _spreadSeries.Colors[bar] = spread >= 0 ? System.Drawing.Color.Lime : System.Drawing.Color.Red;
+        _spreadSeries.Colors[CurrentBar - 1] = spread >= 0 ? SpreadPositiveColor.Convert() : SpreadNegativeColor.Convert();
 
         RaiseBarValueChanged(bar);
 		_lastBar = bar;

--- a/Technical/MultiMarketPower.cs
+++ b/Technical/MultiMarketPower.cs
@@ -73,6 +73,12 @@ public class MultiMarketPower : Indicator
 
     public enum ViewMode { Lines, SmartMoneySpread }
     private ViewMode _viewMode = ViewMode.Lines;
+	public enum SessionMode
+    {
+        None,
+        DefaultSession,
+        CustomSession
+    }
 
     private bool _bigTradesIsReceived;
 	private bool _cumulativeTrades = true;
@@ -112,6 +118,13 @@ public class MultiMarketPower : Indicator
 	private bool _useFilter4 = true;
 	private bool _useFilter5 = true;
 
+    private SessionMode _sessionMode = SessionMode.DefaultSession;
+    private TimeSpan _customSessionStart = new(9, 30, 0); // example
+    private int _sessionsBack = 1;
+    private DateTime _historyStartTime = DateTime.MinValue;
+    private DateTime _historyEndTime = DateTime.MinValue;
+    private bool _pendingRealtimeReplay;
+
     #endregion
 
     #region Properties
@@ -126,6 +139,28 @@ public class MultiMarketPower : Indicator
             UpdateVisibility();
             RecalculateValues();
         }
+    }
+
+    [Display(GroupName = "Session", Name = "Session Mode", Order = 10)]
+    public SessionMode SessionPowerMode
+    {
+        get => _sessionMode;
+        set { _sessionMode = value; RecalculateValues(); }
+    }
+
+    [Display(GroupName = "Session", Name = "Custom Session Start", Order = 20)]
+    public TimeSpan CustomSessionStart
+    {
+        get => _customSessionStart;
+        set { _customSessionStart = value; if (_sessionMode == SessionMode.CustomSession) RecalculateValues(); }
+    }
+
+    [Range(1, 50)]
+    [Display(GroupName = "Session", Name = "Sessions Back", Order = 30)]
+    public int SessionsBack
+    {
+        get => _sessionsBack;
+        set { _sessionsBack = value; RecalculateValues(); }
     }
 
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.CumulativeTrades), GroupName = nameof(Strings.Filters), Description = nameof(Strings.CumulativeTradesModeDescription), Order = 90)]
@@ -443,21 +478,19 @@ public class MultiMarketPower : Indicator
 
         _ticks.Clear();
 		_trades.Clear();
-		var totalBars = CurrentBar - 1;
-		_sessionBegin = totalBars;
-		_lastBar = totalBars;
 
-		for (var i = totalBars; i >= 0; i--)
-		{
-			if (!IsNewSession(i))
-				continue;
+        _sessionBegin = FindSessionBeginBar();
 
-			_sessionBegin = i;
-			break;
-		}
+        _historyStartTime = GetCandle(_sessionBegin).Time;
 
-		var request = new CumulativeTradesRequest(GetCandle(_sessionBegin).Time);
-		_requestId = request.RequestId;
+        // Use the last fully formed bar time window to avoid "moving end" issues.
+        var lastBar = Math.Max(0, CurrentBar - 2);
+        _historyEndTime = GetCandle(lastBar).LastTime;
+
+        _pendingRealtimeReplay = true;
+
+        var request = new CumulativeTradesRequest(_historyStartTime, _historyEndTime, 0, 0);
+        _requestId = request.RequestId;
 		RequestForCumulativeTrades(request);
     }
 	
@@ -467,12 +500,20 @@ public class MultiMarketPower : Indicator
 			return;
 
 		ClearValues();
-		var trades = cumulativeTrades.ToList();
-		
+
+        _bigTradesIsReceived = true;
+
+        var trades = cumulativeTrades?.ToList() ?? new List<CumulativeTrade>();
 		CalculateHistory(trades);
 
-		_bigTradesIsReceived = true;
-	}
+        if (_pendingRealtimeReplay)
+        {
+            ReplayBufferedRealtimeAfterHistory();
+            _pendingRealtimeReplay = false;
+        }
+
+        RedrawChart();
+    }
 
 	protected override void OnNewTrade(MarketDataArg trade)
 	{
@@ -488,9 +529,14 @@ public class MultiMarketPower : Indicator
 		var newBar = _lastBar < CurrentBar - 1;
 
 		if (newBar)
-			_lastBar = CurrentBar - 1;
+        {
+            _lastBar = CurrentBar - 1;
 
-		CalculateTick(trade);
+            if (IsSessionStart(_lastBar))
+                ResetSessionState(_lastBar);
+        }
+
+        CalculateTick(trade);
 	}
 
 	protected override void OnCumulativeTrade(CumulativeTrade trade)
@@ -507,9 +553,14 @@ public class MultiMarketPower : Indicator
 		var newBar = _lastBar < CurrentBar - 1;
 
 		if (newBar)
-			_lastBar = CurrentBar - 1;
+        {
+            _lastBar = CurrentBar - 1;
 
-		CalculateTrade(trade, false, newBar);
+            if (IsSessionStart(_lastBar))
+                ResetSessionState(_lastBar);
+        }
+
+        CalculateTrade(trade, false, newBar);
 	}
 
 	protected override void OnUpdateCumulativeTrade(CumulativeTrade trade)
@@ -527,9 +578,14 @@ public class MultiMarketPower : Indicator
 		var newBar = _lastBar < CurrentBar - 1;
 
 		if (newBar)
-			_lastBar = CurrentBar - 1;
+        {
+            _lastBar = CurrentBar - 1;
 
-		CalculateTrade(trade, true, newBar);
+            if (IsSessionStart(_lastBar))
+                ResetSessionState(_lastBar);
+        }
+
+        CalculateTrade(trade, true, newBar);
 	}
 
 	#endregion
@@ -645,9 +701,14 @@ public class MultiMarketPower : Indicator
 				trades = trades.OrderBy(t => t.Time).ToList();
                 
 				for (var i = _sessionBegin; i <= CurrentBar - 1; i++)
-					CalculateBarTrades(trades, i, ref searchIdx);
+                {
+                    if (IsSessionStart(i))
+                        ResetSessionState(i);
 
-				foreach (var trade in _trades)
+                    CalculateBarTrades(trades, i, ref searchIdx);
+                }
+
+                foreach (var trade in _trades)
 					CalculateTrade(trade, false, false);
 			}
 			else
@@ -658,7 +719,12 @@ public class MultiMarketPower : Indicator
 					.ToList();
 
 				for (var i = _sessionBegin; i <= CurrentBar - 1; i++)
-					CalculateBarTicks(ticks, i, ref searchIdx);
+                {
+                    if (IsSessionStart(i))
+                        ResetSessionState(i);
+
+                    CalculateBarTicks(ticks, i, ref searchIdx);
+                }
 
 				foreach (var tick in _ticks)
 					CalculateTick(tick);
@@ -879,6 +945,99 @@ public class MultiMarketPower : Indicator
             _spreadSeries.VisualType = VisualMode.Hide;
         }
     }
+
+    private bool IsSessionStart(int bar)
+    {
+        switch (_sessionMode)
+        {
+            case SessionMode.None:
+                return bar == 0;
+
+            case SessionMode.DefaultSession:
+                return IsNewSession(bar);
+
+            case SessionMode.CustomSession:
+                if (bar == 0)
+                    return true;
+
+                var candle = GetCandle(bar);
+                var prev = GetCandle(bar - 1);
+
+                // Use the same timezone normalization pattern as CumulativeDelta
+                var tz = InstrumentInfo.TimeZone;
+                return prev.Time.AddHours(tz).TimeOfDay < _customSessionStart
+                    && candle.Time.AddHours(tz).TimeOfDay >= _customSessionStart;
+
+            default:
+                return false;
+        }
+    }
+
+    private int FindSessionBeginBar()
+    {
+        var totalBars = CurrentBar - 1;
+        if (totalBars < 0)
+            return 0;
+
+        // If SessionMode.None, start from bar 0 (or allow SessionsBack to still work: typically no)
+        if (_sessionMode == SessionMode.None)
+            return 0;
+
+        var found = 0;
+
+        for (var i = totalBars; i >= 0; i--)
+        {
+            if (!IsSessionStart(i))
+                continue;
+
+            found++;
+            if (found >= _sessionsBack)
+                return i;
+        }
+
+        // Not enough sessions in history; fall back to earliest bar
+        return 0;
+    }
+
+    private void ResetSessionState(int bar)
+    {
+        // Reset running deltas
+        _delta1 = _delta2 = _delta3 = _delta4 = _delta5 = 0m;
+
+        // Also reset “last per bar” deltas to avoid carry in CalculateBarTrades realtime branch
+        _lastDelta1 = _lastDelta2 = _lastDelta3 = _lastDelta4 = _lastDelta5 = 0m;
+
+        // Initialize series values at session start (optional but helps avoid gaps)
+        _filter1Series[bar] = 0m;
+        _filter2Series[bar] = 0m;
+        _filter3Series[bar] = 0m;
+        _filter4Series[bar] = 0m;
+        _filter5Series[bar] = 0m;
+        _spreadSeries[bar] = 0m;
+    }
+
+    private void ReplayBufferedRealtimeAfterHistory()
+    {
+        // Replay cumulative trades that arrived AFTER the historical request end
+        foreach (var ct in _trades)
+        {
+            if (ct.Time > _historyEndTime)
+                CalculateTrade(ct, isUpdate: false, newBar: false);
+        }
+
+        // Replay ticks that arrived AFTER the historical request end
+        foreach (var t in _ticks)
+        {
+            if (t.Time > _historyEndTime)
+                CalculateTick(t);
+        }
+
+        _trades.Clear();
+        _ticks.Clear();
+    }
+
+
+
 
     #endregion
 }

--- a/Technical/MultiMarketPower.cs
+++ b/Technical/MultiMarketPower.cs
@@ -63,7 +63,18 @@ public class MultiMarketPower : Indicator
 		UseMinimizedModeIfEnabled = true
 	};
 
-	private bool _bigTradesIsReceived;
+    private readonly ValueDataSeries _spreadSeries = new("SpreadSeries", "Smart Money Spread")
+    {
+        VisualType = VisualMode.Histogram,
+        Width = 3,
+        UseMinimizedModeIfEnabled = true,
+        ShowZeroValue = true // Importante para ver el eje 0
+    };
+
+    public enum ViewMode { Lines, SmartMoneySpread }
+    private ViewMode _viewMode = ViewMode.Lines;
+
+    private bool _bigTradesIsReceived;
 	private bool _cumulativeTrades = true;
 	private decimal _delta1;
 	private decimal _delta2;
@@ -101,11 +112,23 @@ public class MultiMarketPower : Indicator
 	private bool _useFilter4 = true;
 	private bool _useFilter5 = true;
 
-	#endregion
+    #endregion
 
-	#region Properties
+    #region Properties
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.CumulativeTrades), GroupName = nameof(Strings.Filters), Description = nameof(Strings.CumulativeTradesModeDescription), Order = 90)]
+    [Display(GroupName = "Configuración General", Name = "Modo de Visualización", Order = 5)]
+    public ViewMode Mode
+    {
+        get => _viewMode;
+        set
+        {
+            _viewMode = value;
+            UpdateVisibility();
+            RecalculateValues();
+        }
+    }
+
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.CumulativeTrades), GroupName = nameof(Strings.Filters), Description = nameof(Strings.CumulativeTradesModeDescription), Order = 90)]
 	[PostValueMode(PostValueModes.Delayed, DelayMilliseconds = 500)]
 	public bool CumulativeTrades
 	{
@@ -124,8 +147,8 @@ public class MultiMarketPower : Indicator
 		set
 		{
 			_useFilter1 = value;
-			_filter1Series.VisualType = value ? VisualMode.Line : VisualMode.Hide;
-		}
+            UpdateVisibility();
+        }
 	}
 
 	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.MinimumVolume), GroupName = nameof(Strings.Filter1), Description = nameof(Strings.MinVolumeFilterCommonDescription), Order = 130)]
@@ -176,8 +199,8 @@ public class MultiMarketPower : Indicator
 		set
 		{
 			_useFilter2 = value;
-			_filter2Series.VisualType = value ? VisualMode.Line : VisualMode.Hide;
-		}
+            UpdateVisibility();
+        }
 	}
 
 	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.MinimumVolume), GroupName = nameof(Strings.Filter2), Description = nameof(Strings.MinVolumeFilterCommonDescription), Order = 230)]
@@ -228,8 +251,8 @@ public class MultiMarketPower : Indicator
 		set
 		{
 			_useFilter3 = value;
-			_filter3Series.VisualType = value ? VisualMode.Line : VisualMode.Hide;
-		}
+            UpdateVisibility();
+        }
 	}
 
 	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.MinimumVolume), GroupName = nameof(Strings.Filter3), Description = nameof(Strings.MinVolumeFilterCommonDescription), Order = 330)]
@@ -280,8 +303,8 @@ public class MultiMarketPower : Indicator
 		set
 		{
 			_useFilter4 = value;
-			_filter4Series.VisualType = value ? VisualMode.Line : VisualMode.Hide;
-		}
+            UpdateVisibility();
+        }
 	}
 
 	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.MinimumVolume), GroupName = nameof(Strings.Filter4), Description = nameof(Strings.MinVolumeFilterCommonDescription), Order = 430)]
@@ -332,7 +355,7 @@ public class MultiMarketPower : Indicator
 		set
 		{
 			_useFilter5 = value;
-			_filter5Series.VisualType = value ? VisualMode.Line : VisualMode.Hide;
+			UpdateVisibility();
 		}
 	}
 
@@ -392,7 +415,11 @@ public class MultiMarketPower : Indicator
 		DataSeries.Add(_filter3Series);
 		DataSeries.Add(_filter4Series);
 		DataSeries.Add(_filter5Series);
-	}
+
+        DataSeries.Add(_spreadSeries);
+
+        UpdateVisibility();
+    }
 
 	#endregion
 
@@ -592,7 +619,15 @@ public class MultiMarketPower : Indicator
 		_filter4Series[CurrentBar - 1] = _delta4;
 		_filter5Series[CurrentBar - 1] = _delta5;
 
-		RaiseBarValueChanged(CurrentBar - 1);
+        // Smart Money (4+5) - Dumb Money (1+2)
+        var smartMoney = _delta4 + _delta5;
+        var dumbMoney = _delta1 + _delta2;
+        var spread = smartMoney - dumbMoney;
+
+        _spreadSeries[CurrentBar - 1] = spread;
+        _spreadSeries.Colors[CurrentBar - 1] = spread >= 0 ? System.Drawing.Color.Lime : System.Drawing.Color.Red;
+
+        RaiseBarValueChanged(CurrentBar - 1);
 		_lastTrade = trade.MemberwiseClone();
 	}
 
@@ -686,7 +721,14 @@ public class MultiMarketPower : Indicator
 		_filter4Series[i] = _delta4;
 		_filter5Series[i] = _delta5;
 
-		RaiseBarValueChanged(i);
+        var smartMoney = _delta4 + _delta5;
+        var dumbMoney = _delta1 + _delta2;
+        var spread = smartMoney - dumbMoney;
+
+        _spreadSeries[i] = spread; // Estaba puesto [CurrentBar - 1]
+        _spreadSeries.Colors[i] = spread >= 0 ? System.Drawing.Color.Lime : System.Drawing.Color.Red;
+
+        RaiseBarValueChanged(i);
 	}
 
 	private void CalculateTick(MarketDataArg tick)
@@ -713,7 +755,15 @@ public class MultiMarketPower : Indicator
 		_filter3Series[^1] = _delta3;
 		_filter4Series[^1] = _delta4;
 		_filter5Series[^1] = _delta5;
-	}
+
+        // Smart Money (4+5) - Dumb Money (1+2)
+        var smartMoney = _delta4 + _delta5;
+        var dumbMoney = _delta1 + _delta2;
+        var spread = smartMoney - dumbMoney;
+
+        _spreadSeries[CurrentBar - 1] = spread;
+        _spreadSeries.Colors[CurrentBar - 1] = spread >= 0 ? System.Drawing.Color.Lime : System.Drawing.Color.Red;
+    }
 
 	private bool IsFiltered(decimal minFilter, decimal maxFilter, decimal volume)
 	{
@@ -794,9 +844,41 @@ public class MultiMarketPower : Indicator
 
 		_filter5Series[bar] = _delta5;
 
-		RaiseBarValueChanged(bar);
+        // Smart Money (4+5) - Dumb Money (1+2)
+        var smartMoney = _delta4 + _delta5;
+        var dumbMoney = _delta1 + _delta2;
+        var spread = smartMoney - dumbMoney;
+
+        _spreadSeries[bar] = spread;
+        _spreadSeries.Colors[bar] = spread >= 0 ? System.Drawing.Color.Lime : System.Drawing.Color.Red;
+
+        RaiseBarValueChanged(bar);
 		_lastBar = bar;
 	}
 
-	#endregion
+    private void UpdateVisibility()
+    {
+        if (_viewMode == ViewMode.SmartMoneySpread)
+        {
+            // Ocultar líneas individuales, mostrar Spread
+            _filter1Series.VisualType = VisualMode.Hide;
+            _filter2Series.VisualType = VisualMode.Hide;
+            _filter3Series.VisualType = VisualMode.Hide;
+            _filter4Series.VisualType = VisualMode.Hide;
+            _filter5Series.VisualType = VisualMode.Hide;
+            _spreadSeries.VisualType = VisualMode.Histogram;
+        }
+        else
+        {
+            // Restaurar visualización basada en los checkboxes individuales
+            _filter1Series.VisualType = _useFilter1 ? VisualMode.Line : VisualMode.Hide;
+            _filter2Series.VisualType = _useFilter2 ? VisualMode.Line : VisualMode.Hide;
+            _filter3Series.VisualType = _useFilter3 ? VisualMode.Line : VisualMode.Hide;
+            _filter4Series.VisualType = _useFilter4 ? VisualMode.Line : VisualMode.Hide;
+            _filter5Series.VisualType = _useFilter5 ? VisualMode.Line : VisualMode.Hide;
+            _spreadSeries.VisualType = VisualMode.Hide;
+        }
+    }
+
+    #endregion
 }

--- a/Technical/MultiMarketPower.cs
+++ b/Technical/MultiMarketPower.cs
@@ -815,7 +815,7 @@ public class MultiMarketPower : Indicator
         var spread = smartMoney - dumbMoney;
 
         _spreadSeries[barIndex] = spread;
-        _spreadSeries.Colors[CurrentBar - 1] = spread >= 0 ? SpreadPositiveColor.Convert() : SpreadNegativeColor.Convert();
+        _spreadSeries.Colors[barIndex] = spread >= 0 ? SpreadPositiveColor.Convert() : SpreadNegativeColor.Convert();
 
         RaiseBarValueChanged(barIndex);
     }
@@ -939,7 +939,7 @@ public class MultiMarketPower : Indicator
         var spread = smartMoney - dumbMoney;
 
         _spreadSeries[bar] = spread;
-        _spreadSeries.Colors[CurrentBar - 1] = spread >= 0 ? SpreadPositiveColor.Convert() : SpreadNegativeColor.Convert();
+        _spreadSeries.Colors[bar] = spread >= 0 ? SpreadPositiveColor.Convert() : SpreadNegativeColor.Convert();
 
         RaiseBarValueChanged(bar);
 		_lastBar = bar;

--- a/Technical/MultiMarketPower.cs
+++ b/Technical/MultiMarketPower.cs
@@ -474,7 +474,9 @@ public class MultiMarketPower : Indicator
 	
 	protected override void OnFinishRecalculate()
 	{
-		_bigTradesIsReceived = false;
+		UpdateVisibility();
+
+        _bigTradesIsReceived = false;
 
         _ticks.Clear();
 		_trades.Clear();
@@ -594,7 +596,6 @@ public class MultiMarketPower : Indicator
 
 	private void ClearValues()
 	{
-		_bigTradesIsReceived = false;
 		DataSeries.ForEach(x => x.Clear());
 		_delta1 = _delta2 = _delta3 = _delta4 = _delta5 = 0;
 	}
@@ -708,8 +709,6 @@ public class MultiMarketPower : Indicator
                     CalculateBarTrades(trades, i, ref searchIdx);
                 }
 
-                foreach (var trade in _trades)
-					CalculateTrade(trade, false, false);
 			}
 			else
 			{
@@ -726,8 +725,6 @@ public class MultiMarketPower : Indicator
                     CalculateBarTicks(ticks, i, ref searchIdx);
                 }
 
-				foreach (var tick in _ticks)
-					CalculateTick(tick);
 			}
 
 			RedrawChart();
@@ -738,66 +735,75 @@ public class MultiMarketPower : Indicator
 		}
 	}
 
-	private void CalculateBarTicks(List<MarketDataArg> trades, int i, ref int searchIdx)
-	{
-		var candle = GetCandle(i);
+    private void CalculateBarTicks(List<MarketDataArg> trades, int barIndex, ref int searchIdx)
+    {
+        var candle = GetCandle(barIndex);
 
-		var candleTrades = new List<MarketDataArg>();
+        var candleTrades = new List<MarketDataArg>();
 
-		for (var bar = searchIdx; bar < trades.Count; bar++)
-		{
-			var trade = trades[bar];
-			searchIdx = bar;
-            
-			if (trade.Direction is TradeDirection.Between)
-				continue;
+        for (var idx = searchIdx; idx < trades.Count; idx++)
+        {
+            var trade = trades[idx];
 
-			if (trade.Time > candle.LastTime)
-				break;
+            if (trade.Direction is TradeDirection.Between)
+                continue;
 
-			if (trade.Time < candle.Time)
-				continue;
+            // If trade is after this candle, stop here and keep cursor at the first non-consumed index.
+            if (trade.Time > candle.LastTime)
+            {
+                searchIdx = idx;
+                break;
+            }
 
-			candleTrades.Add(trade);
-		}
+            // If trade is before this candle, advance cursor and keep scanning.
+            if (trade.Time < candle.Time)
+            {
+                searchIdx = idx;
+                continue;
+            }
+
+            // Trade belongs to this candle.
+            candleTrades.Add(trade);
+            searchIdx = idx;
+        }
 
         foreach (var tick in candleTrades)
-		{
-			var deltaVolume = tick.Volume * (tick.Direction is TradeDirection.Buy ? 1 : -1);
+        {
+            var deltaVolume = tick.Volume * (tick.Direction is TradeDirection.Buy ? 1 : -1);
 
-			if (IsFiltered(MinVolume1, MaxVolume1, tick.Volume))
-				_delta1 += deltaVolume;
+            if (IsFiltered(MinVolume1, MaxVolume1, tick.Volume))
+                _delta1 += deltaVolume;
 
-			if (IsFiltered(MinVolume2, MaxVolume2, tick.Volume))
-				_delta2 += deltaVolume;
+            if (IsFiltered(MinVolume2, MaxVolume2, tick.Volume))
+                _delta2 += deltaVolume;
 
-			if (IsFiltered(MinVolume3, MaxVolume3, tick.Volume))
-				_delta3 += deltaVolume;
+            if (IsFiltered(MinVolume3, MaxVolume3, tick.Volume))
+                _delta3 += deltaVolume;
 
-			if (IsFiltered(MinVolume4, MaxVolume4, tick.Volume))
-				_delta4 += deltaVolume;
+            if (IsFiltered(MinVolume4, MaxVolume4, tick.Volume))
+                _delta4 += deltaVolume;
 
-			if (IsFiltered(MinVolume5, MaxVolume5, tick.Volume))
-				_delta5 += deltaVolume;
-		}
+            if (IsFiltered(MinVolume5, MaxVolume5, tick.Volume))
+                _delta5 += deltaVolume;
+        }
 
-		_filter1Series[i] = _delta1;
-		_filter2Series[i] = _delta2;
-		_filter3Series[i] = _delta3;
-		_filter4Series[i] = _delta4;
-		_filter5Series[i] = _delta5;
+        _filter1Series[barIndex] = _delta1;
+        _filter2Series[barIndex] = _delta2;
+        _filter3Series[barIndex] = _delta3;
+        _filter4Series[barIndex] = _delta4;
+        _filter5Series[barIndex] = _delta5;
 
         var smartMoney = _delta4 + _delta5;
         var dumbMoney = _delta1 + _delta2;
         var spread = smartMoney - dumbMoney;
 
-        _spreadSeries[i] = spread; // Estaba puesto [CurrentBar - 1]
-        _spreadSeries.Colors[i] = spread >= 0 ? System.Drawing.Color.Lime : System.Drawing.Color.Red;
+        _spreadSeries[barIndex] = spread;
+        _spreadSeries.Colors[barIndex] = spread >= 0 ? System.Drawing.Color.Lime : System.Drawing.Color.Red;
 
-        RaiseBarValueChanged(i);
-	}
+        RaiseBarValueChanged(barIndex);
+    }
 
-	private void CalculateTick(MarketDataArg tick)
+    private void CalculateTick(MarketDataArg tick)
 	{
 		var deltaVolume = tick.Volume * (tick.Direction is TradeDirection.Buy ? 1 : -1);
 


### PR DESCRIPTION
### Title
MultiMarketPower: session controls and multi-session cumulative trades history

---

### Summary
This PR extends **MultiMarketPower** with session-aware accumulation and reliable multi-session historical reconstruction.

The indicator can now:
- Reset values at session boundaries (default exchange sessions or a custom start time).
- Display previous sessions via `SessionsBack`.
- Rebuild historical data using a cumulative trades **time-range request**, enabling consistent multi-session behavior.

In addition, the PR includes small stability and UX improvements identified while implementing the session logic.

---

### Why
Previously, MultiMarketPower effectively evaluated only the current session because the cumulative trades request was session-scoped.  
When `SessionsBack > 1`, historical bars outside that session remained flat, while realtime updates continued.

Switching to a time-range cumulative trades request resolves this limitation and allows consistent reconstruction across multiple sessions, both in historical and realtime contexts.

---

### Key Changes

#### Session & Historical Logic
- Added session-related parameters:
  - Session mode: `None` / `Default Session` / `Custom Session Start`
  - Custom session start time
  - `SessionsBack`
- Introduced a unified session boundary detector used in both historical rebuild and realtime updates.
- Switched cumulative trades requests to a `(startTime, endTime)` range.
- Reset internal state at session boundaries during history rebuild and on realtime new-bar transitions.

#### Stability & Correctness
- Fixed tick-history cursor handling to ensure correct index progression when rebuilding history in tick-based mode.
- Removed unintended state mutation from internal clear/reset routines.
- Ensured visual series visibility is restored consistently after recalculation.
- Fixed incorrect bar indexing when assigning Smart Money Spread colors during historical rebuild.

#### UX Improvements
- Made Smart Money Spread positive/negative colors configurable instead of hardcoded.
- Normalized UI display names to English for public repository consistency.

---

### Testing
- `SessionMode = None`: continuous accumulation across the loaded chart range.
- `SessionMode = Default, SessionsBack = 1`: current session only.
- `SessionMode = Default, SessionsBack = 2+`: multiple sessions rendered, each reset at its session boundary.
- `SessionMode = Custom`: values reset exactly at the configured session start time.
- Verified correct behavior in both bar-based and cumulative-trade-based modes.

---

### Screenshots

**1) Session Mode = None**

<img width="1603" height="271" alt="Session Mode None" src="https://github.com/user-attachments/assets/800ff69c-7a92-42c7-b17d-412b946b7695" />

**2) Session Mode = Default, SessionsBack = 2**

<img width="1586" height="272" alt="Default Session, SessionsBack 2" src="https://github.com/user-attachments/assets/e723e6d6-4048-44b5-bacf-7f37bc576a6a" />

**3) Session Mode = Custom (09:30)**

<img width="1594" height="273" alt="Custom Session Start 09:30" src="https://github.com/user-attachments/assets/63103950-6f9e-4650-a17a-0931e77e0fec" />
