### PR TITLE
Feature/account info trade snapshot and per-trade max open PnL reset (stacked on #142)

### DIFF
--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -1,17 +1,16 @@
 namespace ATAS.Indicators.Technical;
 
-using System;
-using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
-using System.Drawing;
-using System.Text;
-
 using ATAS.DataFeedsCore;
-
 using OFT.Attributes;
 using OFT.Localization;
 using OFT.Rendering.Context;
 using OFT.Rendering.Tools;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Drawing;
+using System.Text;
 
 /// <summary>
 /// Displays account information on the chart including account ID, balance, blocked margin, available balance, and PnL.
@@ -22,9 +21,29 @@ using OFT.Rendering.Tools;
 [Display(ResourceType = typeof(Strings), Description = nameof(Strings.AccountInfoDisplayDescription))]
 public class AccountInfoDisplay : Indicator
 {
-	#region Fields
+    #region class
+    private sealed class DisplayRow
+    {
+        public string Label { get; }
+        public string ValueText { get; }
 
-	private Color _backgroundColor = Color.FromArgb(200, 20, 25, 35);
+        // Not used yet in Phase 0 (kept for Phase 1/2).
+        public decimal? NumericValue { get; }
+        public CrossColor? ValueColorOverride { get; }
+
+        public DisplayRow(string label, string valueText, decimal? numericValue = null, CrossColor? valueColorOverride = null)
+        {
+            Label = label ?? string.Empty;
+            ValueText = valueText ?? string.Empty;
+            NumericValue = numericValue;
+            ValueColorOverride = valueColorOverride;
+        }
+    }
+    #endregion
+
+    #region Fields
+
+    private Color _backgroundColor = Color.FromArgb(200, 20, 25, 35);
 	private Color _textColor = Color.FromArgb(220, 220, 220);
 	private Color _positiveColor = Color.FromArgb(0, 230, 118);
 	private Color _negativeColor = Color.FromArgb(255, 82, 82);
@@ -208,150 +227,175 @@ public class AccountInfoDisplay : Indicator
 		// No calculation needed
 	}
 
-	protected override void OnRender(RenderContext context, DrawingLayouts layout)
-	{
-		if (ChartInfo == null || Container?.Region == null)
-			return;
+    protected override void OnRender(RenderContext context, DrawingLayouts layout)
+    {
+        if (ChartInfo == null || Container?.Region == null)
+            return;
 
-		// Get current portfolio
-		var portfolio = _currentPortfolio ?? TradingManager?.Portfolio;
-		if (portfolio == null)
-			return;
+        // Get current portfolio
+        var portfolio = _currentPortfolio ?? TradingManager?.Portfolio;
+        if (portfolio == null)
+            return;
 
-		// Build display text
-		var text = BuildDisplayText(portfolio);
-		if (string.IsNullOrEmpty(text))
-			return;
+        // Build structured rows (Phase 0 replacement)
+        var rows = BuildRows(portfolio);
+        if (rows == null || rows.Count == 0)
+            return;
 
-		// Calculate proper dimensions for table layout
-		var lines = text.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
-		var lineHeight = context.MeasureString("A", _font).Height;
+        // Calculate proper dimensions for table layout
+        var lineHeight = context.MeasureString("A", _font).Height;
 
-		var maxLabelWidth = 0;
-		var maxValueWidth = 0;
+        var maxLabelWidth = 0;
+        var maxValueWidth = 0;
 
-		foreach (var line in lines)
-		{
-			var parts = line.Split('|');
-			if (parts.Length == 2)
-			{
-				var labelWidth = (int)context.MeasureString(parts[0], _font).Width;
-				var valueWidth = (int)context.MeasureString(parts[1], _font).Width;
+        foreach (var row in rows)
+        {
+            var labelWidth = (int)context.MeasureString(row.Label, _font).Width;
+            var valueWidth = (int)context.MeasureString(row.ValueText, _font).Width;
 
-				if (labelWidth > maxLabelWidth)
-					maxLabelWidth = labelWidth;
-				if (valueWidth > maxValueWidth)
-					maxValueWidth = valueWidth;
-			}
-		}
+            if (labelWidth > maxLabelWidth)
+                maxLabelWidth = labelWidth;
 
-		var padding = 10;
-		var rectWidth = maxLabelWidth + ColumnSpacing + maxValueWidth + padding * 2;
-		var rectHeight = lines.Length * lineHeight + padding * 2;
+            if (valueWidth > maxValueWidth)
+                maxValueWidth = valueWidth;
+        }
 
-		// Calculate position
-		var x = CalculateXPosition(rectWidth);
-		var y = CalculateYPosition(rectHeight);
+        var padding = 10;
+        var rectWidth = maxLabelWidth + ColumnSpacing + maxValueWidth + padding * 2;
+        var rectHeight = rows.Count * lineHeight + padding * 2;
 
-		// Draw background
-		var rectangle = new Rectangle(x, y, rectWidth, rectHeight);
-		context.FillRectangle(_backgroundColor, rectangle);
+        // Calculate position
+        var x = CalculateXPosition(rectWidth);
+        var y = CalculateYPosition(rectHeight);
 
-		// Draw border
-		context.DrawRectangle(new RenderPen(Color.Gray, 1), rectangle);
+        // Draw background
+        var rectangle = new Rectangle(x, y, rectWidth, rectHeight);
+        context.FillRectangle(_backgroundColor, rectangle);
 
-		// Draw text
-		var textRect = new Rectangle(x + padding, y + padding, rectWidth - padding * 2, rectHeight - padding * 2);
-		DrawColoredText(context, text, textRect, portfolio, maxLabelWidth);
-	}
+        // Draw border
+        context.DrawRectangle(new RenderPen(Color.Gray, 1), rectangle);
 
-	#endregion
+        // Draw text (keep existing coloring logic for Phase 0)
+        var textRect = new Rectangle(
+            x + padding,
+            y + padding,
+            rectWidth - padding * 2,
+            rectHeight - padding * 2
+        );
 
-	#region Private Methods
+        DrawColoredRows(context, rows, textRect, portfolio, maxLabelWidth);
+    }
 
-	private void OnPortfolioSelected(Portfolio portfolio)
+    #endregion
+
+    #region Private Methods
+
+    private void OnPortfolioSelected(Portfolio portfolio)
 	{
 		_currentPortfolio = portfolio;
 		RedrawChart();
 	}
 
-	private string BuildDisplayText(Portfolio portfolio)
-	{
-		var sb = new StringBuilder();
+    private List<DisplayRow> BuildRows(Portfolio portfolio)
+    {
+        var rows = new List<DisplayRow>();
 
-		if (ShowAccountId)
-			sb.AppendLine($"Account|{portfolio.AccountID}");
+        if (portfolio == null)
+            return rows;
 
-		if (ShowCurrency && portfolio.Currency.HasValue)
-			sb.AppendLine($"Currency|{portfolio.Currency}");
+        if (ShowAccountId)
+            rows.Add(new DisplayRow(
+                "Account",
+                portfolio.AccountID
+            ));
 
-		if (ShowBalance)
-			sb.AppendLine($"Balance|{FormatCurrency(portfolio.Balance)}");
+        if (ShowCurrency && portfolio.Currency.HasValue)
+            rows.Add(new DisplayRow(
+                "Currency",
+                portfolio.Currency.Value.ToString()
+            ));
 
-		if (ShowAvailableBalance && portfolio.BalanceAvailable.HasValue)
-			sb.AppendLine($"Available|{FormatCurrency(portfolio.BalanceAvailable.Value)}");
+        if (ShowBalance)
+            rows.Add(new DisplayRow(
+                "Balance",
+                FormatCurrency(portfolio.Balance)
+            ));
 
-		if (ShowMargin)
-			sb.AppendLine($"Blocked Margin|{FormatCurrency(portfolio.BlockedMargin)}");
+        if (ShowAvailableBalance && portfolio.BalanceAvailable.HasValue)
+            rows.Add(new DisplayRow(
+                "Available",
+                FormatCurrency(portfolio.BalanceAvailable.Value)
+            ));
 
-		if (ShowLeverage && portfolio.Leverage != 1)
-			sb.AppendLine($"Leverage|{portfolio.Leverage:F2}x");
+        if (ShowMargin)
+            rows.Add(new DisplayRow(
+                "Blocked Margin",
+                FormatCurrency(portfolio.BlockedMargin)
+            ));
 
-		if (ShowOpenPnL)
-			sb.AppendLine($"Open PnL|{FormatCurrency(portfolio.OpenPnL)}");
+        if (ShowLeverage && portfolio.Leverage != 1)
+            rows.Add(new DisplayRow(
+                "Leverage",
+                $"{portfolio.Leverage:F2}x"
+            ));
 
-		if (ShowClosedPnL)
-			sb.AppendLine($"Closed PnL|{FormatCurrency(portfolio.ClosedPnL)}");
+        if (ShowOpenPnL)
+            rows.Add(new DisplayRow(
+                "Open PnL",
+                FormatCurrency(portfolio.OpenPnL)
+            ));
 
-		if (ShowTotalPnL)
-			sb.AppendLine($"Total PnL|{FormatCurrency(portfolio.ClosedPnL + portfolio.OpenPnL)}");
+        if (ShowClosedPnL)
+            rows.Add(new DisplayRow(
+                "Closed PnL",
+                FormatCurrency(portfolio.ClosedPnL)
+            ));
 
-		return sb.ToString().TrimEnd();
-	}
+        if (ShowTotalPnL)
+            rows.Add(new DisplayRow(
+                "Total PnL",
+                FormatCurrency(portfolio.ClosedPnL + portfolio.OpenPnL)
+            ));
 
-	private void DrawColoredText(RenderContext context, string text, Rectangle textRect, Portfolio portfolio, int maxLabelWidth)
-	{
-		var lines = text.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
-		var lineHeight = context.MeasureString("A", _font).Height;
+        return rows;
+    }
 
-		// Calculate value column position
-		var valueColumnX = textRect.X + maxLabelWidth + ColumnSpacing;
-		var currentY = textRect.Y;
+    private void DrawColoredRows(RenderContext context, List<DisplayRow> rows, Rectangle textRect, Portfolio portfolio, int maxLabelWidth)
+    {
+        var lineHeight = context.MeasureString("A", _font).Height;
 
-		// Draw lines
-		foreach (var line in lines)
-		{
-			var parts = line.Split('|');
-			if (parts.Length == 2)
-			{
-				var label = parts[0];
-				var valueStr = parts[1];
+        // Calculate value column position
+        var valueColumnX = textRect.X + maxLabelWidth + ColumnSpacing;
+        var currentY = textRect.Y;
 
-				// Draw label
-				context.DrawString(label, _font, _textColor, textRect.X, currentY);
+        foreach (var row in rows)
+        {
+            var label = row?.Label ?? string.Empty;
+            var valueStr = row?.ValueText ?? string.Empty;
 
-				// Determine color for value
-				var valueColor = _textColor;
-				if (line.Contains("PnL"))
-				{
-					var value = ExtractNumericValue(valueStr);
-					valueColor = value > 0 ? _positiveColor : (value < 0 ? _negativeColor : _neutralColor);
-				}
+            // Draw label
+            context.DrawString(label, _font, _textColor, textRect.X, currentY);
 
-				// Draw value
-				context.DrawString(valueStr, _font, valueColor, valueColumnX, currentY);
-			}
-			else
-			{
-				// Fallback for malformed lines
-				context.DrawString(line, _font, _textColor, textRect.X, currentY);
-			}
+            // Determine color for value (Phase 0: keep current behavior)
+            var valueColor = _textColor;
 
-			currentY += lineHeight;
-		}
-	}
+            // Replace old `line.Contains("PnL")` with label check, preserving the intent.
+            if (label.Contains("PnL", StringComparison.OrdinalIgnoreCase))
+            {
+                var value = ExtractNumericValue(valueStr);
+                valueColor = value > 0
+                    ? _positiveColor
+                    : (value < 0 ? _negativeColor : _neutralColor);
+            }
 
-	private decimal ExtractNumericValue(string valueStr)
+            // Draw value
+            context.DrawString(valueStr, _font, valueColor, valueColumnX, currentY);
+
+            currentY += lineHeight;
+        }
+    }
+
+    private decimal ExtractNumericValue(string valueStr)
 	{
 		// Remove currency symbols and try to parse
 		var cleanStr = valueStr.Replace(",", "").Trim();

--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -10,7 +10,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Drawing;
-using System.Text;
 
 /// <summary>
 /// Displays account information on the chart including account ID, balance, blocked margin, available balance, and PnL.
@@ -342,20 +341,27 @@ public class AccountInfoDisplay : Indicator
         if (ShowOpenPnL)
             rows.Add(new DisplayRow(
                 "Open PnL",
-                FormatCurrency(portfolio.OpenPnL)
+                FormatCurrency(portfolio.OpenPnL),
+                numericValue: portfolio.OpenPnL
             ));
 
         if (ShowClosedPnL)
             rows.Add(new DisplayRow(
                 "Closed PnL",
-                FormatCurrency(portfolio.ClosedPnL)
+                FormatCurrency(portfolio.ClosedPnL),
+                numericValue: portfolio.ClosedPnL
             ));
 
         if (ShowTotalPnL)
+        {
+            var totalPnL = portfolio.ClosedPnL + portfolio.OpenPnL;
+
             rows.Add(new DisplayRow(
                 "Total PnL",
-                FormatCurrency(portfolio.ClosedPnL + portfolio.OpenPnL)
+                FormatCurrency(totalPnL),
+                numericValue: totalPnL
             ));
+        }
 
         return rows;
     }
@@ -379,10 +385,9 @@ public class AccountInfoDisplay : Indicator
             // Determine color for value (Phase 0: keep current behavior)
             var valueColor = _textColor;
 
-            // Replace old `line.Contains("PnL")` with label check, preserving the intent.
-            if (label.Contains("PnL", StringComparison.OrdinalIgnoreCase))
+            if (row.NumericValue.HasValue)
             {
-                var value = ExtractNumericValue(valueStr);
+                var value = row.NumericValue.Value;
                 valueColor = value > 0
                     ? _positiveColor
                     : (value < 0 ? _negativeColor : _neutralColor);
@@ -394,15 +399,6 @@ public class AccountInfoDisplay : Indicator
             currentY += lineHeight;
         }
     }
-
-    private decimal ExtractNumericValue(string valueStr)
-	{
-		// Remove currency symbols and try to parse
-		var cleanStr = valueStr.Replace(",", "").Trim();
-		if (decimal.TryParse(cleanStr, out var result))
-			return result;
-		return 0;
-	}
 
 	private string FormatCurrency(decimal value)
 	{

--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -11,10 +11,10 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Drawing;
 using System.IO;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Security.Cryptography;
 
 /// <summary>
 /// Displays account information on the chart including account ID, balance, blocked margin, available balance, and PnL.
@@ -50,7 +50,12 @@ public class AccountInfoDisplay : Indicator
 
         public decimal StartEquity { get; set; }
         public decimal PeakEquity { get; set; }
-        public decimal MaxOpenPnL { get; set; }
+
+        // Phase 1: per-trade max open pnl (NOT historical)
+        public decimal TradeMaxOpenPnL { get; set; }
+        public bool WasPositionOpen { get; set; }
+        public decimal TradeOpenPnlBaseline { get; set; }   // portfolio.OpenPnL en el momento de apertura
+
         public DateTime InitializedAtUtc { get; set; }
 
         // Per-account config
@@ -72,6 +77,8 @@ public class AccountInfoDisplay : Indicator
 
         // Reset markers (per-account)
         public int LastMonthlyResetKey { get; set; } // yyyymm, e.g. 202512
+
+
     }
 
     #region Persistence DTO
@@ -118,6 +125,20 @@ public class AccountInfoDisplay : Indicator
         public int LastMonthlyResetKey { get; set; }           // yyyymm
     }
 
+    #endregion
+
+    #region Live position tracker
+
+    private sealed class PositionSnapshot
+    {
+        public bool IsOpen { get; set; }
+        public OrderDirections Direction { get; set; }
+        public decimal Volume { get; set; }           // absolute contracts
+        public decimal AvgEntryPrice { get; set; }
+        public DateTime OpenTime { get; set; }
+        public string SecurityCode { get; set; }
+        public string AccountId { get; set; }
+    }
     #endregion
 
     #endregion
@@ -181,6 +202,13 @@ public class AccountInfoDisplay : Indicator
         PropertyNameCaseInsensitive = true,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
     };
+
+    #endregion
+
+    #region Live position tracker
+
+    // Trade rebuild buffers (per active account+symbol)
+    private PositionSnapshot _posSnapshot = new();
 
     #endregion
 
@@ -636,6 +664,9 @@ public class AccountInfoDisplay : Indicator
         _activeAccountKey = GetAccountKey(portfolio);
         var state = GetOrCreateTrailingState(_activeAccountKey);
 
+        // Phase 1: update live position snapshot (single open position assumption)
+        UpdatePositionSnapshotFromTradingManager(portfolio);
+
         // Phase 2: equity and trailing DD state
         var equity = portfolio.Balance + portfolio.OpenPnL;
         var nowLocal = DateTime.Now;
@@ -709,6 +740,7 @@ public class AccountInfoDisplay : Indicator
         // 2) Switch
         _currentPortfolio = portfolio;
         _activeAccountKey = GetAccountKey(portfolio);
+        _reinitializeNow = false;
 
         // 3) Ensure state exists
         var state = GetOrCreateTrailingState(_activeAccountKey);
@@ -718,6 +750,8 @@ public class AccountInfoDisplay : Indicator
 
         // 5) Sync UI from the per-account state
         SyncUiFromState(state);
+
+        _posSnapshot = new PositionSnapshot();
 
         RedrawChart();
     }
@@ -779,7 +813,20 @@ public class AccountInfoDisplay : Indicator
             // We keep numericValue as negative magnitude so existing color rules (pos=green, neg=red) still work.
             rows.Add(new DisplayRow("Current DD", FormatCurrency(currentDd), numericValue: -currentDd));
 
-            rows.Add(new DisplayRow("Max Open PnL", FormatCurrency(state.MaxOpenPnL), numericValue: state.MaxOpenPnL));
+            rows.Add(new DisplayRow("Trade Max Open PnL", FormatCurrency(state.TradeMaxOpenPnL), numericValue: state.TradeMaxOpenPnL));
+
+        }
+
+        // --- Phase 1: Current position snapshot (debug/info) ---
+        if (_posSnapshot != null && _posSnapshot.IsOpen)
+        {
+            rows.Add(new DisplayRow("Pos Dir", _posSnapshot.Direction.ToString()));
+            rows.Add(new DisplayRow("Pos Qty", _posSnapshot.Volume.ToString("N0")));
+            rows.Add(new DisplayRow("Pos Entry", _posSnapshot.AvgEntryPrice.ToString("N2")));
+        }
+        else
+        {
+            rows.Add(new DisplayRow("Pos", "FLAT"));
         }
 
         return rows;
@@ -855,9 +902,13 @@ public class AccountInfoDisplay : Indicator
         state.IsInitialized = false;
         state.StartEquity = 0m;
         state.PeakEquity = 0m;
-        state.MaxOpenPnL = 0m;
+
+        // Phase 1
+        state.TradeMaxOpenPnL = 0m;
+        state.WasPositionOpen = false;
         state.InitializedAtUtc = default;
         state.LastEodCaptureDate = default;
+        state.TradeOpenPnlBaseline = 0m;
 
         _reinitializeNow = false;
     }
@@ -895,7 +946,9 @@ public class AccountInfoDisplay : Indicator
             state.PeakEquity = equity;
         }
 
-        state.MaxOpenPnL = portfolio.OpenPnL;
+        state.TradeMaxOpenPnL = 0m;
+        state.WasPositionOpen = false;
+        state.TradeOpenPnlBaseline = 0m;
 
         // Consume the pulse
         _reinitializeNow = false;
@@ -906,10 +959,33 @@ public class AccountInfoDisplay : Indicator
         if (!state.EnableTrailingDrawdown || !state.IsInitialized)
             return;
 
-        // Max OpenPnL is always realtime (it is informational and useful regardless of EOD).
-        if (portfolio.OpenPnL > state.MaxOpenPnL)
-            state.MaxOpenPnL = portfolio.OpenPnL;
+        // Phase 1: per-trade tracking (single open position assumption)
+        var isOpen = IsActivePositionOpen(portfolio);
 
+        if (!isOpen)
+        {
+            state.TradeMaxOpenPnL = 0m;
+            state.TradeOpenPnlBaseline = 0m;
+            state.WasPositionOpen = false;
+        }
+        else
+        {
+            if (!state.WasPositionOpen)
+            {
+                // Trade just opened => lock baseline and reset per-trade max to 0
+                state.TradeOpenPnlBaseline = portfolio.OpenPnL;
+                state.TradeMaxOpenPnL = 0m;
+                state.WasPositionOpen = true;
+            }
+
+            // OpenPnL "since entry" (starts at 0 at trade open)
+            var tradeOpenPnl = portfolio.OpenPnL - state.TradeOpenPnlBaseline;
+
+            if (tradeOpenPnl > state.TradeMaxOpenPnL)
+                state.TradeMaxOpenPnL = tradeOpenPnl;
+        }
+
+        // PeakEquity policy
         if (state.PeakUpdateMode == TrailingPeakUpdateMode.Realtime)
         {
             if (equity > state.PeakEquity)
@@ -921,6 +997,7 @@ public class AccountInfoDisplay : Indicator
         // EOD mode
         MaybeCaptureEodPeak(state, equity, nowLocal);
     }
+
 
     #endregion
 
@@ -1146,7 +1223,9 @@ public class AccountInfoDisplay : Indicator
         state.IsInitialized = rt.IsInitialized;
         state.StartEquity = rt.StartEquity;
         state.PeakEquity = rt.PeakEquity;
-        state.MaxOpenPnL = rt.MaxOpenPnL;
+        state.WasPositionOpen = false;
+        state.TradeMaxOpenPnL = 0m;
+        state.TradeOpenPnlBaseline = 0m;
 
         state.InitializedAtUtc = ParseDateTimeOrDefault(rt.InitializedAtUtc, default);
         state.LastEodCaptureDate = ParseDateOrDefault(rt.LastEodCaptureDate, default);
@@ -1194,7 +1273,6 @@ public class AccountInfoDisplay : Indicator
         persisted.Runtime.IsInitialized = state.IsInitialized;
         persisted.Runtime.StartEquity = state.StartEquity;
         persisted.Runtime.PeakEquity = state.PeakEquity;
-        persisted.Runtime.MaxOpenPnL = state.MaxOpenPnL;
 
         persisted.Runtime.InitializedAtUtc = state.InitializedAtUtc == default
             ? null
@@ -1339,6 +1417,86 @@ public class AccountInfoDisplay : Indicator
         PersistAccountToMemory(accountKey);
         MarkDirty();
         SaveIfNeeded(force);
+    }
+
+
+    #endregion
+
+    #region Live position tracker helpers
+    // ===========================
+    // Phase 1: Position tracker
+    // ===========================
+
+    private void UpdatePositionSnapshotFromTradingManager(Portfolio portfolio)
+    {
+        _posSnapshot ??= new PositionSnapshot();
+
+        var tm = TradingManager;
+        var pos = tm?.Position;
+        var sec = tm?.Security;
+
+        if (portfolio == null || pos == null || sec == null)
+        {
+            _posSnapshot.IsOpen = false;
+            return;
+        }
+
+        // Defensive: ensure the position belongs to the currently selected portfolio/security
+        if (!string.Equals(pos.AccountID, portfolio.AccountID, StringComparison.Ordinal))
+        {
+            _posSnapshot.IsOpen = false;
+            return;
+        }
+
+        if (pos.Security == null || !string.Equals(pos.Security.Code, sec.Code, StringComparison.Ordinal))
+        {
+            _posSnapshot.IsOpen = false;
+            return;
+        }
+
+        var isOpen = pos.IsInPosition && pos.Volume != 0m;
+
+        if (!isOpen)
+        {
+            _posSnapshot = new PositionSnapshot
+            {
+                IsOpen = false,
+                AccountId = portfolio.AccountID,
+                SecurityCode = sec.Code
+            };
+            return;
+        }
+
+        var dir = pos.Volume > 0m ? OrderDirections.Buy : OrderDirections.Sell;
+
+        _posSnapshot = new PositionSnapshot
+        {
+            IsOpen = true,
+            Direction = dir,
+            Volume = Math.Abs(pos.Volume),
+            AvgEntryPrice = pos.AveragePrice,
+            AccountId = portfolio.AccountID,
+            SecurityCode = sec.Code
+            // OpenTime: if needed in Phase 1, it can be approximated using MyTrades; not required for per-trade max reset.
+        };
+    }
+
+    private bool IsActivePositionOpen(Portfolio portfolio)
+    {
+        var tm = TradingManager;
+        var pos = tm?.Position;
+        var sec = tm?.Security;
+
+        if (portfolio == null || pos == null || sec == null)
+            return false;
+
+        if (!string.Equals(pos.AccountID, portfolio.AccountID, StringComparison.Ordinal))
+            return false;
+
+        if (pos.Security == null || !string.Equals(pos.Security.Code, sec.Code, StringComparison.Ordinal))
+            return false;
+
+        return pos.IsInPosition && pos.Volume != 0m;
     }
 
 

--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -16,7 +16,7 @@ using System.Drawing;
 /// </summary>
 [HelpLink("https://help.atas.net/en/support/solutions/articles/72000648751-account-info-display")]
 [Category(IndicatorCategories.Trading)]
-[DisplayName("Account Info Display")]
+[DisplayName("Account Info Display Modif")]
 [Display(ResourceType = typeof(Strings), Description = nameof(Strings.AccountInfoDisplayDescription))]
 public class AccountInfoDisplay : Indicator
 {
@@ -38,6 +38,16 @@ public class AccountInfoDisplay : Indicator
             ValueColorOverride = valueColorOverride;
         }
     }
+
+    private sealed class TrailingDdState
+    {
+        public decimal StartEquity { get; set; }
+        public decimal PeakEquity { get; set; }
+        public decimal MaxOpenPnL { get; set; }
+        public DateTime InitializedAtUtc { get; set; }
+
+        public bool IsInitialized { get; set; }
+    }
     #endregion
 
     #region Fields
@@ -56,11 +66,13 @@ public class AccountInfoDisplay : Indicator
 
 	private Portfolio _currentPortfolio;
 
-	#endregion
+    private TrailingDdState _trailingState = new();
 
-	#region Properties
+    #endregion
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.BackGround),
+    #region Properties
+
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.BackGround),
 		Description = nameof(Strings.LabelFillColorDescription), GroupName = nameof(Strings.Visualization))]
 	public CrossColor BackgroundColor
 	{
@@ -168,11 +180,78 @@ public class AccountInfoDisplay : Indicator
 	[Range(5, 50)]
 	public int ColumnSpacing { get; set; } = 15;
 
-	#endregion
+    #region Trailing Drawdown Settings
 
-	#region Enums
+    public enum TrailingInitMode
+    {
+        AutoFromCurrentEquity = 0,
+        ManualStopEquity = 1
+    }
 
-	public enum HorizontalAlignment
+    [Display(
+        Name = "Enable Trailing Drawdown",
+        Description = "Enable trailing drawdown tracking based on peak equity.",
+        GroupName = "Funding / Trailing DD",
+        Order = 10
+    )]
+    public bool EnableTrailingDrawdown { get; set; } = true;
+
+    [Display(
+        Name = "Max Trailing Drawdown",
+        Description = "Maximum allowed trailing drawdown from peak equity (absolute currency amount).",
+        GroupName = "Funding / Trailing DD",
+        Order = 11
+    )]
+    [Range(0, 1_000_000)]
+    public decimal MaxTrailingDrawdown { get; set; } = 2500m;
+
+    [Display(
+        Name = "Initialization Mode",
+        Description = "How the trailing drawdown state is initialized.",
+        GroupName = "Funding / Trailing DD",
+        Order = 12
+    )]
+    public TrailingInitMode InitializationMode { get; set; } = TrailingInitMode.AutoFromCurrentEquity;
+
+    [Display(
+        Name = "Manual Stop Equity",
+        Description = "Current liquidation/stop equity level (bootstrap). Peak is derived as Stop + Max DD.",
+        GroupName = "Funding / Trailing DD",
+        Order = 13
+    )]
+    [Range(-1_000_000, 10_000_000)]
+    public decimal ManualStopEquity { get; set; } = 0m;
+
+    [Display(
+        Name = "Reinitialize Now",
+        Description = "Forces trailing drawdown state re-initialization on next render.",
+        GroupName = "Funding / Trailing DD",
+        Order = 14
+    )]
+    public bool ReinitializeNow
+    {
+        get => _reinitializeNow;
+        set
+        {
+            if (value == _reinitializeNow)
+                return;
+
+            _reinitializeNow = value;
+
+            // Re-render immediately when toggled
+            RedrawChart();
+        }
+    }
+
+    private bool _reinitializeNow;
+
+    #endregion
+
+    #endregion
+
+    #region Enums
+
+    public enum HorizontalAlignment
 	{
 		Left,
 		Center,
@@ -231,17 +310,20 @@ public class AccountInfoDisplay : Indicator
         if (ChartInfo == null || Container?.Region == null)
             return;
 
-        // Get current portfolio
         var portfolio = _currentPortfolio ?? TradingManager?.Portfolio;
         if (portfolio == null)
             return;
 
-        // Build structured rows (Phase 0 replacement)
-        var rows = BuildRows(portfolio);
+        // Phase 2: equity and trailing DD state
+        var equity = portfolio.Balance + portfolio.OpenPnL;
+
+        InitializeTrailingState(portfolio, equity);
+        UpdateTrailingState(portfolio, equity);
+
+        var rows = BuildRows(portfolio, equity); // updated signature
         if (rows == null || rows.Count == 0)
             return;
 
-        // Calculate proper dimensions for table layout
         var lineHeight = context.MeasureString("A", _font).Height;
 
         var maxLabelWidth = 0;
@@ -263,18 +345,14 @@ public class AccountInfoDisplay : Indicator
         var rectWidth = maxLabelWidth + ColumnSpacing + maxValueWidth + padding * 2;
         var rectHeight = rows.Count * lineHeight + padding * 2;
 
-        // Calculate position
         var x = CalculateXPosition(rectWidth);
         var y = CalculateYPosition(rectHeight);
 
-        // Draw background
         var rectangle = new Rectangle(x, y, rectWidth, rectHeight);
         context.FillRectangle(_backgroundColor, rectangle);
 
-        // Draw border
         context.DrawRectangle(new RenderPen(Color.Gray, 1), rectangle);
 
-        // Draw text (keep existing coloring logic for Phase 0)
         var textRect = new Rectangle(
             x + padding,
             y + padding,
@@ -292,75 +370,68 @@ public class AccountInfoDisplay : Indicator
     private void OnPortfolioSelected(Portfolio portfolio)
 	{
 		_currentPortfolio = portfolio;
-		RedrawChart();
+        ResetTrailingState();
+        RedrawChart();
 	}
 
-    private List<DisplayRow> BuildRows(Portfolio portfolio)
+    private List<DisplayRow> BuildRows(Portfolio portfolio, decimal equity)
     {
         var rows = new List<DisplayRow>();
 
         if (portfolio == null)
             return rows;
 
+        // --- Existing rows (unchanged) ---
         if (ShowAccountId)
-            rows.Add(new DisplayRow(
-                "Account",
-                portfolio.AccountID
-            ));
+            rows.Add(new DisplayRow("Account", portfolio.AccountID));
 
         if (ShowCurrency && portfolio.Currency.HasValue)
-            rows.Add(new DisplayRow(
-                "Currency",
-                portfolio.Currency.Value.ToString()
-            ));
+            rows.Add(new DisplayRow("Currency", portfolio.Currency.Value.ToString()));
 
         if (ShowBalance)
-            rows.Add(new DisplayRow(
-                "Balance",
-                FormatCurrency(portfolio.Balance)
-            ));
+            rows.Add(new DisplayRow("Balance", FormatCurrency(portfolio.Balance)));
 
         if (ShowAvailableBalance && portfolio.BalanceAvailable.HasValue)
-            rows.Add(new DisplayRow(
-                "Available",
-                FormatCurrency(portfolio.BalanceAvailable.Value)
-            ));
+            rows.Add(new DisplayRow("Available", FormatCurrency(portfolio.BalanceAvailable.Value)));
 
         if (ShowMargin)
-            rows.Add(new DisplayRow(
-                "Blocked Margin",
-                FormatCurrency(portfolio.BlockedMargin)
-            ));
+            rows.Add(new DisplayRow("Blocked Margin", FormatCurrency(portfolio.BlockedMargin)));
 
         if (ShowLeverage && portfolio.Leverage != 1)
-            rows.Add(new DisplayRow(
-                "Leverage",
-                $"{portfolio.Leverage:F2}x"
-            ));
+            rows.Add(new DisplayRow("Leverage", $"{portfolio.Leverage:F2}x"));
 
         if (ShowOpenPnL)
-            rows.Add(new DisplayRow(
-                "Open PnL",
-                FormatCurrency(portfolio.OpenPnL),
-                numericValue: portfolio.OpenPnL
-            ));
+            rows.Add(new DisplayRow("Open PnL", FormatCurrency(portfolio.OpenPnL), numericValue: portfolio.OpenPnL));
 
         if (ShowClosedPnL)
-            rows.Add(new DisplayRow(
-                "Closed PnL",
-                FormatCurrency(portfolio.ClosedPnL),
-                numericValue: portfolio.ClosedPnL
-            ));
+            rows.Add(new DisplayRow("Closed PnL", FormatCurrency(portfolio.ClosedPnL), numericValue: portfolio.ClosedPnL));
 
         if (ShowTotalPnL)
         {
             var totalPnL = portfolio.ClosedPnL + portfolio.OpenPnL;
+            rows.Add(new DisplayRow("Total PnL", FormatCurrency(totalPnL), numericValue: totalPnL));
+        }
 
-            rows.Add(new DisplayRow(
-                "Total PnL",
-                FormatCurrency(totalPnL),
-                numericValue: totalPnL
-            ));
+        // --- Trailing Drawdown block (Phase 2) ---
+        if (EnableTrailingDrawdown && _trailingState.IsInitialized)
+        {
+            var stopEquity = _trailingState.PeakEquity - MaxTrailingDrawdown;
+            var currentDd = _trailingState.PeakEquity - equity;
+            var remainingDd = equity - stopEquity;
+
+            rows.Add(new DisplayRow("Equity", FormatCurrency(equity)));
+            rows.Add(new DisplayRow("Start Equity", FormatCurrency(_trailingState.StartEquity)));
+            rows.Add(new DisplayRow("Peak Equity", FormatCurrency(_trailingState.PeakEquity)));
+            rows.Add(new DisplayRow("Stop Equity", FormatCurrency(stopEquity)));
+
+            // Remaining DD: positive => safe (green), negative => breached (red)
+            rows.Add(new DisplayRow("Remaining DD", FormatCurrency(remainingDd), numericValue: remainingDd));
+
+            // Current DD: show as positive magnitude but color should reflect "bad when larger".
+            // We keep numericValue as negative magnitude so existing color rules (pos=green, neg=red) still work.
+            rows.Add(new DisplayRow("Current DD", FormatCurrency(currentDd), numericValue: -currentDd));
+
+            rows.Add(new DisplayRow("Max Open PnL", FormatCurrency(_trailingState.MaxOpenPnL), numericValue: _trailingState.MaxOpenPnL));
         }
 
         return rows;
@@ -382,7 +453,7 @@ public class AccountInfoDisplay : Indicator
             // Draw label
             context.DrawString(label, _font, _textColor, textRect.X, currentY);
 
-            // Determine color for value (Phase 0: keep current behavior)
+            // Determine color for numeric values (PnL/DD rows are provided via NumericValue)
             var valueColor = _textColor;
 
             if (row.NumericValue.HasValue)
@@ -427,5 +498,60 @@ public class AccountInfoDisplay : Indicator
 		};
 	}
 
-	#endregion
+    #region Trailing Drawdown Helpers
+
+    private void ResetTrailingState()
+    {
+        _trailingState = new TrailingDdState();
+        _reinitializeNow = false;
+    }
+
+    private void InitializeTrailingState(Portfolio portfolio, decimal equity)
+    {
+        if (!EnableTrailingDrawdown)
+            return;
+
+
+        // One-shot init unless forced.
+        if (_trailingState.IsInitialized && !_reinitializeNow)
+            return;
+
+        _trailingState.IsInitialized = true;
+        _trailingState.InitializedAtUtc = DateTime.UtcNow;
+
+        _trailingState.StartEquity = equity;
+
+        if (InitializationMode == TrailingInitMode.ManualStopEquity && MaxTrailingDrawdown > 0m)
+        {
+            // Bootstrap using user-provided stop equity:
+            // PeakEquity is derived so that: StopEquity = PeakEquity - MaxDD == ManualStopEquity
+            _trailingState.PeakEquity = ManualStopEquity + MaxTrailingDrawdown;
+        }
+        else
+        {
+            // Default: start from current equity
+            _trailingState.PeakEquity = equity;
+        }
+
+        _trailingState.MaxOpenPnL = portfolio.OpenPnL;
+
+        // Consume the pulse
+        _reinitializeNow = false;
+    }
+
+    private void UpdateTrailingState(Portfolio portfolio, decimal equity)
+    {
+        if (!EnableTrailingDrawdown || !_trailingState.IsInitialized)
+            return;
+
+        if (equity > _trailingState.PeakEquity)
+            _trailingState.PeakEquity = equity;
+
+        if (portfolio.OpenPnL > _trailingState.MaxOpenPnL)
+            _trailingState.MaxOpenPnL = portfolio.OpenPnL;
+    }
+
+    #endregion
+
+    #endregion
 }

--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -53,6 +53,13 @@ public class AccountInfoDisplay : Indicator
         public decimal MaxTrailingDrawdown { get; set; }
         public TrailingInitMode InitializationMode { get; set; }
         public decimal ManualStopEquity { get; set; }
+
+        // Phase 4: EOD engine (per-account)
+        public TrailingPeakUpdateMode PeakUpdateMode { get; set; }
+        public TimeSpan EodTimeLocal { get; set; }
+
+        // Marker to ensure we capture EOD only once per local day
+        public DateTime LastEodCaptureDate { get; set; } // Date component only
     }
     #endregion
 
@@ -78,6 +85,11 @@ public class AccountInfoDisplay : Indicator
     private bool _defaultEnableTrailingDrawdown = true;
     private TrailingInitMode _defaultInitializationMode = TrailingInitMode.AutoFromCurrentEquity;
     private decimal _defaultManualStopEquity = 0m;
+
+    private TrailingPeakUpdateMode _defaultPeakUpdateMode = TrailingPeakUpdateMode.Realtime;
+
+    // Bulenox default: 17:00 CT (user can change depending on local timezone)
+    private TimeSpan _defaultEodTimeLocal = new(17, 0, 0);
 
     #endregion
 
@@ -309,6 +321,63 @@ public class AccountInfoDisplay : Indicator
 
     private bool _reinitializeNow;
 
+    public enum TrailingPeakUpdateMode
+    {
+        Realtime = 0, // classic trailing: peak updates whenever equity makes a new high
+        EndOfDay = 1  // EOD: peak updates only once per day at EOD time
+    }
+
+    [Display(
+    Name = "Peak Update Mode",
+    Description = "Controls when Peak Equity is allowed to update. Realtime updates continuously; EndOfDay updates only once per day at the configured EOD time.",
+    GroupName = "Funding / Trailing DD",
+    Order = 15
+)]
+    public TrailingPeakUpdateMode DefaultPeakUpdateMode
+    {
+        get => _defaultPeakUpdateMode;
+        set
+        {
+            _defaultPeakUpdateMode = value;
+
+            var state = TryGetActiveState();
+            if (state != null)
+            {
+                state.PeakUpdateMode = value;
+                state.LastEodCaptureDate = default; // allow EOD capture immediately if applicable
+            }
+
+            RedrawChart();
+        }
+    }
+
+    [Display(
+        Name = "EOD Time (Local)",
+        Description = "End-of-day time used when Peak Update Mode is EndOfDay. Uses the PC local clock (DateTime.Now). Default 17:00 (Bulenox CT).",
+        GroupName = "Funding / Trailing DD",
+        Order = 16
+    )]
+    public TimeSpan DefaultEodTimeLocal
+    {
+        get => _defaultEodTimeLocal;
+        set
+        {
+            // Defensive clamp: keep it within a day range
+            if (value < TimeSpan.Zero)
+                value = TimeSpan.Zero;
+            if (value >= TimeSpan.FromDays(1))
+                value = TimeSpan.FromDays(1) - TimeSpan.FromSeconds(1);
+
+            _defaultEodTimeLocal = value;
+
+            var state = TryGetActiveState();
+            if (state != null)
+                state.EodTimeLocal = value;
+
+            RedrawChart();
+        }
+    }
+
     #endregion
 
     #endregion
@@ -383,9 +452,10 @@ public class AccountInfoDisplay : Indicator
 
         // Phase 2: equity and trailing DD state
         var equity = portfolio.Balance + portfolio.OpenPnL;
+        var nowLocal = DateTime.Now;
 
         InitializeTrailingState(state, portfolio, equity);
-        UpdateTrailingState(state, portfolio, equity);
+        UpdateTrailingState(state, portfolio, equity, nowLocal);
 
         var rows = BuildRows(state, portfolio, equity); // updated signature
         if (rows == null || rows.Count == 0)
@@ -578,6 +648,7 @@ public class AccountInfoDisplay : Indicator
         state.PeakEquity = 0m;
         state.MaxOpenPnL = 0m;
         state.InitializedAtUtc = default;
+        state.LastEodCaptureDate = default;
 
         _reinitializeNow = false;
     }
@@ -621,16 +692,25 @@ public class AccountInfoDisplay : Indicator
         _reinitializeNow = false;
     }
 
-    private void UpdateTrailingState(TrailingDdState state, Portfolio portfolio, decimal equity)
+    private void UpdateTrailingState(TrailingDdState state, Portfolio portfolio, decimal equity, DateTime nowLocal)
     {
         if (!state.EnableTrailingDrawdown || !state.IsInitialized)
             return;
 
-        if (equity > state.PeakEquity)
-            state.PeakEquity = equity;
-
+        // Max OpenPnL is always realtime (it is informational and useful regardless of EOD).
         if (portfolio.OpenPnL > state.MaxOpenPnL)
             state.MaxOpenPnL = portfolio.OpenPnL;
+
+        if (state.PeakUpdateMode == TrailingPeakUpdateMode.Realtime)
+        {
+            if (equity > state.PeakEquity)
+                state.PeakEquity = equity;
+
+            return;
+        }
+
+        // EOD mode
+        MaybeCaptureEodPeak(state, equity, nowLocal);
     }
 
     #endregion
@@ -657,7 +737,11 @@ public class AccountInfoDisplay : Indicator
             EnableTrailingDrawdown = DefaultEnableTrailingDrawdown,
             MaxTrailingDrawdown = DefaultMaxTrailingDrawdown,
             InitializationMode = DefaultInitializationMode,
-            ManualStopEquity = DefaultManualStopEquity
+            ManualStopEquity = DefaultManualStopEquity,
+
+            PeakUpdateMode = DefaultPeakUpdateMode,
+            EodTimeLocal = DefaultEodTimeLocal,
+            LastEodCaptureDate = default
         };
 
         _trailingStatesByAccount[accountKey] = state;
@@ -670,6 +754,9 @@ public class AccountInfoDisplay : Indicator
         _defaultInitializationMode = state.InitializationMode;
         _defaultManualStopEquity = state.ManualStopEquity;
         _defaultEnableTrailingDrawdown = state.EnableTrailingDrawdown;
+
+        _defaultPeakUpdateMode = state.PeakUpdateMode;
+        _defaultEodTimeLocal = state.EodTimeLocal;
     }
 
     private TrailingDdState TryGetActiveState()
@@ -680,6 +767,32 @@ public class AccountInfoDisplay : Indicator
         return _trailingStatesByAccount.TryGetValue(_activeAccountKey, out var state)
             ? state
             : null;
+    }
+
+    private void MaybeCaptureEodPeak(TrailingDdState state, decimal equity, DateTime nowLocal)
+    {
+        // EOD capture happens at most once per local day, after EOD time.
+        var today = nowLocal.Date;
+
+        // If already captured for today, do nothing.
+        if (state.LastEodCaptureDate.Date == today)
+            return;
+
+        // Determine today's EOD timestamp in local time.
+        var eod = today.Add(state.EodTimeLocal);
+
+        // Only capture after EOD time.
+        if (nowLocal < eod)
+            return;
+
+        // Capture rule: peak updates only if equity makes a new high at EOD snapshot.
+        if (equity > state.PeakEquity)
+            state.PeakEquity = equity;
+
+        state.LastEodCaptureDate = today;
+
+        // Defensive: do not let a pending UI pulse override the EOD snapshot.
+        _reinitializeNow = false;
     }
 
     #endregion

--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -41,12 +41,18 @@ public class AccountInfoDisplay : Indicator
 
     private sealed class TrailingDdState
     {
+        public bool IsInitialized { get; set; }
+
         public decimal StartEquity { get; set; }
         public decimal PeakEquity { get; set; }
         public decimal MaxOpenPnL { get; set; }
         public DateTime InitializedAtUtc { get; set; }
 
-        public bool IsInitialized { get; set; }
+        // Per-account config
+        public bool EnableTrailingDrawdown { get; set; }
+        public decimal MaxTrailingDrawdown { get; set; }
+        public TrailingInitMode InitializationMode { get; set; }
+        public decimal ManualStopEquity { get; set; }
     }
     #endregion
 
@@ -66,7 +72,12 @@ public class AccountInfoDisplay : Indicator
 
 	private Portfolio _currentPortfolio;
 
-    private TrailingDdState _trailingState = new();
+    private readonly Dictionary<string, TrailingDdState> _trailingStatesByAccount = new();
+    private string _activeAccountKey;
+
+    private bool _defaultEnableTrailingDrawdown = true;
+    private TrailingInitMode _defaultInitializationMode = TrailingInitMode.AutoFromCurrentEquity;
+    private decimal _defaultManualStopEquity = 0m;
 
     #endregion
 
@@ -194,7 +205,22 @@ public class AccountInfoDisplay : Indicator
         GroupName = "Funding / Trailing DD",
         Order = 10
     )]
-    public bool EnableTrailingDrawdown { get; set; } = true;
+    public bool DefaultEnableTrailingDrawdown
+    {
+        get => _defaultEnableTrailingDrawdown;
+        set
+        {
+            _defaultEnableTrailingDrawdown = value;
+
+            var state = TryGetActiveState();
+            if (state != null)
+                state.EnableTrailingDrawdown = value;
+
+            RedrawChart();
+        }
+    }
+
+    private decimal _maxTrailingDrawdownDefault = 2500m;
 
     [Display(
         Name = "Max Trailing Drawdown",
@@ -203,7 +229,21 @@ public class AccountInfoDisplay : Indicator
         Order = 11
     )]
     [Range(0, 1_000_000)]
-    public decimal MaxTrailingDrawdown { get; set; } = 2500m;
+    public decimal DefaultMaxTrailingDrawdown
+    {
+        get => _maxTrailingDrawdownDefault;
+        set
+        {
+            _maxTrailingDrawdownDefault = value;
+
+            // write into active account state as well
+            var state = TryGetActiveState();
+            if (state != null)
+                state.MaxTrailingDrawdown = value;
+
+            RedrawChart();
+        }
+    }
 
     [Display(
         Name = "Initialization Mode",
@@ -211,7 +251,20 @@ public class AccountInfoDisplay : Indicator
         GroupName = "Funding / Trailing DD",
         Order = 12
     )]
-    public TrailingInitMode InitializationMode { get; set; } = TrailingInitMode.AutoFromCurrentEquity;
+    public TrailingInitMode DefaultInitializationMode
+    {
+        get => _defaultInitializationMode;
+        set
+        {
+            _defaultInitializationMode = value;
+
+            var state = TryGetActiveState();
+            if (state != null)
+                state.InitializationMode = value;
+
+            RedrawChart();
+        }
+    }
 
     [Display(
         Name = "Manual Stop Equity",
@@ -220,7 +273,20 @@ public class AccountInfoDisplay : Indicator
         Order = 13
     )]
     [Range(-1_000_000, 10_000_000)]
-    public decimal ManualStopEquity { get; set; } = 0m;
+    public decimal DefaultManualStopEquity
+    {
+        get => _defaultManualStopEquity;
+        set
+        {
+            _defaultManualStopEquity = value;
+
+            var state = TryGetActiveState();
+            if (state != null)
+                state.ManualStopEquity = value;
+
+            RedrawChart();
+        }
+    }
 
     [Display(
      Name = "Reinitialize Now",
@@ -312,13 +378,16 @@ public class AccountInfoDisplay : Indicator
         if (portfolio == null)
             return;
 
+        _activeAccountKey = GetAccountKey(portfolio);
+        var state = GetOrCreateTrailingState(_activeAccountKey);
+
         // Phase 2: equity and trailing DD state
         var equity = portfolio.Balance + portfolio.OpenPnL;
 
-        InitializeTrailingState(portfolio, equity);
-        UpdateTrailingState(portfolio, equity);
+        InitializeTrailingState(state, portfolio, equity);
+        UpdateTrailingState(state, portfolio, equity);
 
-        var rows = BuildRows(portfolio, equity); // updated signature
+        var rows = BuildRows(state, portfolio, equity); // updated signature
         if (rows == null || rows.Count == 0)
             return;
 
@@ -366,13 +435,17 @@ public class AccountInfoDisplay : Indicator
     #region Private Methods
 
     private void OnPortfolioSelected(Portfolio portfolio)
-	{
-		_currentPortfolio = portfolio;
-        ResetTrailingState();
-        RedrawChart();
-	}
+    {
+        _currentPortfolio = portfolio;
+        _activeAccountKey = GetAccountKey(portfolio);
 
-    private List<DisplayRow> BuildRows(Portfolio portfolio, decimal equity)
+        var state = GetOrCreateTrailingState(_activeAccountKey);
+        SyncUiFromState(state);
+
+        RedrawChart();
+    }
+
+    private List<DisplayRow> BuildRows(TrailingDdState state, Portfolio portfolio, decimal equity)
     {
         var rows = new List<DisplayRow>();
 
@@ -411,15 +484,15 @@ public class AccountInfoDisplay : Indicator
         }
 
         // --- Trailing Drawdown block (Phase 2) ---
-        if (EnableTrailingDrawdown && _trailingState.IsInitialized)
+        if (state.EnableTrailingDrawdown && state.IsInitialized)
         {
-            var stopEquity = _trailingState.PeakEquity - MaxTrailingDrawdown;
-            var currentDd = _trailingState.PeakEquity - equity;
+            var stopEquity = state.PeakEquity - state.MaxTrailingDrawdown;
+            var currentDd = state.PeakEquity - equity;
             var remainingDd = equity - stopEquity;
 
             rows.Add(new DisplayRow("Equity", FormatCurrency(equity)));
-            rows.Add(new DisplayRow("Start Equity", FormatCurrency(_trailingState.StartEquity)));
-            rows.Add(new DisplayRow("Peak Equity", FormatCurrency(_trailingState.PeakEquity)));
+            rows.Add(new DisplayRow("Start Equity", FormatCurrency(state.StartEquity)));
+            rows.Add(new DisplayRow("Peak Equity", FormatCurrency(state.PeakEquity)));
             rows.Add(new DisplayRow("Stop Equity", FormatCurrency(stopEquity)));
 
             // Remaining DD: positive => safe (green), negative => breached (red)
@@ -429,7 +502,7 @@ public class AccountInfoDisplay : Indicator
             // We keep numericValue as negative magnitude so existing color rules (pos=green, neg=red) still work.
             rows.Add(new DisplayRow("Current DD", FormatCurrency(currentDd), numericValue: -currentDd));
 
-            rows.Add(new DisplayRow("Max Open PnL", FormatCurrency(_trailingState.MaxOpenPnL), numericValue: _trailingState.MaxOpenPnL));
+            rows.Add(new DisplayRow("Max Open PnL", FormatCurrency(state.MaxOpenPnL), numericValue: state.MaxOpenPnL));
         }
 
         return rows;
@@ -498,55 +571,115 @@ public class AccountInfoDisplay : Indicator
 
     #region Trailing Drawdown Helpers
 
-    private void ResetTrailingState()
+    private void ResetActiveAccountState(TrailingDdState state)
     {
-        _trailingState = new TrailingDdState();
+        state.IsInitialized = false;
+        state.StartEquity = 0m;
+        state.PeakEquity = 0m;
+        state.MaxOpenPnL = 0m;
+        state.InitializedAtUtc = default;
+
         _reinitializeNow = false;
     }
 
-    private void InitializeTrailingState(Portfolio portfolio, decimal equity)
+    private void ResetAllAccountStates()
     {
-        if (!EnableTrailingDrawdown)
+        _trailingStatesByAccount.Clear();
+        _reinitializeNow = false;
+    }
+
+    private void InitializeTrailingState(TrailingDdState state, Portfolio portfolio, decimal equity)
+    {
+        if (!state.EnableTrailingDrawdown)
             return;
 
 
         // One-shot init unless forced.
-        if (_trailingState.IsInitialized && !_reinitializeNow)
+        if (state.IsInitialized && !_reinitializeNow)
             return;
 
-        _trailingState.IsInitialized = true;
-        _trailingState.InitializedAtUtc = DateTime.UtcNow;
+        state.IsInitialized = true;
+        state.InitializedAtUtc = DateTime.UtcNow;
 
-        _trailingState.StartEquity = equity;
+        state.StartEquity = equity;
 
-        if (InitializationMode == TrailingInitMode.ManualStopEquity && MaxTrailingDrawdown > 0m)
+        if (state.InitializationMode == TrailingInitMode.ManualStopEquity && state.MaxTrailingDrawdown > 0m)
         {
             // Bootstrap using user-provided stop equity:
             // PeakEquity is derived so that: StopEquity = PeakEquity - MaxDD == ManualStopEquity
-            _trailingState.PeakEquity = ManualStopEquity + MaxTrailingDrawdown;
+            state.PeakEquity = state.ManualStopEquity + state.MaxTrailingDrawdown;
         }
         else
         {
             // Default: start from current equity
-            _trailingState.PeakEquity = equity;
+            state.PeakEquity = equity;
         }
 
-        _trailingState.MaxOpenPnL = portfolio.OpenPnL;
+        state.MaxOpenPnL = portfolio.OpenPnL;
 
         // Consume the pulse
         _reinitializeNow = false;
     }
 
-    private void UpdateTrailingState(Portfolio portfolio, decimal equity)
+    private void UpdateTrailingState(TrailingDdState state, Portfolio portfolio, decimal equity)
     {
-        if (!EnableTrailingDrawdown || !_trailingState.IsInitialized)
+        if (!state.EnableTrailingDrawdown || !state.IsInitialized)
             return;
 
-        if (equity > _trailingState.PeakEquity)
-            _trailingState.PeakEquity = equity;
+        if (equity > state.PeakEquity)
+            state.PeakEquity = equity;
 
-        if (portfolio.OpenPnL > _trailingState.MaxOpenPnL)
-            _trailingState.MaxOpenPnL = portfolio.OpenPnL;
+        if (portfolio.OpenPnL > state.MaxOpenPnL)
+            state.MaxOpenPnL = portfolio.OpenPnL;
+    }
+
+    #endregion
+
+    #region Multi account helpers
+
+    private string GetAccountKey(Portfolio portfolio)
+    {
+        // Prefer AccountID if present; fallback to a stable placeholder
+        if (!string.IsNullOrWhiteSpace(portfolio?.AccountID))
+            return portfolio.AccountID;
+
+        // Worst-case fallback: single bucket to avoid exceptions
+        return "DEFAULT";
+    }
+
+    private TrailingDdState GetOrCreateTrailingState(string accountKey)
+    {
+        if (_trailingStatesByAccount.TryGetValue(accountKey, out var state))
+            return state;
+
+        state = new TrailingDdState
+        {
+            EnableTrailingDrawdown = DefaultEnableTrailingDrawdown,
+            MaxTrailingDrawdown = DefaultMaxTrailingDrawdown,
+            InitializationMode = DefaultInitializationMode,
+            ManualStopEquity = DefaultManualStopEquity
+        };
+
+        _trailingStatesByAccount[accountKey] = state;
+        return state;
+    }
+
+    private void SyncUiFromState(TrailingDdState state)
+    {
+        _maxTrailingDrawdownDefault = state.MaxTrailingDrawdown;
+        _defaultInitializationMode = state.InitializationMode;
+        _defaultManualStopEquity = state.ManualStopEquity;
+        _defaultEnableTrailingDrawdown = state.EnableTrailingDrawdown;
+    }
+
+    private TrailingDdState TryGetActiveState()
+    {
+        if (string.IsNullOrEmpty(_activeAccountKey))
+            return null;
+
+        return _trailingStatesByAccount.TryGetValue(_activeAccountKey, out var state)
+            ? state
+            : null;
     }
 
     #endregion

--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -52,9 +52,10 @@ public class AccountInfoDisplay : Indicator
         public decimal PeakEquity { get; set; }
 
         // Phase 1: per-trade max open pnl (NOT historical)
-        public decimal TradeMaxOpenPnL { get; set; }
-        public bool WasPositionOpen { get; set; }
-        public decimal TradeOpenPnlBaseline { get; set; }   // portfolio.OpenPnL en el momento de apertura
+        public decimal TradeOpenPnlBaseline { get; set; }      // OpenPnL at trade open (baseline)
+        public decimal TradeMaxOpenPnL { get; set; }           // Max OpenPnL since entry (current trade)
+        public decimal LastTradeMaxOpenPnL { get; set; }       // Max OpenPnL since entry (last closed trade)
+        public bool WasPositionOpen { get; set; }              // Lifecycle flag for FLAT<->OPEN transitions
 
         public DateTime InitializedAtUtc { get; set; }
 
@@ -813,7 +814,11 @@ public class AccountInfoDisplay : Indicator
             // We keep numericValue as negative magnitude so existing color rules (pos=green, neg=red) still work.
             rows.Add(new DisplayRow("Current DD", FormatCurrency(currentDd), numericValue: -currentDd));
 
-            rows.Add(new DisplayRow("Trade Max Open PnL", FormatCurrency(state.TradeMaxOpenPnL), numericValue: state.TradeMaxOpenPnL));
+            if (state.WasPositionOpen == true)
+                rows.Add(new DisplayRow("Trade Max Open PnL (Current)", FormatCurrency(state.TradeMaxOpenPnL), numericValue: state.TradeMaxOpenPnL));
+
+            if (state.WasPositionOpen == false)
+                rows.Add(new DisplayRow("Trade Max Open PnL (Last)", FormatCurrency(state.LastTradeMaxOpenPnL), numericValue: state.LastTradeMaxOpenPnL));
 
         }
 
@@ -909,6 +914,7 @@ public class AccountInfoDisplay : Indicator
         state.InitializedAtUtc = default;
         state.LastEodCaptureDate = default;
         state.TradeOpenPnlBaseline = 0m;
+        state.LastTradeMaxOpenPnL = 0m;
 
         _reinitializeNow = false;
     }
@@ -949,6 +955,7 @@ public class AccountInfoDisplay : Indicator
         state.TradeMaxOpenPnL = 0m;
         state.WasPositionOpen = false;
         state.TradeOpenPnlBaseline = 0m;
+        state.LastTradeMaxOpenPnL = 0m;
 
         // Consume the pulse
         _reinitializeNow = false;
@@ -959,31 +966,35 @@ public class AccountInfoDisplay : Indicator
         if (!state.EnableTrailingDrawdown || !state.IsInitialized)
             return;
 
-        // Phase 1: per-trade tracking (single open position assumption)
+        // Phase 1: per-account per-trade tracking (single open position assumption)
         var isOpen = IsActivePositionOpen(portfolio);
 
-        if (!isOpen)
+        // OPEN event: FLAT -> OPEN
+        if (!state.WasPositionOpen && isOpen)
         {
-            state.TradeMaxOpenPnL = 0m;
+            state.TradeOpenPnlBaseline = portfolio.OpenPnL; // baseline at entry
+            state.TradeMaxOpenPnL = 0m;                     // current trade starts at 0
+            state.WasPositionOpen = true;
+        }
+        // CLOSE event: OPEN -> FLAT
+        else if (state.WasPositionOpen && !isOpen)
+        {
+            // Store the final max of the trade that just closed
+            state.LastTradeMaxOpenPnL = state.TradeMaxOpenPnL;
+
+            // Reset current-trade runtime (last trade remains visible)
             state.TradeOpenPnlBaseline = 0m;
+            state.TradeMaxOpenPnL = 0m;
             state.WasPositionOpen = false;
         }
-        else
+        // UPDATE while OPEN
+        else if (state.WasPositionOpen && isOpen)
         {
-            if (!state.WasPositionOpen)
-            {
-                // Trade just opened => lock baseline and reset per-trade max to 0
-                state.TradeOpenPnlBaseline = portfolio.OpenPnL;
-                state.TradeMaxOpenPnL = 0m;
-                state.WasPositionOpen = true;
-            }
-
-            // OpenPnL "since entry" (starts at 0 at trade open)
-            var tradeOpenPnl = portfolio.OpenPnL - state.TradeOpenPnlBaseline;
-
+            var tradeOpenPnl = portfolio.OpenPnL - state.TradeOpenPnlBaseline; // OpenPnL since entry
             if (tradeOpenPnl > state.TradeMaxOpenPnL)
                 state.TradeMaxOpenPnL = tradeOpenPnl;
         }
+        // UPDATE while FLAT: do nothing (LastTradeMaxOpenPnL stays visible)
 
         // PeakEquity policy
         if (state.PeakUpdateMode == TrailingPeakUpdateMode.Realtime)
@@ -1226,6 +1237,7 @@ public class AccountInfoDisplay : Indicator
         state.WasPositionOpen = false;
         state.TradeMaxOpenPnL = 0m;
         state.TradeOpenPnlBaseline = 0m;
+        state.LastTradeMaxOpenPnL = 0m;
 
         state.InitializedAtUtc = ParseDateTimeOrDefault(rt.InitializedAtUtc, default);
         state.LastEodCaptureDate = ParseDateOrDefault(rt.LastEodCaptureDate, default);

--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -382,7 +382,10 @@ public class AccountInfoDisplay : Indicator
 
             var state = TryGetActiveState();
             if (state != null)
-                state.EodTimeLocal = value;
+            { 
+                state.EodTimeLocal = value; 
+                state.LastEodCaptureDate = default; 
+            }
 
             RedrawChart();
         }
@@ -709,10 +712,7 @@ public class AccountInfoDisplay : Indicator
         state.PeakEquity = 0m;
         state.MaxOpenPnL = 0m;
         state.InitializedAtUtc = default;
-
-        // Reset markers
         state.LastEodCaptureDate = default;
-        state.LastMonthlyResetKey = 0;
 
         _reinitializeNow = false;
     }
@@ -863,11 +863,13 @@ public class AccountInfoDisplay : Indicator
             // If we're past the reset day and we haven't reset this month yet -> reset now.
             if (nowLocal.Day >= effectiveResetDay && state.LastMonthlyResetKey != monthKey)
             {
+                // Mark that we've reset this month (avoid multiple resets)
+                state.LastMonthlyResetKey = monthKey;
+
                 // Full reset for the new "monthly period"
                 ResetActiveAccountState(state);
 
-                // Mark that we've reset this month (avoid multiple resets)
-                state.LastMonthlyResetKey = monthKey;
+
 
                 // Ensure we don't immediately re-init again due to a pending UI pulse
                 _reinitializeNow = false;

--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -60,6 +60,13 @@ public class AccountInfoDisplay : Indicator
 
         // Marker to ensure we capture EOD only once per local day
         public DateTime LastEodCaptureDate { get; set; } // Date component only
+
+        // Reset policy (per-account)
+        public bool EnableMonthlyReset { get; set; }
+        public int MonthlyResetDay { get; set; }   // 1..31 (validaremos)
+
+        // Reset markers (per-account)
+        public int LastMonthlyResetKey { get; set; } // yyyymm, e.g. 202512
     }
     #endregion
 
@@ -90,6 +97,9 @@ public class AccountInfoDisplay : Indicator
 
     // Bulenox default: 17:00 CT (user can change depending on local timezone)
     private TimeSpan _defaultEodTimeLocal = new(17, 0, 0);
+
+    private bool _defaultEnableMonthlyReset = true;
+    private int _defaultMonthlyResetDay = 1;
 
     #endregion
 
@@ -380,6 +390,55 @@ public class AccountInfoDisplay : Indicator
 
     #endregion
 
+    #region Trailing Reset Settings
+
+    // ---------- Monthly reset ----------
+
+    [Display(
+        Name = "Enable Monthly Reset",
+        Description = "Resets trailing drawdown at a fixed day of each month (per account).",
+        GroupName = "Funding / Trailing DD",
+        Order = 20
+    )]
+    public bool DefaultEnableMonthlyReset
+    {
+        get => _defaultEnableMonthlyReset;
+        set
+        {
+            _defaultEnableMonthlyReset = value;
+
+            var state = TryGetActiveState();
+            if (state != null)
+                state.EnableMonthlyReset = value;
+
+            RedrawChart();
+        }
+    }
+
+    [Display(
+        Name = "Monthly Reset Day",
+        Description = "Day of month when trailing drawdown resets (1–31). If the month has fewer days, last day is used.",
+        GroupName = "Funding / Trailing DD",
+        Order = 21
+    )]
+    [Range(1, 31)]
+    public int DefaultMonthlyResetDay
+    {
+        get => _defaultMonthlyResetDay;
+        set
+        {
+            _defaultMonthlyResetDay = value;
+
+            var state = TryGetActiveState();
+            if (state != null)
+                state.MonthlyResetDay = value;
+
+            RedrawChart();
+        }
+    }
+
+    #endregion
+
     #endregion
 
     #region Enums
@@ -453,6 +512,8 @@ public class AccountInfoDisplay : Indicator
         // Phase 2: equity and trailing DD state
         var equity = portfolio.Balance + portfolio.OpenPnL;
         var nowLocal = DateTime.Now;
+
+        MaybeResetForSchedule(state, portfolio, equity, nowLocal);
 
         InitializeTrailingState(state, portfolio, equity);
         UpdateTrailingState(state, portfolio, equity, nowLocal);
@@ -648,7 +709,10 @@ public class AccountInfoDisplay : Indicator
         state.PeakEquity = 0m;
         state.MaxOpenPnL = 0m;
         state.InitializedAtUtc = default;
+
+        // Reset markers
         state.LastEodCaptureDate = default;
+        state.LastMonthlyResetKey = 0;
 
         _reinitializeNow = false;
     }
@@ -741,7 +805,9 @@ public class AccountInfoDisplay : Indicator
 
             PeakUpdateMode = DefaultPeakUpdateMode,
             EodTimeLocal = DefaultEodTimeLocal,
-            LastEodCaptureDate = default
+            LastEodCaptureDate = default,
+            EnableMonthlyReset = DefaultEnableMonthlyReset,
+            MonthlyResetDay = DefaultMonthlyResetDay
         };
 
         _trailingStatesByAccount[accountKey] = state;
@@ -757,6 +823,9 @@ public class AccountInfoDisplay : Indicator
 
         _defaultPeakUpdateMode = state.PeakUpdateMode;
         _defaultEodTimeLocal = state.EodTimeLocal;
+
+        _defaultEnableMonthlyReset = state.EnableMonthlyReset;
+        _defaultMonthlyResetDay = state.MonthlyResetDay;
     }
 
     private TrailingDdState TryGetActiveState()
@@ -767,6 +836,43 @@ public class AccountInfoDisplay : Indicator
         return _trailingStatesByAccount.TryGetValue(_activeAccountKey, out var state)
             ? state
             : null;
+    }
+
+    private void MaybeResetForSchedule(TrailingDdState state, Portfolio portfolio, decimal equity, DateTime nowLocal)
+    {
+        if (state == null || portfolio == null)
+            return;
+
+        // ---------------------------------------------------------------------
+        // 1) Monthly reset (per account)
+        // Resets the whole trailing state once per month when Day >= MonthlyResetDay.
+        // If MonthlyResetDay exceeds the days in the month, the last day is used.
+        // ---------------------------------------------------------------------
+        if (state.EnableMonthlyReset)
+        {
+            var daysInMonth = DateTime.DaysInMonth(nowLocal.Year, nowLocal.Month);
+
+            // Defensive clamp (state.MonthlyResetDay is UI-ranged, but keep it safe)
+            var requestedDay = state.MonthlyResetDay;
+            if (requestedDay < 1) requestedDay = 1;
+
+            var effectiveResetDay = requestedDay > daysInMonth ? daysInMonth : requestedDay;
+
+            var monthKey = (nowLocal.Year * 100) + nowLocal.Month; // yyyymm
+
+            // If we're past the reset day and we haven't reset this month yet -> reset now.
+            if (nowLocal.Day >= effectiveResetDay && state.LastMonthlyResetKey != monthKey)
+            {
+                // Full reset for the new "monthly period"
+                ResetActiveAccountState(state);
+
+                // Mark that we've reset this month (avoid multiple resets)
+                state.LastMonthlyResetKey = monthKey;
+
+                // Ensure we don't immediately re-init again due to a pending UI pulse
+                _reinitializeNow = false;
+            }
+        }
     }
 
     private void MaybeCaptureEodPeak(TrailingDdState state, decimal equity, DateTime nowLocal)

--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -10,6 +10,11 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Drawing;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Security.Cryptography;
 
 /// <summary>
 /// Displays account information on the chart including account ID, balance, blocked margin, available balance, and PnL.
@@ -68,6 +73,53 @@ public class AccountInfoDisplay : Indicator
         // Reset markers (per-account)
         public int LastMonthlyResetKey { get; set; } // yyyymm, e.g. 202512
     }
+
+    #region Persistence DTO
+
+    private sealed class PersistedRootV1
+    {
+        public int SchemaVersion { get; set; } = _schemaVersion;
+        public string UpdatedAtUtc { get; set; } = DateTime.UtcNow.ToString("O");
+
+        // Key: accountKey (AccountID or fallback)
+        public Dictionary<string, PersistedAccountV1> Accounts { get; set; } = new();
+    }
+
+    private sealed class PersistedAccountV1
+    {
+        public PersistedConfigV1 Config { get; set; } = new();
+        public PersistedRuntimeV1 Runtime { get; set; } = new();
+    }
+
+    private sealed class PersistedConfigV1
+    {
+        public bool EnableTrailingDrawdown { get; set; }
+        public decimal MaxTrailingDrawdown { get; set; }
+        public int InitializationMode { get; set; }            // enum as int
+        public decimal ManualStopEquity { get; set; }
+
+        public int PeakUpdateMode { get; set; }                // enum as int
+        public string EodTimeLocal { get; set; }               // "HH:mm:ss"
+
+        public bool EnableMonthlyReset { get; set; }
+        public int MonthlyResetDay { get; set; }
+    }
+
+    private sealed class PersistedRuntimeV1
+    {
+        public bool IsInitialized { get; set; }
+        public decimal StartEquity { get; set; }
+        public decimal PeakEquity { get; set; }
+        public decimal MaxOpenPnL { get; set; }
+
+        public string InitializedAtUtc { get; set; }           // "O"
+        public string LastEodCaptureDate { get; set; }         // "yyyy-MM-dd" (date only)
+
+        public int LastMonthlyResetKey { get; set; }           // yyyymm
+    }
+
+    #endregion
+
     #endregion
 
     #region Fields
@@ -100,6 +152,35 @@ public class AccountInfoDisplay : Indicator
 
     private bool _defaultEnableMonthlyReset = true;
     private int _defaultMonthlyResetDay = 1;
+
+    #endregion
+
+    #region Persistence
+
+    private const int _schemaVersion = 1;
+    private const string _stateFileName = "AccountInfoDisplay.states.v1.json";
+
+    private string _stateFilePath;
+
+    private PersistedRootV1 _persistedRoot;
+
+    // Dirty + throttle
+    private bool _isDirty;
+    private DateTime _lastSaveUtc = DateTime.MinValue;
+    private readonly TimeSpan _minSaveInterval = TimeSpan.FromSeconds(10);
+
+    // Fingerprint to skip redundant disk writes
+    private string _lastSavedHash = string.Empty;
+
+    // Json options
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        WriteIndented = true,
+        AllowTrailingCommas = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        PropertyNameCaseInsensitive = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
 
     #endregion
 
@@ -238,6 +319,7 @@ public class AccountInfoDisplay : Indicator
             if (state != null)
                 state.EnableTrailingDrawdown = value;
 
+            TouchActiveAccountAndScheduleSave(force: false);
             RedrawChart();
         }
     }
@@ -263,6 +345,7 @@ public class AccountInfoDisplay : Indicator
             if (state != null)
                 state.MaxTrailingDrawdown = value;
 
+            TouchActiveAccountAndScheduleSave(force: false);
             RedrawChart();
         }
     }
@@ -284,6 +367,7 @@ public class AccountInfoDisplay : Indicator
             if (state != null)
                 state.InitializationMode = value;
 
+            TouchActiveAccountAndScheduleSave(force: false);
             RedrawChart();
         }
     }
@@ -306,6 +390,7 @@ public class AccountInfoDisplay : Indicator
             if (state != null)
                 state.ManualStopEquity = value;
 
+            TouchActiveAccountAndScheduleSave(force: false);
             RedrawChart();
         }
     }
@@ -357,6 +442,7 @@ public class AccountInfoDisplay : Indicator
                 state.LastEodCaptureDate = default; // allow EOD capture immediately if applicable
             }
 
+            TouchActiveAccountAndScheduleSave(force: false);
             RedrawChart();
         }
     }
@@ -387,6 +473,7 @@ public class AccountInfoDisplay : Indicator
                 state.LastEodCaptureDate = default; 
             }
 
+            TouchActiveAccountAndScheduleSave(force: false);
             RedrawChart();
         }
     }
@@ -414,6 +501,7 @@ public class AccountInfoDisplay : Indicator
             if (state != null)
                 state.EnableMonthlyReset = value;
 
+            TouchActiveAccountAndScheduleSave(force: false);
             RedrawChart();
         }
     }
@@ -436,6 +524,7 @@ public class AccountInfoDisplay : Indicator
             if (state != null)
                 state.MonthlyResetDay = value;
 
+            TouchActiveAccountAndScheduleSave(force: false);
             RedrawChart();
         }
     }
@@ -485,15 +574,50 @@ public class AccountInfoDisplay : Indicator
 			TradingManager.PortfolioSelected += OnPortfolioSelected;
 			_currentPortfolio = TradingManager.Portfolio;
 		}
-	}
 
-	protected override void OnDispose()
+        InitPersistencePath();
+        LoadStateFromDisk();
+
+        // Ensure active portfolio state is created, then apply persisted data if present
+        var portfolio = _currentPortfolio ?? TradingManager?.Portfolio;
+        if (portfolio != null)
+        {
+            _activeAccountKey = GetAccountKey(portfolio);
+
+            // Create state with defaults
+            var state = GetOrCreateTrailingState(_activeAccountKey);
+
+            // Apply persisted data (if any)
+            ApplyLoadedStateToAccount(_activeAccountKey);
+
+            // Sync UI from loaded state (so UI shows per-account values)
+            SyncUiFromState(state);
+
+            RedrawChart();
+        }
+
+    }
+
+    protected override void OnDispose()
 	{
 		if (TradingManager != null)
 		{
 			TradingManager.PortfolioSelected -= OnPortfolioSelected;
 		}
-	}
+
+        try
+        {
+            if (!string.IsNullOrEmpty(_activeAccountKey))
+            {
+                PersistAccountToMemory(_activeAccountKey);
+                SaveIfNeeded(force: true);
+            }
+        }
+        catch
+        {
+            // ignore
+        }
+    }
 
 	protected override void OnCalculate(int bar, decimal value)
 	{
@@ -562,6 +686,10 @@ public class AccountInfoDisplay : Indicator
         );
 
         DrawColoredRows(context, rows, textRect, portfolio, maxLabelWidth);
+
+        // Throttled autosave (only if dirty)
+        if (_isDirty)
+            SaveIfNeeded(force: false);
     }
 
     #endregion
@@ -570,10 +698,25 @@ public class AccountInfoDisplay : Indicator
 
     private void OnPortfolioSelected(Portfolio portfolio)
     {
+        // 1) Persist previous account (upsert + save)
+        if (!string.IsNullOrEmpty(_activeAccountKey))
+        {
+            PersistAccountToMemory(_activeAccountKey);
+            MarkDirty();
+            SaveIfNeeded(force: true);
+        }
+
+        // 2) Switch
         _currentPortfolio = portfolio;
         _activeAccountKey = GetAccountKey(portfolio);
 
+        // 3) Ensure state exists
         var state = GetOrCreateTrailingState(_activeAccountKey);
+
+        // 4) Load persisted data for new account if present
+        ApplyLoadedStateToAccount(_activeAccountKey);
+
+        // 5) Sync UI from the per-account state
         SyncUiFromState(state);
 
         RedrawChart();
@@ -869,7 +1012,8 @@ public class AccountInfoDisplay : Indicator
                 // Full reset for the new "monthly period"
                 ResetActiveAccountState(state);
 
-
+                // Persist the reset (throttled)
+                TouchMonthlyResetAndScheduleSave(GetAccountKey(portfolio), force: false);
 
                 // Ensure we don't immediately re-init again due to a pending UI pulse
                 _reinitializeNow = false;
@@ -904,6 +1048,300 @@ public class AccountInfoDisplay : Indicator
     }
 
     #endregion
+
+    #region Persistence helpers
+
+    private void InitPersistencePath()
+    {
+        // %AppData%\Roaming\ATAS\JSON\AccountInfoDisplay.states.v1.json
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        var baseDir = Path.Combine(appData, "ATAS", "JSON");
+
+        Directory.CreateDirectory(baseDir);
+
+        _stateFilePath = Path.Combine(baseDir, _stateFileName);
+    }
+
+    private void LoadStateFromDisk()
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(_stateFilePath))
+                InitPersistencePath();
+
+            if (!File.Exists(_stateFilePath))
+            {
+                _persistedRoot = new PersistedRootV1();
+                return;
+            }
+
+            var json = File.ReadAllText(_stateFilePath, Encoding.UTF8);
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                _persistedRoot = new PersistedRootV1();
+                return;
+            }
+
+            var loaded = JsonSerializer.Deserialize<PersistedRootV1>(json, _jsonOptions);
+            if (loaded == null)
+            {
+                _persistedRoot = new PersistedRootV1();
+                return;
+            }
+
+            // Basic schema guard (v1 only for now)
+            if (loaded.SchemaVersion != _schemaVersion)
+            {
+                // For now: re-init, or you can implement migrations later.
+                _persistedRoot = new PersistedRootV1();
+                return;
+            }
+
+            loaded.Accounts ??= new Dictionary<string, PersistedAccountV1>();
+            _persistedRoot = loaded;
+
+            // Seed fingerprint to avoid immediate rewrite
+            _lastSavedHash = ComputeSha256(json);
+            _isDirty = false;
+        }
+        catch
+        {
+            // Fail-safe: never break indicator rendering due to IO/JSON issues.
+            _persistedRoot = new PersistedRootV1();
+        }
+    }
+
+    private void ApplyLoadedStateToAccount(string accountKey)
+    {
+        if (string.IsNullOrEmpty(accountKey))
+            return;
+
+        if (_persistedRoot?.Accounts == null)
+            return;
+
+        if (!_persistedRoot.Accounts.TryGetValue(accountKey, out var persisted))
+            return;
+
+        if (!_trailingStatesByAccount.TryGetValue(accountKey, out var state))
+            return;
+
+        var cfg = persisted.Config ?? new PersistedConfigV1();
+        var rt = persisted.Runtime ?? new PersistedRuntimeV1();
+
+        // --- Config ---
+        state.EnableTrailingDrawdown = cfg.EnableTrailingDrawdown;
+        state.MaxTrailingDrawdown = cfg.MaxTrailingDrawdown;
+        state.InitializationMode = (TrailingInitMode)cfg.InitializationMode;
+        state.ManualStopEquity = cfg.ManualStopEquity;
+
+        state.PeakUpdateMode = (TrailingPeakUpdateMode)cfg.PeakUpdateMode;
+        state.EodTimeLocal = ParseTimeSpanOrDefault(cfg.EodTimeLocal, state.EodTimeLocal);
+
+        state.EnableMonthlyReset = cfg.EnableMonthlyReset;
+        state.MonthlyResetDay = cfg.MonthlyResetDay;
+
+        // --- Runtime ---
+        state.IsInitialized = rt.IsInitialized;
+        state.StartEquity = rt.StartEquity;
+        state.PeakEquity = rt.PeakEquity;
+        state.MaxOpenPnL = rt.MaxOpenPnL;
+
+        state.InitializedAtUtc = ParseDateTimeOrDefault(rt.InitializedAtUtc, default);
+        state.LastEodCaptureDate = ParseDateOrDefault(rt.LastEodCaptureDate, default);
+
+        state.LastMonthlyResetKey = rt.LastMonthlyResetKey;
+
+        // IMPORTANT: loading should not mark dirty.
+    }
+
+    private void PersistAccountToMemory(string accountKey)
+    {
+        if (string.IsNullOrEmpty(accountKey))
+            return;
+
+        if (_persistedRoot == null)
+            _persistedRoot = new PersistedRootV1();
+
+        _persistedRoot.Accounts ??= new Dictionary<string, PersistedAccountV1>();
+
+        if (!_trailingStatesByAccount.TryGetValue(accountKey, out var state))
+            return;
+
+        if (!_persistedRoot.Accounts.TryGetValue(accountKey, out var persisted))
+        {
+            persisted = new PersistedAccountV1();
+            _persistedRoot.Accounts[accountKey] = persisted;
+        }
+
+        persisted.Config ??= new PersistedConfigV1();
+        persisted.Runtime ??= new PersistedRuntimeV1();
+
+        // --- Config ---
+        persisted.Config.EnableTrailingDrawdown = state.EnableTrailingDrawdown;
+        persisted.Config.MaxTrailingDrawdown = state.MaxTrailingDrawdown;
+        persisted.Config.InitializationMode = (int)state.InitializationMode;
+        persisted.Config.ManualStopEquity = state.ManualStopEquity;
+
+        persisted.Config.PeakUpdateMode = (int)state.PeakUpdateMode;
+        persisted.Config.EodTimeLocal = FormatTimeSpan(state.EodTimeLocal);
+
+        persisted.Config.EnableMonthlyReset = state.EnableMonthlyReset;
+        persisted.Config.MonthlyResetDay = state.MonthlyResetDay;
+
+        // --- Runtime ---
+        persisted.Runtime.IsInitialized = state.IsInitialized;
+        persisted.Runtime.StartEquity = state.StartEquity;
+        persisted.Runtime.PeakEquity = state.PeakEquity;
+        persisted.Runtime.MaxOpenPnL = state.MaxOpenPnL;
+
+        persisted.Runtime.InitializedAtUtc = state.InitializedAtUtc == default
+            ? null
+            : state.InitializedAtUtc.ToString("O");
+
+        persisted.Runtime.LastEodCaptureDate = state.LastEodCaptureDate == default
+            ? null
+            : state.LastEodCaptureDate.Date.ToString("yyyy-MM-dd");
+
+        persisted.Runtime.LastMonthlyResetKey = state.LastMonthlyResetKey;
+
+        _persistedRoot.UpdatedAtUtc = DateTime.UtcNow.ToString("O");
+    }
+
+    private void SaveIfNeeded(bool force)
+    {
+        if (_persistedRoot == null)
+            return;
+
+        if (string.IsNullOrEmpty(_stateFilePath))
+            InitPersistencePath();
+
+        if (!force)
+        {
+            if (!_isDirty)
+                return;
+
+            var nowUtc = DateTime.UtcNow;
+            if (nowUtc - _lastSaveUtc < _minSaveInterval)
+                return;
+        }
+
+        try
+        {
+            var json = JsonSerializer.Serialize(_persistedRoot, _jsonOptions);
+            var hash = ComputeSha256(json);
+
+            // Skip disk write if content identical
+            if (!force && string.Equals(hash, _lastSavedHash, StringComparison.Ordinal))
+            {
+                _isDirty = false;
+                return;
+            }
+
+            // Atomic-ish write: write temp then replace
+            var tmp = _stateFilePath + ".tmp";
+            File.WriteAllText(tmp, json, Encoding.UTF8);
+
+            if (File.Exists(_stateFilePath))
+            {
+                // Replace destination atomically; no need to delete first
+                File.Replace(tmp, _stateFilePath, null);
+            }
+
+            else
+
+            {
+                // First-time save
+                File.Move(tmp, _stateFilePath);
+            }
+
+            _lastSavedHash = hash;
+            _lastSaveUtc = DateTime.UtcNow;
+            _isDirty = false;
+        }
+        catch
+        {
+            // Never break indicator due to IO errors.
+            // Keep dirty true so we can retry later.
+            _isDirty = true;
+        }
+    }
+
+    private void MarkDirty()
+    {
+        _isDirty = true;
+    }
+
+    private static string ComputeSha256(string text)
+    {
+        if (text == null)
+            return string.Empty;
+
+        using var sha = SHA256.Create();
+        var bytes = Encoding.UTF8.GetBytes(text);
+        var hash = sha.ComputeHash(bytes);
+        return Convert.ToHexString(hash);
+    }
+
+    private static TimeSpan ParseTimeSpanOrDefault(string value, TimeSpan fallback)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return fallback;
+
+        return TimeSpan.TryParse(value, out var ts) ? ts : fallback;
+    }
+
+    private static string FormatTimeSpan(TimeSpan value)
+    {
+        // HH:mm:ss (safe, stable)
+        var h = (int)value.TotalHours;
+        var m = value.Minutes;
+        var s = value.Seconds;
+        return $"{h:00}:{m:00}:{s:00}";
+    }
+
+    private static DateTime ParseDateTimeOrDefault(string value, DateTime fallback)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return fallback;
+
+        return DateTime.TryParse(value, null, System.Globalization.DateTimeStyles.RoundtripKind, out var dt)
+            ? dt
+            : fallback;
+    }
+
+    private static DateTime ParseDateOrDefault(string value, DateTime fallback)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return fallback;
+
+        return DateTime.TryParseExact(value, "yyyy-MM-dd", null, System.Globalization.DateTimeStyles.None, out var dt)
+            ? dt.Date
+            : fallback;
+    }
+
+    private void TouchActiveAccountAndScheduleSave(bool force = false)
+    {
+        if (string.IsNullOrEmpty(_activeAccountKey))
+            return;
+
+        PersistAccountToMemory(_activeAccountKey);
+        MarkDirty();
+        SaveIfNeeded(force);
+    }
+
+    private void TouchMonthlyResetAndScheduleSave(string accountKey, bool force = false)
+    {
+        if (string.IsNullOrEmpty(accountKey))
+            return;
+
+        PersistAccountToMemory(accountKey);
+        MarkDirty();
+        SaveIfNeeded(force);
+    }
+
+
+    #endregion
+
 
     #endregion
 }

--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -223,22 +223,20 @@ public class AccountInfoDisplay : Indicator
     public decimal ManualStopEquity { get; set; } = 0m;
 
     [Display(
-        Name = "Reinitialize Now",
-        Description = "Forces trailing drawdown state re-initialization on next render.",
-        GroupName = "Funding / Trailing DD",
-        Order = 14
-    )]
+     Name = "Reinitialize Now",
+     Description = "Forces trailing drawdown state re-initialization on next render.",
+     GroupName = "Funding / Trailing DD",
+     Order = 14
+ )]
     public bool ReinitializeNow
     {
-        get => _reinitializeNow;
+        get => false; // always show unchecked (button-like)
         set
         {
-            if (value == _reinitializeNow)
+            if (!value)
                 return;
 
-            _reinitializeNow = value;
-
-            // Re-render immediately when toggled
+            _reinitializeNow = true;
             RedrawChart();
         }
     }

--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -813,6 +813,8 @@ public class AccountInfoDisplay : Indicator
             }
 
             // Draw value
+            var valueRect = new Rectangle(valueColumnX, currentY, textRect.Right - valueColumnX, lineHeight);
+            context.FillRectangle(_backgroundColor, valueRect);
             context.DrawString(valueStr, _font, valueColor, valueColumnX, currentY);
 
             currentY += lineHeight;


### PR DESCRIPTION
### Per-account trade snapshot + per-trade max open PnL reset

### Description
**Context**
This PR advances `AccountInfoDisplay` into a new phase: capturing a snapshot of the
current trade and fixing the previously confirmed bug where MaxOpenPnL was
historical across trades.

**What changed**
- Per-account position detection uses `TradingManager.Position` and validates
  `AccountID` + `Security` to avoid cross-account contamination.
- Introduces per-trade tracking:
  - `TradeOpenPnlBaseline` captured at trade open.
  - `TradeMaxOpenPnL` computed as the maximum of `(OpenPnL - baseline)` while
    the position is open.
  - Reset to `0` when a position closes so the next trade starts clean.
- No chart rendering changes in this PR (explicitly deferred to later phases).
- Per-trade runtime values are not persisted; they are recomputed at runtime.

**Why**
Carrying the previous trade’s max into the next
trade produced incorrect and confusing readings.

**Testing notes**
- Switch accounts and confirm the trade snapshot and TradeMaxOpenPnL reflect the
  currently selected account only.
- Open a trade, let OpenPnL peak, close the trade, then open a new trade:
  TradeMaxOpenPnL should reset to 0 at the new trade open and track the new peak.

### Checklist
- [ ] Build passes locally
- [ ] Verified account switching keeps calculations per-account
- [ ] Verified TradeMaxOpenPnL resets on each new trade