### PR TITLE
Feature/account info - Daily Rails

### DIFF
--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -1,17 +1,16 @@
 namespace ATAS.Indicators.Technical;
 
-using System;
-using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
-using System.Drawing;
-using System.Text;
-
 using ATAS.DataFeedsCore;
-
 using OFT.Attributes;
 using OFT.Localization;
 using OFT.Rendering.Context;
 using OFT.Rendering.Tools;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Drawing;
+using System.Text;
 
 /// <summary>
 /// Displays account information on the chart including account ID, balance, blocked margin, available balance, and PnL.
@@ -22,9 +21,29 @@ using OFT.Rendering.Tools;
 [Display(ResourceType = typeof(Strings), Description = nameof(Strings.AccountInfoDisplayDescription))]
 public class AccountInfoDisplay : Indicator
 {
-	#region Fields
+    #region class
+    private sealed class DisplayRow
+    {
+        public string Label { get; }
+        public string ValueText { get; }
 
-	private Color _backgroundColor = Color.FromArgb(200, 20, 25, 35);
+        // Not used yet in Phase 0 (kept for Phase 1/2).
+        public decimal? NumericValue { get; }
+        public CrossColor? ValueColorOverride { get; }
+
+        public DisplayRow(string label, string valueText, decimal? numericValue = null, CrossColor? valueColorOverride = null)
+        {
+            Label = label ?? string.Empty;
+            ValueText = valueText ?? string.Empty;
+            NumericValue = numericValue;
+            ValueColorOverride = valueColorOverride;
+        }
+    }
+    #endregion
+
+    #region Fields
+
+    private Color _backgroundColor = Color.FromArgb(200, 20, 25, 35);
 	private Color _textColor = Color.FromArgb(220, 220, 220);
 	private Color _positiveColor = Color.FromArgb(0, 230, 118);
 	private Color _negativeColor = Color.FromArgb(255, 82, 82);
@@ -208,150 +227,175 @@ public class AccountInfoDisplay : Indicator
 		// No calculation needed
 	}
 
-	protected override void OnRender(RenderContext context, DrawingLayouts layout)
-	{
-		if (ChartInfo == null || Container?.Region == null)
-			return;
+    protected override void OnRender(RenderContext context, DrawingLayouts layout)
+    {
+        if (ChartInfo == null || Container?.Region == null)
+            return;
 
-		// Get current portfolio
-		var portfolio = _currentPortfolio ?? TradingManager?.Portfolio;
-		if (portfolio == null)
-			return;
+        // Get current portfolio
+        var portfolio = _currentPortfolio ?? TradingManager?.Portfolio;
+        if (portfolio == null)
+            return;
 
-		// Build display text
-		var text = BuildDisplayText(portfolio);
-		if (string.IsNullOrEmpty(text))
-			return;
+        // Build structured rows (Phase 0 replacement)
+        var rows = BuildRows(portfolio);
+        if (rows == null || rows.Count == 0)
+            return;
 
-		// Calculate proper dimensions for table layout
-		var lines = text.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
-		var lineHeight = context.MeasureString("A", _font).Height;
+        // Calculate proper dimensions for table layout
+        var lineHeight = context.MeasureString("A", _font).Height;
 
-		var maxLabelWidth = 0;
-		var maxValueWidth = 0;
+        var maxLabelWidth = 0;
+        var maxValueWidth = 0;
 
-		foreach (var line in lines)
-		{
-			var parts = line.Split('|');
-			if (parts.Length == 2)
-			{
-				var labelWidth = (int)context.MeasureString(parts[0], _font).Width;
-				var valueWidth = (int)context.MeasureString(parts[1], _font).Width;
+        foreach (var row in rows)
+        {
+            var labelWidth = (int)context.MeasureString(row.Label, _font).Width;
+            var valueWidth = (int)context.MeasureString(row.ValueText, _font).Width;
 
-				if (labelWidth > maxLabelWidth)
-					maxLabelWidth = labelWidth;
-				if (valueWidth > maxValueWidth)
-					maxValueWidth = valueWidth;
-			}
-		}
+            if (labelWidth > maxLabelWidth)
+                maxLabelWidth = labelWidth;
 
-		var padding = 10;
-		var rectWidth = maxLabelWidth + ColumnSpacing + maxValueWidth + padding * 2;
-		var rectHeight = lines.Length * lineHeight + padding * 2;
+            if (valueWidth > maxValueWidth)
+                maxValueWidth = valueWidth;
+        }
 
-		// Calculate position
-		var x = CalculateXPosition(rectWidth);
-		var y = CalculateYPosition(rectHeight);
+        var padding = 10;
+        var rectWidth = maxLabelWidth + ColumnSpacing + maxValueWidth + padding * 2;
+        var rectHeight = rows.Count * lineHeight + padding * 2;
 
-		// Draw background
-		var rectangle = new Rectangle(x, y, rectWidth, rectHeight);
-		context.FillRectangle(_backgroundColor, rectangle);
+        // Calculate position
+        var x = CalculateXPosition(rectWidth);
+        var y = CalculateYPosition(rectHeight);
 
-		// Draw border
-		context.DrawRectangle(new RenderPen(Color.Gray, 1), rectangle);
+        // Draw background
+        var rectangle = new Rectangle(x, y, rectWidth, rectHeight);
+        context.FillRectangle(_backgroundColor, rectangle);
 
-		// Draw text
-		var textRect = new Rectangle(x + padding, y + padding, rectWidth - padding * 2, rectHeight - padding * 2);
-		DrawColoredText(context, text, textRect, portfolio, maxLabelWidth);
-	}
+        // Draw border
+        context.DrawRectangle(new RenderPen(Color.Gray, 1), rectangle);
 
-	#endregion
+        // Draw text (keep existing coloring logic for Phase 0)
+        var textRect = new Rectangle(
+            x + padding,
+            y + padding,
+            rectWidth - padding * 2,
+            rectHeight - padding * 2
+        );
 
-	#region Private Methods
+        DrawColoredRows(context, rows, textRect, portfolio, maxLabelWidth);
+    }
 
-	private void OnPortfolioSelected(Portfolio portfolio)
+    #endregion
+
+    #region Private Methods
+
+    private void OnPortfolioSelected(Portfolio portfolio)
 	{
 		_currentPortfolio = portfolio;
 		RedrawChart();
 	}
 
-	private string BuildDisplayText(Portfolio portfolio)
-	{
-		var sb = new StringBuilder();
+    private List<DisplayRow> BuildRows(Portfolio portfolio)
+    {
+        var rows = new List<DisplayRow>();
 
-		if (ShowAccountId)
-			sb.AppendLine($"Account|{portfolio.AccountID}");
+        if (portfolio == null)
+            return rows;
 
-		if (ShowCurrency && portfolio.Currency.HasValue)
-			sb.AppendLine($"Currency|{portfolio.Currency}");
+        if (ShowAccountId)
+            rows.Add(new DisplayRow(
+                "Account",
+                portfolio.AccountID
+            ));
 
-		if (ShowBalance)
-			sb.AppendLine($"Balance|{FormatCurrency(portfolio.Balance)}");
+        if (ShowCurrency && portfolio.Currency.HasValue)
+            rows.Add(new DisplayRow(
+                "Currency",
+                portfolio.Currency.Value.ToString()
+            ));
 
-		if (ShowAvailableBalance && portfolio.BalanceAvailable.HasValue)
-			sb.AppendLine($"Available|{FormatCurrency(portfolio.BalanceAvailable.Value)}");
+        if (ShowBalance)
+            rows.Add(new DisplayRow(
+                "Balance",
+                FormatCurrency(portfolio.Balance)
+            ));
 
-		if (ShowMargin)
-			sb.AppendLine($"Blocked Margin|{FormatCurrency(portfolio.BlockedMargin)}");
+        if (ShowAvailableBalance && portfolio.BalanceAvailable.HasValue)
+            rows.Add(new DisplayRow(
+                "Available",
+                FormatCurrency(portfolio.BalanceAvailable.Value)
+            ));
 
-		if (ShowLeverage && portfolio.Leverage != 1)
-			sb.AppendLine($"Leverage|{portfolio.Leverage:F2}x");
+        if (ShowMargin)
+            rows.Add(new DisplayRow(
+                "Blocked Margin",
+                FormatCurrency(portfolio.BlockedMargin)
+            ));
 
-		if (ShowOpenPnL)
-			sb.AppendLine($"Open PnL|{FormatCurrency(portfolio.OpenPnL)}");
+        if (ShowLeverage && portfolio.Leverage != 1)
+            rows.Add(new DisplayRow(
+                "Leverage",
+                $"{portfolio.Leverage:F2}x"
+            ));
 
-		if (ShowClosedPnL)
-			sb.AppendLine($"Closed PnL|{FormatCurrency(portfolio.ClosedPnL)}");
+        if (ShowOpenPnL)
+            rows.Add(new DisplayRow(
+                "Open PnL",
+                FormatCurrency(portfolio.OpenPnL)
+            ));
 
-		if (ShowTotalPnL)
-			sb.AppendLine($"Total PnL|{FormatCurrency(portfolio.ClosedPnL + portfolio.OpenPnL)}");
+        if (ShowClosedPnL)
+            rows.Add(new DisplayRow(
+                "Closed PnL",
+                FormatCurrency(portfolio.ClosedPnL)
+            ));
 
-		return sb.ToString().TrimEnd();
-	}
+        if (ShowTotalPnL)
+            rows.Add(new DisplayRow(
+                "Total PnL",
+                FormatCurrency(portfolio.ClosedPnL + portfolio.OpenPnL)
+            ));
 
-	private void DrawColoredText(RenderContext context, string text, Rectangle textRect, Portfolio portfolio, int maxLabelWidth)
-	{
-		var lines = text.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
-		var lineHeight = context.MeasureString("A", _font).Height;
+        return rows;
+    }
 
-		// Calculate value column position
-		var valueColumnX = textRect.X + maxLabelWidth + ColumnSpacing;
-		var currentY = textRect.Y;
+    private void DrawColoredRows(RenderContext context, List<DisplayRow> rows, Rectangle textRect, Portfolio portfolio, int maxLabelWidth)
+    {
+        var lineHeight = context.MeasureString("A", _font).Height;
 
-		// Draw lines
-		foreach (var line in lines)
-		{
-			var parts = line.Split('|');
-			if (parts.Length == 2)
-			{
-				var label = parts[0];
-				var valueStr = parts[1];
+        // Calculate value column position
+        var valueColumnX = textRect.X + maxLabelWidth + ColumnSpacing;
+        var currentY = textRect.Y;
 
-				// Draw label
-				context.DrawString(label, _font, _textColor, textRect.X, currentY);
+        foreach (var row in rows)
+        {
+            var label = row?.Label ?? string.Empty;
+            var valueStr = row?.ValueText ?? string.Empty;
 
-				// Determine color for value
-				var valueColor = _textColor;
-				if (line.Contains("PnL"))
-				{
-					var value = ExtractNumericValue(valueStr);
-					valueColor = value > 0 ? _positiveColor : (value < 0 ? _negativeColor : _neutralColor);
-				}
+            // Draw label
+            context.DrawString(label, _font, _textColor, textRect.X, currentY);
 
-				// Draw value
-				context.DrawString(valueStr, _font, valueColor, valueColumnX, currentY);
-			}
-			else
-			{
-				// Fallback for malformed lines
-				context.DrawString(line, _font, _textColor, textRect.X, currentY);
-			}
+            // Determine color for value (Phase 0: keep current behavior)
+            var valueColor = _textColor;
 
-			currentY += lineHeight;
-		}
-	}
+            // Replace old `line.Contains("PnL")` with label check, preserving the intent.
+            if (label.Contains("PnL", StringComparison.OrdinalIgnoreCase))
+            {
+                var value = ExtractNumericValue(valueStr);
+                valueColor = value > 0
+                    ? _positiveColor
+                    : (value < 0 ? _negativeColor : _neutralColor);
+            }
 
-	private decimal ExtractNumericValue(string valueStr)
+            // Draw value
+            context.DrawString(valueStr, _font, valueColor, valueColumnX, currentY);
+
+            currentY += lineHeight;
+        }
+    }
+
+    private decimal ExtractNumericValue(string valueStr)
 	{
 		// Remove currency symbols and try to parse
 		var cleanStr = valueStr.Replace(",", "").Trim();

--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -10,7 +10,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Drawing;
-using System.Text;
 
 /// <summary>
 /// Displays account information on the chart including account ID, balance, blocked margin, available balance, and PnL.
@@ -342,20 +341,27 @@ public class AccountInfoDisplay : Indicator
         if (ShowOpenPnL)
             rows.Add(new DisplayRow(
                 "Open PnL",
-                FormatCurrency(portfolio.OpenPnL)
+                FormatCurrency(portfolio.OpenPnL),
+                numericValue: portfolio.OpenPnL
             ));
 
         if (ShowClosedPnL)
             rows.Add(new DisplayRow(
                 "Closed PnL",
-                FormatCurrency(portfolio.ClosedPnL)
+                FormatCurrency(portfolio.ClosedPnL),
+                numericValue: portfolio.ClosedPnL
             ));
 
         if (ShowTotalPnL)
+        {
+            var totalPnL = portfolio.ClosedPnL + portfolio.OpenPnL;
+
             rows.Add(new DisplayRow(
                 "Total PnL",
-                FormatCurrency(portfolio.ClosedPnL + portfolio.OpenPnL)
+                FormatCurrency(totalPnL),
+                numericValue: totalPnL
             ));
+        }
 
         return rows;
     }
@@ -379,10 +385,9 @@ public class AccountInfoDisplay : Indicator
             // Determine color for value (Phase 0: keep current behavior)
             var valueColor = _textColor;
 
-            // Replace old `line.Contains("PnL")` with label check, preserving the intent.
-            if (label.Contains("PnL", StringComparison.OrdinalIgnoreCase))
+            if (row.NumericValue.HasValue)
             {
-                var value = ExtractNumericValue(valueStr);
+                var value = row.NumericValue.Value;
                 valueColor = value > 0
                     ? _positiveColor
                     : (value < 0 ? _negativeColor : _neutralColor);
@@ -394,15 +399,6 @@ public class AccountInfoDisplay : Indicator
             currentY += lineHeight;
         }
     }
-
-    private decimal ExtractNumericValue(string valueStr)
-	{
-		// Remove currency symbols and try to parse
-		var cleanStr = valueStr.Replace(",", "").Trim();
-		if (decimal.TryParse(cleanStr, out var result))
-			return result;
-		return 0;
-	}
 
 	private string FormatCurrency(decimal value)
 	{

--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -11,10 +11,10 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Drawing;
 using System.IO;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Security.Cryptography;
 
 /// <summary>
 /// Displays account information on the chart including account ID, balance, blocked margin, available balance, and PnL.
@@ -50,7 +50,12 @@ public class AccountInfoDisplay : Indicator
 
         public decimal StartEquity { get; set; }
         public decimal PeakEquity { get; set; }
-        public decimal MaxOpenPnL { get; set; }
+
+        // Phase 1: per-trade max open pnl (NOT historical)
+        public decimal TradeMaxOpenPnL { get; set; }
+        public bool WasPositionOpen { get; set; }
+        public decimal TradeOpenPnlBaseline { get; set; }   // portfolio.OpenPnL en el momento de apertura
+
         public DateTime InitializedAtUtc { get; set; }
 
         // Per-account config
@@ -72,6 +77,8 @@ public class AccountInfoDisplay : Indicator
 
         // Reset markers (per-account)
         public int LastMonthlyResetKey { get; set; } // yyyymm, e.g. 202512
+
+
     }
 
     #region Persistence DTO
@@ -118,6 +125,20 @@ public class AccountInfoDisplay : Indicator
         public int LastMonthlyResetKey { get; set; }           // yyyymm
     }
 
+    #endregion
+
+    #region Live position tracker
+
+    private sealed class PositionSnapshot
+    {
+        public bool IsOpen { get; set; }
+        public OrderDirections Direction { get; set; }
+        public decimal Volume { get; set; }           // absolute contracts
+        public decimal AvgEntryPrice { get; set; }
+        public DateTime OpenTime { get; set; }
+        public string SecurityCode { get; set; }
+        public string AccountId { get; set; }
+    }
     #endregion
 
     #endregion
@@ -181,6 +202,13 @@ public class AccountInfoDisplay : Indicator
         PropertyNameCaseInsensitive = true,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
     };
+
+    #endregion
+
+    #region Live position tracker
+
+    // Trade rebuild buffers (per active account+symbol)
+    private PositionSnapshot _posSnapshot = new();
 
     #endregion
 
@@ -636,6 +664,9 @@ public class AccountInfoDisplay : Indicator
         _activeAccountKey = GetAccountKey(portfolio);
         var state = GetOrCreateTrailingState(_activeAccountKey);
 
+        // Phase 1: update live position snapshot (single open position assumption)
+        UpdatePositionSnapshotFromTradingManager(portfolio);
+
         // Phase 2: equity and trailing DD state
         var equity = portfolio.Balance + portfolio.OpenPnL;
         var nowLocal = DateTime.Now;
@@ -709,6 +740,7 @@ public class AccountInfoDisplay : Indicator
         // 2) Switch
         _currentPortfolio = portfolio;
         _activeAccountKey = GetAccountKey(portfolio);
+        _reinitializeNow = false;
 
         // 3) Ensure state exists
         var state = GetOrCreateTrailingState(_activeAccountKey);
@@ -718,6 +750,8 @@ public class AccountInfoDisplay : Indicator
 
         // 5) Sync UI from the per-account state
         SyncUiFromState(state);
+
+        _posSnapshot = new PositionSnapshot();
 
         RedrawChart();
     }
@@ -779,7 +813,20 @@ public class AccountInfoDisplay : Indicator
             // We keep numericValue as negative magnitude so existing color rules (pos=green, neg=red) still work.
             rows.Add(new DisplayRow("Current DD", FormatCurrency(currentDd), numericValue: -currentDd));
 
-            rows.Add(new DisplayRow("Max Open PnL", FormatCurrency(state.MaxOpenPnL), numericValue: state.MaxOpenPnL));
+            rows.Add(new DisplayRow("Trade Max Open PnL", FormatCurrency(state.TradeMaxOpenPnL), numericValue: state.TradeMaxOpenPnL));
+
+        }
+
+        // --- Phase 1: Current position snapshot (debug/info) ---
+        if (_posSnapshot != null && _posSnapshot.IsOpen)
+        {
+            rows.Add(new DisplayRow("Pos Dir", _posSnapshot.Direction.ToString()));
+            rows.Add(new DisplayRow("Pos Qty", _posSnapshot.Volume.ToString("N0")));
+            rows.Add(new DisplayRow("Pos Entry", _posSnapshot.AvgEntryPrice.ToString("N2")));
+        }
+        else
+        {
+            rows.Add(new DisplayRow("Pos", "FLAT"));
         }
 
         return rows;
@@ -855,9 +902,13 @@ public class AccountInfoDisplay : Indicator
         state.IsInitialized = false;
         state.StartEquity = 0m;
         state.PeakEquity = 0m;
-        state.MaxOpenPnL = 0m;
+
+        // Phase 1
+        state.TradeMaxOpenPnL = 0m;
+        state.WasPositionOpen = false;
         state.InitializedAtUtc = default;
         state.LastEodCaptureDate = default;
+        state.TradeOpenPnlBaseline = 0m;
 
         _reinitializeNow = false;
     }
@@ -895,7 +946,9 @@ public class AccountInfoDisplay : Indicator
             state.PeakEquity = equity;
         }
 
-        state.MaxOpenPnL = portfolio.OpenPnL;
+        state.TradeMaxOpenPnL = 0m;
+        state.WasPositionOpen = false;
+        state.TradeOpenPnlBaseline = 0m;
 
         // Consume the pulse
         _reinitializeNow = false;
@@ -906,10 +959,33 @@ public class AccountInfoDisplay : Indicator
         if (!state.EnableTrailingDrawdown || !state.IsInitialized)
             return;
 
-        // Max OpenPnL is always realtime (it is informational and useful regardless of EOD).
-        if (portfolio.OpenPnL > state.MaxOpenPnL)
-            state.MaxOpenPnL = portfolio.OpenPnL;
+        // Phase 1: per-trade tracking (single open position assumption)
+        var isOpen = IsActivePositionOpen(portfolio);
 
+        if (!isOpen)
+        {
+            state.TradeMaxOpenPnL = 0m;
+            state.TradeOpenPnlBaseline = 0m;
+            state.WasPositionOpen = false;
+        }
+        else
+        {
+            if (!state.WasPositionOpen)
+            {
+                // Trade just opened => lock baseline and reset per-trade max to 0
+                state.TradeOpenPnlBaseline = portfolio.OpenPnL;
+                state.TradeMaxOpenPnL = 0m;
+                state.WasPositionOpen = true;
+            }
+
+            // OpenPnL "since entry" (starts at 0 at trade open)
+            var tradeOpenPnl = portfolio.OpenPnL - state.TradeOpenPnlBaseline;
+
+            if (tradeOpenPnl > state.TradeMaxOpenPnL)
+                state.TradeMaxOpenPnL = tradeOpenPnl;
+        }
+
+        // PeakEquity policy
         if (state.PeakUpdateMode == TrailingPeakUpdateMode.Realtime)
         {
             if (equity > state.PeakEquity)
@@ -921,6 +997,7 @@ public class AccountInfoDisplay : Indicator
         // EOD mode
         MaybeCaptureEodPeak(state, equity, nowLocal);
     }
+
 
     #endregion
 
@@ -1146,7 +1223,9 @@ public class AccountInfoDisplay : Indicator
         state.IsInitialized = rt.IsInitialized;
         state.StartEquity = rt.StartEquity;
         state.PeakEquity = rt.PeakEquity;
-        state.MaxOpenPnL = rt.MaxOpenPnL;
+        state.WasPositionOpen = false;
+        state.TradeMaxOpenPnL = 0m;
+        state.TradeOpenPnlBaseline = 0m;
 
         state.InitializedAtUtc = ParseDateTimeOrDefault(rt.InitializedAtUtc, default);
         state.LastEodCaptureDate = ParseDateOrDefault(rt.LastEodCaptureDate, default);
@@ -1194,7 +1273,6 @@ public class AccountInfoDisplay : Indicator
         persisted.Runtime.IsInitialized = state.IsInitialized;
         persisted.Runtime.StartEquity = state.StartEquity;
         persisted.Runtime.PeakEquity = state.PeakEquity;
-        persisted.Runtime.MaxOpenPnL = state.MaxOpenPnL;
 
         persisted.Runtime.InitializedAtUtc = state.InitializedAtUtc == default
             ? null
@@ -1339,6 +1417,86 @@ public class AccountInfoDisplay : Indicator
         PersistAccountToMemory(accountKey);
         MarkDirty();
         SaveIfNeeded(force);
+    }
+
+
+    #endregion
+
+    #region Live position tracker helpers
+    // ===========================
+    // Phase 1: Position tracker
+    // ===========================
+
+    private void UpdatePositionSnapshotFromTradingManager(Portfolio portfolio)
+    {
+        _posSnapshot ??= new PositionSnapshot();
+
+        var tm = TradingManager;
+        var pos = tm?.Position;
+        var sec = tm?.Security;
+
+        if (portfolio == null || pos == null || sec == null)
+        {
+            _posSnapshot.IsOpen = false;
+            return;
+        }
+
+        // Defensive: ensure the position belongs to the currently selected portfolio/security
+        if (!string.Equals(pos.AccountID, portfolio.AccountID, StringComparison.Ordinal))
+        {
+            _posSnapshot.IsOpen = false;
+            return;
+        }
+
+        if (pos.Security == null || !string.Equals(pos.Security.Code, sec.Code, StringComparison.Ordinal))
+        {
+            _posSnapshot.IsOpen = false;
+            return;
+        }
+
+        var isOpen = pos.IsInPosition && pos.Volume != 0m;
+
+        if (!isOpen)
+        {
+            _posSnapshot = new PositionSnapshot
+            {
+                IsOpen = false,
+                AccountId = portfolio.AccountID,
+                SecurityCode = sec.Code
+            };
+            return;
+        }
+
+        var dir = pos.Volume > 0m ? OrderDirections.Buy : OrderDirections.Sell;
+
+        _posSnapshot = new PositionSnapshot
+        {
+            IsOpen = true,
+            Direction = dir,
+            Volume = Math.Abs(pos.Volume),
+            AvgEntryPrice = pos.AveragePrice,
+            AccountId = portfolio.AccountID,
+            SecurityCode = sec.Code
+            // OpenTime: if needed in Phase 1, it can be approximated using MyTrades; not required for per-trade max reset.
+        };
+    }
+
+    private bool IsActivePositionOpen(Portfolio portfolio)
+    {
+        var tm = TradingManager;
+        var pos = tm?.Position;
+        var sec = tm?.Security;
+
+        if (portfolio == null || pos == null || sec == null)
+            return false;
+
+        if (!string.Equals(pos.AccountID, portfolio.AccountID, StringComparison.Ordinal))
+            return false;
+
+        if (pos.Security == null || !string.Equals(pos.Security.Code, sec.Code, StringComparison.Ordinal))
+            return false;
+
+        return pos.IsInPosition && pos.Volume != 0m;
     }
 
 

--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -16,7 +16,7 @@ using System.Drawing;
 /// </summary>
 [HelpLink("https://help.atas.net/en/support/solutions/articles/72000648751-account-info-display")]
 [Category(IndicatorCategories.Trading)]
-[DisplayName("Account Info Display")]
+[DisplayName("Account Info Display Modif")]
 [Display(ResourceType = typeof(Strings), Description = nameof(Strings.AccountInfoDisplayDescription))]
 public class AccountInfoDisplay : Indicator
 {
@@ -38,6 +38,16 @@ public class AccountInfoDisplay : Indicator
             ValueColorOverride = valueColorOverride;
         }
     }
+
+    private sealed class TrailingDdState
+    {
+        public decimal StartEquity { get; set; }
+        public decimal PeakEquity { get; set; }
+        public decimal MaxOpenPnL { get; set; }
+        public DateTime InitializedAtUtc { get; set; }
+
+        public bool IsInitialized { get; set; }
+    }
     #endregion
 
     #region Fields
@@ -56,11 +66,13 @@ public class AccountInfoDisplay : Indicator
 
 	private Portfolio _currentPortfolio;
 
-	#endregion
+    private TrailingDdState _trailingState = new();
 
-	#region Properties
+    #endregion
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.BackGround),
+    #region Properties
+
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.BackGround),
 		Description = nameof(Strings.LabelFillColorDescription), GroupName = nameof(Strings.Visualization))]
 	public CrossColor BackgroundColor
 	{
@@ -168,11 +180,78 @@ public class AccountInfoDisplay : Indicator
 	[Range(5, 50)]
 	public int ColumnSpacing { get; set; } = 15;
 
-	#endregion
+    #region Trailing Drawdown Settings
 
-	#region Enums
+    public enum TrailingInitMode
+    {
+        AutoFromCurrentEquity = 0,
+        ManualStopEquity = 1
+    }
 
-	public enum HorizontalAlignment
+    [Display(
+        Name = "Enable Trailing Drawdown",
+        Description = "Enable trailing drawdown tracking based on peak equity.",
+        GroupName = "Funding / Trailing DD",
+        Order = 10
+    )]
+    public bool EnableTrailingDrawdown { get; set; } = true;
+
+    [Display(
+        Name = "Max Trailing Drawdown",
+        Description = "Maximum allowed trailing drawdown from peak equity (absolute currency amount).",
+        GroupName = "Funding / Trailing DD",
+        Order = 11
+    )]
+    [Range(0, 1_000_000)]
+    public decimal MaxTrailingDrawdown { get; set; } = 2500m;
+
+    [Display(
+        Name = "Initialization Mode",
+        Description = "How the trailing drawdown state is initialized.",
+        GroupName = "Funding / Trailing DD",
+        Order = 12
+    )]
+    public TrailingInitMode InitializationMode { get; set; } = TrailingInitMode.AutoFromCurrentEquity;
+
+    [Display(
+        Name = "Manual Stop Equity",
+        Description = "Current liquidation/stop equity level (bootstrap). Peak is derived as Stop + Max DD.",
+        GroupName = "Funding / Trailing DD",
+        Order = 13
+    )]
+    [Range(-1_000_000, 10_000_000)]
+    public decimal ManualStopEquity { get; set; } = 0m;
+
+    [Display(
+        Name = "Reinitialize Now",
+        Description = "Forces trailing drawdown state re-initialization on next render.",
+        GroupName = "Funding / Trailing DD",
+        Order = 14
+    )]
+    public bool ReinitializeNow
+    {
+        get => _reinitializeNow;
+        set
+        {
+            if (value == _reinitializeNow)
+                return;
+
+            _reinitializeNow = value;
+
+            // Re-render immediately when toggled
+            RedrawChart();
+        }
+    }
+
+    private bool _reinitializeNow;
+
+    #endregion
+
+    #endregion
+
+    #region Enums
+
+    public enum HorizontalAlignment
 	{
 		Left,
 		Center,
@@ -231,17 +310,20 @@ public class AccountInfoDisplay : Indicator
         if (ChartInfo == null || Container?.Region == null)
             return;
 
-        // Get current portfolio
         var portfolio = _currentPortfolio ?? TradingManager?.Portfolio;
         if (portfolio == null)
             return;
 
-        // Build structured rows (Phase 0 replacement)
-        var rows = BuildRows(portfolio);
+        // Phase 2: equity and trailing DD state
+        var equity = portfolio.Balance + portfolio.OpenPnL;
+
+        InitializeTrailingState(portfolio, equity);
+        UpdateTrailingState(portfolio, equity);
+
+        var rows = BuildRows(portfolio, equity); // updated signature
         if (rows == null || rows.Count == 0)
             return;
 
-        // Calculate proper dimensions for table layout
         var lineHeight = context.MeasureString("A", _font).Height;
 
         var maxLabelWidth = 0;
@@ -263,18 +345,14 @@ public class AccountInfoDisplay : Indicator
         var rectWidth = maxLabelWidth + ColumnSpacing + maxValueWidth + padding * 2;
         var rectHeight = rows.Count * lineHeight + padding * 2;
 
-        // Calculate position
         var x = CalculateXPosition(rectWidth);
         var y = CalculateYPosition(rectHeight);
 
-        // Draw background
         var rectangle = new Rectangle(x, y, rectWidth, rectHeight);
         context.FillRectangle(_backgroundColor, rectangle);
 
-        // Draw border
         context.DrawRectangle(new RenderPen(Color.Gray, 1), rectangle);
 
-        // Draw text (keep existing coloring logic for Phase 0)
         var textRect = new Rectangle(
             x + padding,
             y + padding,
@@ -292,75 +370,68 @@ public class AccountInfoDisplay : Indicator
     private void OnPortfolioSelected(Portfolio portfolio)
 	{
 		_currentPortfolio = portfolio;
-		RedrawChart();
+        ResetTrailingState();
+        RedrawChart();
 	}
 
-    private List<DisplayRow> BuildRows(Portfolio portfolio)
+    private List<DisplayRow> BuildRows(Portfolio portfolio, decimal equity)
     {
         var rows = new List<DisplayRow>();
 
         if (portfolio == null)
             return rows;
 
+        // --- Existing rows (unchanged) ---
         if (ShowAccountId)
-            rows.Add(new DisplayRow(
-                "Account",
-                portfolio.AccountID
-            ));
+            rows.Add(new DisplayRow("Account", portfolio.AccountID));
 
         if (ShowCurrency && portfolio.Currency.HasValue)
-            rows.Add(new DisplayRow(
-                "Currency",
-                portfolio.Currency.Value.ToString()
-            ));
+            rows.Add(new DisplayRow("Currency", portfolio.Currency.Value.ToString()));
 
         if (ShowBalance)
-            rows.Add(new DisplayRow(
-                "Balance",
-                FormatCurrency(portfolio.Balance)
-            ));
+            rows.Add(new DisplayRow("Balance", FormatCurrency(portfolio.Balance)));
 
         if (ShowAvailableBalance && portfolio.BalanceAvailable.HasValue)
-            rows.Add(new DisplayRow(
-                "Available",
-                FormatCurrency(portfolio.BalanceAvailable.Value)
-            ));
+            rows.Add(new DisplayRow("Available", FormatCurrency(portfolio.BalanceAvailable.Value)));
 
         if (ShowMargin)
-            rows.Add(new DisplayRow(
-                "Blocked Margin",
-                FormatCurrency(portfolio.BlockedMargin)
-            ));
+            rows.Add(new DisplayRow("Blocked Margin", FormatCurrency(portfolio.BlockedMargin)));
 
         if (ShowLeverage && portfolio.Leverage != 1)
-            rows.Add(new DisplayRow(
-                "Leverage",
-                $"{portfolio.Leverage:F2}x"
-            ));
+            rows.Add(new DisplayRow("Leverage", $"{portfolio.Leverage:F2}x"));
 
         if (ShowOpenPnL)
-            rows.Add(new DisplayRow(
-                "Open PnL",
-                FormatCurrency(portfolio.OpenPnL),
-                numericValue: portfolio.OpenPnL
-            ));
+            rows.Add(new DisplayRow("Open PnL", FormatCurrency(portfolio.OpenPnL), numericValue: portfolio.OpenPnL));
 
         if (ShowClosedPnL)
-            rows.Add(new DisplayRow(
-                "Closed PnL",
-                FormatCurrency(portfolio.ClosedPnL),
-                numericValue: portfolio.ClosedPnL
-            ));
+            rows.Add(new DisplayRow("Closed PnL", FormatCurrency(portfolio.ClosedPnL), numericValue: portfolio.ClosedPnL));
 
         if (ShowTotalPnL)
         {
             var totalPnL = portfolio.ClosedPnL + portfolio.OpenPnL;
+            rows.Add(new DisplayRow("Total PnL", FormatCurrency(totalPnL), numericValue: totalPnL));
+        }
 
-            rows.Add(new DisplayRow(
-                "Total PnL",
-                FormatCurrency(totalPnL),
-                numericValue: totalPnL
-            ));
+        // --- Trailing Drawdown block (Phase 2) ---
+        if (EnableTrailingDrawdown && _trailingState.IsInitialized)
+        {
+            var stopEquity = _trailingState.PeakEquity - MaxTrailingDrawdown;
+            var currentDd = _trailingState.PeakEquity - equity;
+            var remainingDd = equity - stopEquity;
+
+            rows.Add(new DisplayRow("Equity", FormatCurrency(equity)));
+            rows.Add(new DisplayRow("Start Equity", FormatCurrency(_trailingState.StartEquity)));
+            rows.Add(new DisplayRow("Peak Equity", FormatCurrency(_trailingState.PeakEquity)));
+            rows.Add(new DisplayRow("Stop Equity", FormatCurrency(stopEquity)));
+
+            // Remaining DD: positive => safe (green), negative => breached (red)
+            rows.Add(new DisplayRow("Remaining DD", FormatCurrency(remainingDd), numericValue: remainingDd));
+
+            // Current DD: show as positive magnitude but color should reflect "bad when larger".
+            // We keep numericValue as negative magnitude so existing color rules (pos=green, neg=red) still work.
+            rows.Add(new DisplayRow("Current DD", FormatCurrency(currentDd), numericValue: -currentDd));
+
+            rows.Add(new DisplayRow("Max Open PnL", FormatCurrency(_trailingState.MaxOpenPnL), numericValue: _trailingState.MaxOpenPnL));
         }
 
         return rows;
@@ -382,7 +453,7 @@ public class AccountInfoDisplay : Indicator
             // Draw label
             context.DrawString(label, _font, _textColor, textRect.X, currentY);
 
-            // Determine color for value (Phase 0: keep current behavior)
+            // Determine color for numeric values (PnL/DD rows are provided via NumericValue)
             var valueColor = _textColor;
 
             if (row.NumericValue.HasValue)
@@ -427,5 +498,60 @@ public class AccountInfoDisplay : Indicator
 		};
 	}
 
-	#endregion
+    #region Trailing Drawdown Helpers
+
+    private void ResetTrailingState()
+    {
+        _trailingState = new TrailingDdState();
+        _reinitializeNow = false;
+    }
+
+    private void InitializeTrailingState(Portfolio portfolio, decimal equity)
+    {
+        if (!EnableTrailingDrawdown)
+            return;
+
+
+        // One-shot init unless forced.
+        if (_trailingState.IsInitialized && !_reinitializeNow)
+            return;
+
+        _trailingState.IsInitialized = true;
+        _trailingState.InitializedAtUtc = DateTime.UtcNow;
+
+        _trailingState.StartEquity = equity;
+
+        if (InitializationMode == TrailingInitMode.ManualStopEquity && MaxTrailingDrawdown > 0m)
+        {
+            // Bootstrap using user-provided stop equity:
+            // PeakEquity is derived so that: StopEquity = PeakEquity - MaxDD == ManualStopEquity
+            _trailingState.PeakEquity = ManualStopEquity + MaxTrailingDrawdown;
+        }
+        else
+        {
+            // Default: start from current equity
+            _trailingState.PeakEquity = equity;
+        }
+
+        _trailingState.MaxOpenPnL = portfolio.OpenPnL;
+
+        // Consume the pulse
+        _reinitializeNow = false;
+    }
+
+    private void UpdateTrailingState(Portfolio portfolio, decimal equity)
+    {
+        if (!EnableTrailingDrawdown || !_trailingState.IsInitialized)
+            return;
+
+        if (equity > _trailingState.PeakEquity)
+            _trailingState.PeakEquity = equity;
+
+        if (portfolio.OpenPnL > _trailingState.MaxOpenPnL)
+            _trailingState.MaxOpenPnL = portfolio.OpenPnL;
+    }
+
+    #endregion
+
+    #endregion
 }

--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -53,6 +53,13 @@ public class AccountInfoDisplay : Indicator
         public decimal MaxTrailingDrawdown { get; set; }
         public TrailingInitMode InitializationMode { get; set; }
         public decimal ManualStopEquity { get; set; }
+
+        // Phase 4: EOD engine (per-account)
+        public TrailingPeakUpdateMode PeakUpdateMode { get; set; }
+        public TimeSpan EodTimeLocal { get; set; }
+
+        // Marker to ensure we capture EOD only once per local day
+        public DateTime LastEodCaptureDate { get; set; } // Date component only
     }
     #endregion
 
@@ -78,6 +85,11 @@ public class AccountInfoDisplay : Indicator
     private bool _defaultEnableTrailingDrawdown = true;
     private TrailingInitMode _defaultInitializationMode = TrailingInitMode.AutoFromCurrentEquity;
     private decimal _defaultManualStopEquity = 0m;
+
+    private TrailingPeakUpdateMode _defaultPeakUpdateMode = TrailingPeakUpdateMode.Realtime;
+
+    // Bulenox default: 17:00 CT (user can change depending on local timezone)
+    private TimeSpan _defaultEodTimeLocal = new(17, 0, 0);
 
     #endregion
 
@@ -309,6 +321,63 @@ public class AccountInfoDisplay : Indicator
 
     private bool _reinitializeNow;
 
+    public enum TrailingPeakUpdateMode
+    {
+        Realtime = 0, // classic trailing: peak updates whenever equity makes a new high
+        EndOfDay = 1  // EOD: peak updates only once per day at EOD time
+    }
+
+    [Display(
+    Name = "Peak Update Mode",
+    Description = "Controls when Peak Equity is allowed to update. Realtime updates continuously; EndOfDay updates only once per day at the configured EOD time.",
+    GroupName = "Funding / Trailing DD",
+    Order = 15
+)]
+    public TrailingPeakUpdateMode DefaultPeakUpdateMode
+    {
+        get => _defaultPeakUpdateMode;
+        set
+        {
+            _defaultPeakUpdateMode = value;
+
+            var state = TryGetActiveState();
+            if (state != null)
+            {
+                state.PeakUpdateMode = value;
+                state.LastEodCaptureDate = default; // allow EOD capture immediately if applicable
+            }
+
+            RedrawChart();
+        }
+    }
+
+    [Display(
+        Name = "EOD Time (Local)",
+        Description = "End-of-day time used when Peak Update Mode is EndOfDay. Uses the PC local clock (DateTime.Now). Default 17:00 (Bulenox CT).",
+        GroupName = "Funding / Trailing DD",
+        Order = 16
+    )]
+    public TimeSpan DefaultEodTimeLocal
+    {
+        get => _defaultEodTimeLocal;
+        set
+        {
+            // Defensive clamp: keep it within a day range
+            if (value < TimeSpan.Zero)
+                value = TimeSpan.Zero;
+            if (value >= TimeSpan.FromDays(1))
+                value = TimeSpan.FromDays(1) - TimeSpan.FromSeconds(1);
+
+            _defaultEodTimeLocal = value;
+
+            var state = TryGetActiveState();
+            if (state != null)
+                state.EodTimeLocal = value;
+
+            RedrawChart();
+        }
+    }
+
     #endregion
 
     #endregion
@@ -383,9 +452,10 @@ public class AccountInfoDisplay : Indicator
 
         // Phase 2: equity and trailing DD state
         var equity = portfolio.Balance + portfolio.OpenPnL;
+        var nowLocal = DateTime.Now;
 
         InitializeTrailingState(state, portfolio, equity);
-        UpdateTrailingState(state, portfolio, equity);
+        UpdateTrailingState(state, portfolio, equity, nowLocal);
 
         var rows = BuildRows(state, portfolio, equity); // updated signature
         if (rows == null || rows.Count == 0)
@@ -578,6 +648,7 @@ public class AccountInfoDisplay : Indicator
         state.PeakEquity = 0m;
         state.MaxOpenPnL = 0m;
         state.InitializedAtUtc = default;
+        state.LastEodCaptureDate = default;
 
         _reinitializeNow = false;
     }
@@ -621,16 +692,25 @@ public class AccountInfoDisplay : Indicator
         _reinitializeNow = false;
     }
 
-    private void UpdateTrailingState(TrailingDdState state, Portfolio portfolio, decimal equity)
+    private void UpdateTrailingState(TrailingDdState state, Portfolio portfolio, decimal equity, DateTime nowLocal)
     {
         if (!state.EnableTrailingDrawdown || !state.IsInitialized)
             return;
 
-        if (equity > state.PeakEquity)
-            state.PeakEquity = equity;
-
+        // Max OpenPnL is always realtime (it is informational and useful regardless of EOD).
         if (portfolio.OpenPnL > state.MaxOpenPnL)
             state.MaxOpenPnL = portfolio.OpenPnL;
+
+        if (state.PeakUpdateMode == TrailingPeakUpdateMode.Realtime)
+        {
+            if (equity > state.PeakEquity)
+                state.PeakEquity = equity;
+
+            return;
+        }
+
+        // EOD mode
+        MaybeCaptureEodPeak(state, equity, nowLocal);
     }
 
     #endregion
@@ -657,7 +737,11 @@ public class AccountInfoDisplay : Indicator
             EnableTrailingDrawdown = DefaultEnableTrailingDrawdown,
             MaxTrailingDrawdown = DefaultMaxTrailingDrawdown,
             InitializationMode = DefaultInitializationMode,
-            ManualStopEquity = DefaultManualStopEquity
+            ManualStopEquity = DefaultManualStopEquity,
+
+            PeakUpdateMode = DefaultPeakUpdateMode,
+            EodTimeLocal = DefaultEodTimeLocal,
+            LastEodCaptureDate = default
         };
 
         _trailingStatesByAccount[accountKey] = state;
@@ -670,6 +754,9 @@ public class AccountInfoDisplay : Indicator
         _defaultInitializationMode = state.InitializationMode;
         _defaultManualStopEquity = state.ManualStopEquity;
         _defaultEnableTrailingDrawdown = state.EnableTrailingDrawdown;
+
+        _defaultPeakUpdateMode = state.PeakUpdateMode;
+        _defaultEodTimeLocal = state.EodTimeLocal;
     }
 
     private TrailingDdState TryGetActiveState()
@@ -680,6 +767,32 @@ public class AccountInfoDisplay : Indicator
         return _trailingStatesByAccount.TryGetValue(_activeAccountKey, out var state)
             ? state
             : null;
+    }
+
+    private void MaybeCaptureEodPeak(TrailingDdState state, decimal equity, DateTime nowLocal)
+    {
+        // EOD capture happens at most once per local day, after EOD time.
+        var today = nowLocal.Date;
+
+        // If already captured for today, do nothing.
+        if (state.LastEodCaptureDate.Date == today)
+            return;
+
+        // Determine today's EOD timestamp in local time.
+        var eod = today.Add(state.EodTimeLocal);
+
+        // Only capture after EOD time.
+        if (nowLocal < eod)
+            return;
+
+        // Capture rule: peak updates only if equity makes a new high at EOD snapshot.
+        if (equity > state.PeakEquity)
+            state.PeakEquity = equity;
+
+        state.LastEodCaptureDate = today;
+
+        // Defensive: do not let a pending UI pulse override the EOD snapshot.
+        _reinitializeNow = false;
     }
 
     #endregion

--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -79,7 +79,19 @@ public class AccountInfoDisplay : Indicator
         // Reset markers (per-account)
         public int LastMonthlyResetKey { get; set; } // yyyymm, e.g. 202512
 
+        // Phase 5-2: Daily Rails (per-account)
+        public bool EnableDailyLossLimit { get; set; }
+        public decimal DailyLossLimit { get; set; }
+        public DailyLossModeKind DailyLossMode { get; set; }
+        public bool EnableDailyProfitCap { get; set; }
+        public decimal DailyProfitCap { get; set; } // FromSessionStart only (equity - DailyStartEquity)
 
+        public DailyResetModeKind DailyResetMode { get; set; }
+        public TimeSpan DailyResetTimeLocal { get; set; } // used only when DailyResetMode == LocalCustomTime
+
+        public int LastDailyResetKey { get; set; } // yyyymmdd based on trading day key (NY 17:00)
+        public decimal DailyStartEquity { get; set; }
+        public decimal DailyPeakEquity { get; set; }
     }
 
     #region Persistence DTO
@@ -111,6 +123,17 @@ public class AccountInfoDisplay : Indicator
 
         public bool EnableMonthlyReset { get; set; }
         public int MonthlyResetDay { get; set; }
+
+        // Daily Rails (config)
+        public bool EnableDailyLossLimit { get; set; }
+        public decimal DailyLossLimit { get; set; }
+        public int DailyLossMode { get; set; }          // enum as int
+
+        public bool EnableDailyProfitCap { get; set; }
+        public decimal DailyProfitCap { get; set; }     // from day start only
+
+        public int DailyResetMode { get; set; }         // enum as int
+        public string DailyResetTimeLocal { get; set; } // "HH:mm:ss"
     }
 
     private sealed class PersistedRuntimeV1
@@ -124,6 +147,11 @@ public class AccountInfoDisplay : Indicator
         public string LastEodCaptureDate { get; set; }         // "yyyy-MM-dd" (date only)
 
         public int LastMonthlyResetKey { get; set; }           // yyyymm
+
+        // Daily Rails (runtime)
+        public int LastDailyResetKey { get; set; }      // yyyymmdd key
+        public decimal DailyStartEquity { get; set; }
+        public decimal DailyPeakEquity { get; set; }
     }
 
     #endregion
@@ -174,6 +202,17 @@ public class AccountInfoDisplay : Indicator
 
     private bool _defaultEnableMonthlyReset = true;
     private int _defaultMonthlyResetDay = 1;
+
+    //Daily rails
+    private bool _enableDailyLossLimit;
+    private decimal _dailyLossLimit;
+    private DailyLossModeKind _dailyLossMode;
+
+    private bool _enableDailyProfitCap;
+    private decimal _dailyProfitCap;
+
+    private DailyResetModeKind _dailyResetMode = DailyResetModeKind.NewYork1700;
+    private TimeSpan _dailyResetTimeLocal = new TimeSpan(17, 0, 0);
 
     #endregion
 
@@ -325,12 +364,6 @@ public class AccountInfoDisplay : Indicator
 
     #region Trailing Drawdown Settings
 
-    public enum TrailingInitMode
-    {
-        AutoFromCurrentEquity = 0,
-        ManualStopEquity = 1
-    }
-
     [Display(
         Name = "Enable Trailing Drawdown",
         Description = "Enable trailing drawdown tracking based on peak equity.",
@@ -445,12 +478,6 @@ public class AccountInfoDisplay : Indicator
 
     private bool _reinitializeNow;
 
-    public enum TrailingPeakUpdateMode
-    {
-        Realtime = 0, // classic trailing: peak updates whenever equity makes a new high
-        EndOfDay = 1  // EOD: peak updates only once per day at EOD time
-    }
-
     [Display(
     Name = "Peak Update Mode",
     Description = "Controls when Peak Equity is allowed to update. Realtime updates continuously; EndOfDay updates only once per day at the configured EOD time.",
@@ -560,6 +587,137 @@ public class AccountInfoDisplay : Indicator
 
     #endregion
 
+    #region Daily Rails
+
+    [Display(GroupName = "Daily Rails", Name = "Enable Daily Loss Limit", Order = 10)]
+    public bool EnableDailyLossLimit
+    {
+        get => _enableDailyLossLimit;
+        set
+        {
+            _enableDailyLossLimit = value;
+
+            var state = TryGetActiveState();
+            if (state != null)
+                state.EnableDailyLossLimit = value;
+
+            TouchActiveAccountAndScheduleSave(force: false);
+            RedrawChart();
+        }
+    }
+
+    [Display(GroupName = "Daily Rails", Name = "Daily Loss Limit", Order = 11)]
+    public decimal DailyLossLimit
+    {
+        get => _dailyLossLimit;
+        set
+        {
+            _dailyLossLimit = value;
+
+            var state = TryGetActiveState();
+            if (state != null)
+                state.DailyLossLimit = value;
+
+            TouchActiveAccountAndScheduleSave(force: false);
+            RedrawChart();
+        }
+    }
+
+    [Display(GroupName = "Daily Rails", Name = "Daily Loss Mode", Order = 12)]
+    public DailyLossModeKind DailyLossMode
+    {
+        get => _dailyLossMode;
+        set
+        {
+            _dailyLossMode = value;
+
+            var state = TryGetActiveState();
+            if (state != null)
+                state.DailyLossMode = value;
+
+            TouchActiveAccountAndScheduleSave(force: false);
+            RedrawChart();
+        }
+    }
+
+    [Display(GroupName = "Daily Rails", Name = "Enable Daily Profit Cap", Order = 13)]
+    public bool EnableDailyProfitCap
+    {
+        get => _enableDailyProfitCap;
+        set
+        {
+            _enableDailyProfitCap = value;
+
+            var state = TryGetActiveState();
+            if (state != null)
+                state.EnableDailyProfitCap = value;
+
+            TouchActiveAccountAndScheduleSave(force: false);
+            RedrawChart();
+        }
+    }
+
+    [Display(GroupName = "Daily Rails", Name = "Daily Profit Cap", Order = 14)]
+    public decimal DailyProfitCap
+    {
+        get => _dailyProfitCap;
+        set
+        {
+            _dailyProfitCap = value;
+
+            var state = TryGetActiveState();
+            if (state != null)
+                state.DailyProfitCap = value;
+
+            TouchActiveAccountAndScheduleSave(force: false);
+            RedrawChart();
+        }
+    }
+
+    [Display(GroupName = "Daily Rails", Name = "Daily Reset Mode", Order = 15)]
+    public DailyResetModeKind DailyResetMode
+    {
+        get => _dailyResetMode;
+        set
+        {
+            _dailyResetMode = value;
+
+            var state = TryGetActiveState();
+            if (state != null)
+                state.DailyResetMode = value;
+
+            TouchActiveAccountAndScheduleSave(force: false);
+            RedrawChart();
+        }
+    }
+
+    [Display(GroupName = "Daily Rails", Name = "Daily Reset Time (Local)", Order = 16)]
+    public TimeSpan DailyResetTimeLocal
+    {
+        get => _dailyResetTimeLocal;
+        set
+        {
+            // Defensive clamp (same style you used for EOD)
+            if (value < TimeSpan.Zero)
+                value = TimeSpan.Zero;
+            if (value >= TimeSpan.FromDays(1))
+                value = TimeSpan.FromDays(1) - TimeSpan.FromSeconds(1);
+
+            _dailyResetTimeLocal = value;
+
+            var state = TryGetActiveState();
+            if (state != null)
+                state.DailyResetTimeLocal = value;
+
+            TouchActiveAccountAndScheduleSave(force: false);
+            RedrawChart();
+        }
+    }
+
+    #endregion
+
+
+
     #endregion
 
     #region Enums
@@ -578,11 +736,35 @@ public class AccountInfoDisplay : Indicator
 		Bottom
 	}
 
-	#endregion
+    public enum TrailingPeakUpdateMode
+    {
+        Realtime = 0, // classic trailing: peak updates whenever equity makes a new high
+        EndOfDay = 1  // EOD: peak updates only once per day at EOD time
+    }
 
-	#region ctor
+    public enum TrailingInitMode
+    {
+        AutoFromCurrentEquity = 0,
+        ManualStopEquity = 1
+    }
 
-	public AccountInfoDisplay()
+    public enum DailyResetModeKind
+    {
+        NewYork1700,
+        LocalCustomTime
+    }
+
+    public enum DailyLossModeKind
+    {
+        FromSessionStart,
+        FromSessionPeak
+    }
+
+    #endregion
+
+    #region ctor
+
+    public AccountInfoDisplay()
 		: base(true)
 	{
 		DenyToChangePanel = true;
@@ -673,6 +855,7 @@ public class AccountInfoDisplay : Indicator
         var nowLocal = DateTime.Now;
 
         MaybeResetForSchedule(state, portfolio, equity, nowLocal);
+        MaybeResetDailyRails(state, equity, nowLocal);
 
         InitializeTrailingState(state, portfolio, equity);
         UpdateTrailingState(state, portfolio, equity, nowLocal);
@@ -834,6 +1017,40 @@ public class AccountInfoDisplay : Indicator
             rows.Add(new DisplayRow("Pos", "FLAT"));
         }
 
+        // --- Daily Rails (Phase 2) ---
+        if ((state.EnableDailyLossLimit && state.DailyLossLimit > 0m) ||
+            (state.EnableDailyProfitCap && state.DailyProfitCap > 0m))
+        {
+            var dailyPnl = equity - state.DailyStartEquity;
+
+            rows.Add(new DisplayRow("Daily Start Equity", FormatCurrency(state.DailyStartEquity)));
+            rows.Add(new DisplayRow("Daily PnL", FormatCurrency(dailyPnl), numericValue: dailyPnl));
+
+            if (state.EnableDailyLossLimit && state.DailyLossLimit > 0m)
+            {
+                var lossBase = state.DailyLossMode == DailyLossModeKind.FromSessionPeak
+                    ? state.DailyPeakEquity
+                    : state.DailyStartEquity;
+
+                var dailyStopEquity = lossBase - state.DailyLossLimit;
+                var remainingLoss = equity - dailyStopEquity;
+
+                rows.Add(new DisplayRow("Daily Loss Base", FormatCurrency(lossBase)));
+                rows.Add(new DisplayRow("Daily Stop Equity", FormatCurrency(dailyStopEquity)));
+                rows.Add(new DisplayRow("Remaining Daily Loss", FormatCurrency(remainingLoss), numericValue: remainingLoss));
+            }
+
+            if (state.EnableDailyProfitCap && state.DailyProfitCap > 0m)
+            {
+                // Profit cap is always from day start (non-trailing), by design.
+                var profitAchieved = Math.Max(0m, dailyPnl);
+                var remainingToCap = state.DailyProfitCap - profitAchieved;
+
+                rows.Add(new DisplayRow("Daily Profit Cap", FormatCurrency(state.DailyProfitCap)));
+                rows.Add(new DisplayRow("Remaining to Profit Cap", FormatCurrency(remainingToCap), numericValue: remainingToCap));
+            }
+        }
+
         return rows;
     }
 
@@ -853,16 +1070,26 @@ public class AccountInfoDisplay : Indicator
             // Draw label
             context.DrawString(label, _font, _textColor, textRect.X, currentY);
 
-            // Determine color for numeric values (PnL/DD rows are provided via NumericValue)
-            var valueColor = _textColor;
+            // Determine color for numeric values
+            var valueColor = _neutralColor; // System.Drawing.Color
 
-            if (row.NumericValue.HasValue)
+            if (row.ValueColorOverride.HasValue)
             {
-                var value = row.NumericValue.Value;
-                valueColor = value > 0
-                    ? _positiveColor
-                    : (value < 0 ? _negativeColor : _neutralColor);
+                // CrossColor -> System.Drawing.Color
+                valueColor = row.ValueColorOverride.Value.Convert();
             }
+            else if (row.NumericValue.HasValue)
+            {
+                var v = row.NumericValue.Value;
+
+                if (v > 0)
+                    valueColor = _positiveColor;
+                else if (v < 0)
+                    valueColor = _negativeColor;
+                else
+                    valueColor = _neutralColor;
+            }
+
 
             // Draw value
             var valueRect = new Rectangle(valueColumnX, currentY, textRect.Right - valueColumnX, lineHeight);
@@ -915,6 +1142,7 @@ public class AccountInfoDisplay : Indicator
         state.LastEodCaptureDate = default;
         state.TradeOpenPnlBaseline = 0m;
         state.LastTradeMaxOpenPnL = 0m;
+
 
         _reinitializeNow = false;
     }
@@ -1040,7 +1268,11 @@ public class AccountInfoDisplay : Indicator
             EodTimeLocal = DefaultEodTimeLocal,
             LastEodCaptureDate = default,
             EnableMonthlyReset = DefaultEnableMonthlyReset,
-            MonthlyResetDay = DefaultMonthlyResetDay
+            MonthlyResetDay = DefaultMonthlyResetDay,
+
+            DailyResetMode = DailyResetModeKind.NewYork1700,
+            DailyLossMode = DailyLossModeKind.FromSessionStart,
+            DailyResetTimeLocal = new TimeSpan(17, 0, 0),
         };
 
         _trailingStatesByAccount[accountKey] = state;
@@ -1059,6 +1291,16 @@ public class AccountInfoDisplay : Indicator
 
         _defaultEnableMonthlyReset = state.EnableMonthlyReset;
         _defaultMonthlyResetDay = state.MonthlyResetDay;
+
+        _enableDailyLossLimit = state.EnableDailyLossLimit;
+        _dailyLossLimit = state.DailyLossLimit;
+        _dailyLossMode = state.DailyLossMode;
+
+        _enableDailyProfitCap = state.EnableDailyProfitCap;
+        _dailyProfitCap = state.DailyProfitCap;
+
+        _dailyResetMode = state.DailyResetMode;
+        _dailyResetTimeLocal = state.DailyResetTimeLocal;
     }
 
     private TrailingDdState TryGetActiveState()
@@ -1113,29 +1355,28 @@ public class AccountInfoDisplay : Indicator
 
     private void MaybeCaptureEodPeak(TrailingDdState state, decimal equity, DateTime nowLocal)
     {
-        // EOD capture happens at most once per local day, after EOD time.
+        if (state == null)
+            return;
+
+        // Capture only once per local day after configured EOD time
+        if (nowLocal.TimeOfDay < state.EodTimeLocal)
+            return;
+
         var today = nowLocal.Date;
 
-        // If already captured for today, do nothing.
-        if (state.LastEodCaptureDate.Date == today)
+        if (state.LastEodCaptureDate != default && state.LastEodCaptureDate.Date == today)
             return;
 
-        // Determine today's EOD timestamp in local time.
-        var eod = today.Add(state.EodTimeLocal);
-
-        // Only capture after EOD time.
-        if (nowLocal < eod)
-            return;
-
-        // Capture rule: peak updates only if equity makes a new high at EOD snapshot.
+        // In EOD mode, PeakEquity updates only at capture time
         if (equity > state.PeakEquity)
             state.PeakEquity = equity;
 
         state.LastEodCaptureDate = today;
 
-        // Defensive: do not let a pending UI pulse override the EOD snapshot.
-        _reinitializeNow = false;
+        PersistAccountToMemory(_activeAccountKey);
+        MarkDirty();
     }
+
 
     #endregion
 
@@ -1230,6 +1471,18 @@ public class AccountInfoDisplay : Indicator
         state.EnableMonthlyReset = cfg.EnableMonthlyReset;
         state.MonthlyResetDay = cfg.MonthlyResetDay;
 
+        // --- Daily Rails Config ---
+        state.EnableDailyLossLimit = cfg.EnableDailyLossLimit;
+        state.DailyLossLimit = cfg.DailyLossLimit;
+        state.DailyLossMode = (DailyLossModeKind)cfg.DailyLossMode;
+
+        state.EnableDailyProfitCap = cfg.EnableDailyProfitCap;
+        state.DailyProfitCap = cfg.DailyProfitCap;
+
+        state.DailyResetMode = (DailyResetModeKind)cfg.DailyResetMode;
+        state.DailyResetTimeLocal = ParseTimeSpanOrDefault(cfg.DailyResetTimeLocal, state.DailyResetTimeLocal);
+
+
         // --- Runtime ---
         state.IsInitialized = rt.IsInitialized;
         state.StartEquity = rt.StartEquity;
@@ -1243,6 +1496,11 @@ public class AccountInfoDisplay : Indicator
         state.LastEodCaptureDate = ParseDateOrDefault(rt.LastEodCaptureDate, default);
 
         state.LastMonthlyResetKey = rt.LastMonthlyResetKey;
+
+        // --- Daily Rails Runtime ---
+        state.LastDailyResetKey = rt.LastDailyResetKey;
+        state.DailyStartEquity = rt.DailyStartEquity;
+        state.DailyPeakEquity = rt.DailyPeakEquity;
 
         // IMPORTANT: loading should not mark dirty.
     }
@@ -1281,6 +1539,17 @@ public class AccountInfoDisplay : Indicator
         persisted.Config.EnableMonthlyReset = state.EnableMonthlyReset;
         persisted.Config.MonthlyResetDay = state.MonthlyResetDay;
 
+        // --- Daily Rails Config ---
+        persisted.Config.EnableDailyLossLimit = state.EnableDailyLossLimit;
+        persisted.Config.DailyLossLimit = state.DailyLossLimit;
+        persisted.Config.DailyLossMode = (int)state.DailyLossMode;
+
+        persisted.Config.EnableDailyProfitCap = state.EnableDailyProfitCap;
+        persisted.Config.DailyProfitCap = state.DailyProfitCap;
+
+        persisted.Config.DailyResetMode = (int)state.DailyResetMode;
+        persisted.Config.DailyResetTimeLocal = FormatTimeSpan(state.DailyResetTimeLocal);
+
         // --- Runtime ---
         persisted.Runtime.IsInitialized = state.IsInitialized;
         persisted.Runtime.StartEquity = state.StartEquity;
@@ -1297,6 +1566,11 @@ public class AccountInfoDisplay : Indicator
         persisted.Runtime.LastMonthlyResetKey = state.LastMonthlyResetKey;
 
         _persistedRoot.UpdatedAtUtc = DateTime.UtcNow.ToString("O");
+
+        // --- Daily Rails Runtime ---
+        persisted.Runtime.LastDailyResetKey = state.LastDailyResetKey;
+        persisted.Runtime.DailyStartEquity = state.DailyStartEquity;
+        persisted.Runtime.DailyPeakEquity = state.DailyPeakEquity;
     }
 
     private void SaveIfNeeded(bool force)
@@ -1429,6 +1703,71 @@ public class AccountInfoDisplay : Indicator
         PersistAccountToMemory(accountKey);
         MarkDirty();
         SaveIfNeeded(force);
+    }
+
+
+    #endregion
+
+    #region Daily Rails Helpers
+    private static int ToYyyyMmDdKey(DateTime d)
+    => (d.Year * 10000) + (d.Month * 100) + d.Day;
+
+    private static DateTime EnsureLocalKind(DateTime dt)
+    {
+        // ATAS often provides Unspecified; treat as Local for timezone conversions.
+        return dt.Kind == DateTimeKind.Unspecified
+            ? DateTime.SpecifyKind(dt, DateTimeKind.Local)
+            : dt;
+    }
+
+    private int GetDailyTradingKey(DateTime nowLocal, TrailingDdState state)
+    {
+        if (state.DailyResetMode == DailyResetModeKind.LocalCustomTime)
+        {
+            var baseDate = nowLocal.Date;
+            var keyDate = nowLocal.TimeOfDay < state.DailyResetTimeLocal ? baseDate.AddDays(-1) : baseDate;
+            return ToYyyyMmDdKey(keyDate);
+        }
+
+        // Default: NewYork1700 (DST-safe)
+        TimeZoneInfo nyTz;
+        try { nyTz = TimeZoneInfo.FindSystemTimeZoneById("America/New_York"); }
+        catch { nyTz = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time"); }
+
+        var local = EnsureLocalKind(nowLocal);
+        var nowNy = TimeZoneInfo.ConvertTime(local, nyTz);
+
+        var cutoff = new TimeSpan(17, 0, 0);
+        var keyDateNy = nowNy.TimeOfDay < cutoff ? nowNy.Date.AddDays(-1) : nowNy.Date;
+
+        return ToYyyyMmDdKey(keyDateNy);
+    }
+
+    private void MaybeResetDailyRails(TrailingDdState state, decimal equity, DateTime nowLocal)
+    {
+        if (state == null)
+            return;
+
+        // Compute the daily trading key according to configured reset mode
+        var key = GetDailyTradingKey(nowLocal, state);
+
+        // Always maintain daily peak if we already have a session in progress
+        if (state.LastDailyResetKey == key && state.LastDailyResetKey != 0)
+        {
+            if (equity > state.DailyPeakEquity)
+                state.DailyPeakEquity = equity;
+
+            return;
+        }
+
+        // First time today (or first initialization)
+        state.LastDailyResetKey = key;
+        state.DailyStartEquity = equity;
+        state.DailyPeakEquity = equity;
+
+        // Persist per-account runtime so it survives restarts / account switches
+        PersistAccountToMemory(_activeAccountKey);
+        MarkDirty();
     }
 
 

--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -262,8 +262,12 @@ public class AccountInfoDisplay : Indicator
 
     #region Properties
 
+    // ==============================
+    // Visualization (Look & Feel)
+    // ==============================
+
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.BackGround),
-		Description = nameof(Strings.LabelFillColorDescription), GroupName = nameof(Strings.Visualization))]
+        Description = nameof(Strings.LabelFillColorDescription), GroupName = nameof(Strings.Visualization), Order = 10)]
     public CrossColor BackgroundColor
     {
         get => _backgroundColor.Convert();
@@ -276,10 +280,10 @@ public class AccountInfoDisplay : Indicator
     }
 
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.TextColor),
-		Description = nameof(Strings.LabelTextColorDescription), GroupName = nameof(Strings.Visualization))]
-	public CrossColor TextColor
-	{
-		get => _textColor.Convert();
+        Description = nameof(Strings.LabelTextColorDescription), GroupName = nameof(Strings.Visualization), Order = 11)]
+    public CrossColor TextColor
+    {
+        get => _textColor.Convert();
         set
         {
             _textColor = value.Convert();
@@ -288,48 +292,48 @@ public class AccountInfoDisplay : Indicator
         }
     }
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.PositiveColor),
-		Description = nameof(Strings.PositiveColorDescription), GroupName = nameof(Strings.Visualization))]
-	public CrossColor PositiveColor
-	{
-		get => _positiveColor.Convert();
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.PositiveColor),
+        Description = nameof(Strings.PositiveColorDescription), GroupName = nameof(Strings.Visualization), Order = 12)]
+    public CrossColor PositiveColor
+    {
+        get => _positiveColor.Convert();
         set
         {
             _positiveColor = value.Convert();
             _lastPanelRect = null;
             RedrawChart();
         }
-	}
+    }
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.NegativeColor),
-		Description = nameof(Strings.NegativeColorDescription), GroupName = nameof(Strings.Visualization))]
-	public CrossColor NegativeColor
-	{
-		get => _negativeColor.Convert();
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.NegativeColor),
+        Description = nameof(Strings.NegativeColorDescription), GroupName = nameof(Strings.Visualization), Order = 13)]
+    public CrossColor NegativeColor
+    {
+        get => _negativeColor.Convert();
         set
         {
             _negativeColor = value.Convert();
             _lastPanelRect = null;
             RedrawChart();
         }
-	}
+    }
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.NeutralColor),
-		Description = nameof(Strings.NeutralColorDescription), GroupName = nameof(Strings.Visualization))]
-	public CrossColor NeutralColor
-	{
-		get => _neutralColor.Convert();
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.NeutralColor),
+        Description = nameof(Strings.NeutralColorDescription), GroupName = nameof(Strings.Visualization), Order = 14)]
+    public CrossColor NeutralColor
+    {
+        get => _neutralColor.Convert();
         set
         {
             _neutralColor = value.Convert();
             _lastPanelRect = null;
             RedrawChart();
         }
-	}
+    }
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.FontSize),
-		Description = nameof(Strings.FontSizeDescription), GroupName = nameof(Strings.Visualization))]
-	[Range(6, 30)]
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.FontSize),
+        Description = nameof(Strings.FontSizeDescription), GroupName = nameof(Strings.Visualization), Order = 15)]
+    [Range(6, 30)]
     public float FontSize
     {
         get => _font.Size;
@@ -346,122 +350,175 @@ public class AccountInfoDisplay : Indicator
         }
     }
 
+    // ==============================
+    // Layout (Panel placement)
+    // ==============================
+
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.HorizontalPosition),
+        Description = "Panel horizontal alignment on the chart.", GroupName = nameof(Strings.LayoutGroup), Order = 20)]
+    public HorizontalAlignment HorizontalPosition { get; set; } = HorizontalAlignment.Left;
+
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.VerticalPosition),
+        Description = "Panel vertical alignment on the chart.", GroupName = nameof(Strings.LayoutGroup), Order = 21)]
+    public VerticalAlignment VerticalPosition { get; set; } = VerticalAlignment.Bottom;
+
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.OffsetX),
+        Description = nameof(Strings.OffsetXDescription), GroupName = nameof(Strings.LayoutGroup), Order = 22)]
+    [Range(0, 1000)]
+    public int OffsetX { get; set; } = 20;
+
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.OffsetY),
+        Description = nameof(Strings.OffsetYDescription), GroupName = nameof(Strings.LayoutGroup), Order = 23)]
+    [Range(0, 1000)]
+    public int OffsetY { get; set; } = 20;
+
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.ColumnSpacing),
+        Description = nameof(Strings.ColumnSpacingDescription), GroupName = nameof(Strings.LayoutGroup), Order = 24)]
+    [Range(5, 50)]
+    public int ColumnSpacing { get; set; } = 15;
+
+    // ==============================
+    // Rows (Core upstream toggles)
+    // Keep as-is for upstream compatibility
+    // ==============================
+
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.ShowAccountId),
-		Description = nameof(Strings.ShowAccountIdDescription), GroupName = nameof(Strings.Settings))]
-	public bool ShowAccountId { get; set; } = true;
+        Description = nameof(Strings.ShowAccountIdDescription), GroupName = nameof(Strings.Settings), Order = 30)]
+    public bool ShowAccountId { get; set; } = true;
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.ShowCurrency),
-		Description = nameof(Strings.ShowCurrencyDescription), GroupName = nameof(Strings.Settings))]
-	public bool ShowCurrency { get; set; } = true;
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.ShowCurrency),
+        Description = nameof(Strings.ShowCurrencyDescription), GroupName = nameof(Strings.Settings), Order = 31)]
+    public bool ShowCurrency { get; set; } = true;
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.ShowBalance),
-		Description = nameof(Strings.ShowBalanceDescription), GroupName = nameof(Strings.Settings))]
-	public bool ShowBalance { get; set; } = true;
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.ShowBalance),
+        Description = nameof(Strings.ShowBalanceDescription), GroupName = nameof(Strings.Settings), Order = 32)]
+    public bool ShowBalance { get; set; } = true;
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.ShowAvailableBalance),
-		Description = nameof(Strings.ShowAvailableBalanceDescription), GroupName = nameof(Strings.Settings))]
-	public bool ShowAvailableBalance { get; set; } = true;
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.ShowAvailableBalance),
+        Description = nameof(Strings.ShowAvailableBalanceDescription), GroupName = nameof(Strings.Settings), Order = 33)]
+    public bool ShowAvailableBalance { get; set; } = true;
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.ShowBlockedMargin),
-		Description = nameof(Strings.ShowBlockedMarginDescription), GroupName = nameof(Strings.Settings))]
-	public bool ShowMargin { get; set; } = false;
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.ShowBlockedMargin),
+        Description = nameof(Strings.ShowBlockedMarginDescription), GroupName = nameof(Strings.Settings), Order = 34)]
+    public bool ShowMargin { get; set; } = false;
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.ShowLeverage),
-		Description = nameof(Strings.ShowLeverageDescription), GroupName = nameof(Strings.Settings))]
-	public bool ShowLeverage { get; set; } = true;
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.ShowLeverage),
+        Description = nameof(Strings.ShowLeverageDescription), GroupName = nameof(Strings.Settings), Order = 35)]
+    public bool ShowLeverage { get; set; } = true;
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.ShowOpenPnL),
-		Description = nameof(Strings.ShowOpenPnLDescription), GroupName = nameof(Strings.Settings))]
-	public bool ShowOpenPnL { get; set; } = true;
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.ShowOpenPnL),
+        Description = nameof(Strings.ShowOpenPnLDescription), GroupName = nameof(Strings.Settings), Order = 36)]
+    public bool ShowOpenPnL { get; set; } = true;
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.ShowClosedPnL),
-		Description = nameof(Strings.ShowClosedPnLDescription), GroupName = nameof(Strings.Settings))]
-	public bool ShowClosedPnL { get; set; } = true;
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.ShowClosedPnL),
+        Description = nameof(Strings.ShowClosedPnLDescription), GroupName = nameof(Strings.Settings), Order = 37)]
+    public bool ShowClosedPnL { get; set; } = true;
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.ShowTotalPnL),
-		Description = nameof(Strings.ShowTotalPnLDescription), GroupName = nameof(Strings.Settings))]
-	public bool ShowTotalPnL { get; set; } = false;
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.ShowTotalPnL),
+        Description = nameof(Strings.ShowTotalPnLDescription), GroupName = nameof(Strings.Settings), Order = 38)]
+    public bool ShowTotalPnL { get; set; } = false;
+
+    // ==============================
+    // Rows (New granular toggles — literal strings)
+    // ==============================
 
     // Trailing DD rows (Group: Rows / Trailing DD)
-    [Display(Name = "Show Equity", GroupName = _rowsGroupTrailingDd, Order = 40)]
+    [Display(Name = "Show Equity",
+        Description = "Shows the current account equity used by trailing drawdown calculations.",
+        GroupName = _rowsGroupTrailingDd, Order = 40)]
     public bool ShowEquityRow { get; set; } = true;
 
-    [Display(Name = "Show Start Equity", GroupName = _rowsGroupTrailingDd, Order = 41)]
+    [Display(Name = "Show Start Equity",
+        Description = "Shows the equity captured when trailing drawdown was initialized for this account.",
+        GroupName = _rowsGroupTrailingDd, Order = 41)]
     public bool ShowStartEquityRow { get; set; } = true;
 
-    [Display(Name = "Show Peak Equity", GroupName = _rowsGroupTrailingDd, Order = 42)]
+    [Display(Name = "Show Peak Equity",
+        Description = "Shows the highest equity recorded according to the selected peak update mode.",
+        GroupName = _rowsGroupTrailingDd, Order = 42)]
     public bool ShowPeakEquityRow { get; set; } = true;
 
-    [Display(Name = "Show Stop Equity", GroupName = _rowsGroupTrailingDd, Order = 43)]
+    [Display(Name = "Show Stop Equity",
+        Description = "Shows the trailing stop equity (Peak Equity minus Max Trailing Drawdown).",
+        GroupName = _rowsGroupTrailingDd, Order = 43)]
     public bool ShowStopEquityRow { get; set; } = true;
 
-    [Display(Name = "Show Remaining DD", GroupName = _rowsGroupTrailingDd, Order = 44)]
+    [Display(Name = "Show Remaining DD",
+        Description = "Shows how much equity can still be lost before the trailing stop is reached. Positive = safe, negative = breached.",
+        GroupName = _rowsGroupTrailingDd, Order = 44)]
     public bool ShowRemainingDdRow { get; set; } = true;
 
-    [Display(Name = "Show Current DD", GroupName = _rowsGroupTrailingDd, Order = 45)]
+    [Display(Name = "Show Current DD",
+        Description = "Shows the current drawdown from Peak Equity. The value increases as drawdown worsens.",
+        GroupName = _rowsGroupTrailingDd, Order = 45)]
     public bool ShowCurrentDdRow { get; set; } = true;
 
     // Trade metrics rows (Group: Rows / Trade)
-    [Display(Name = "Show Trade Max Open PnL (Current)", GroupName = _rowsGroupTrade, Order = 50)]
+    [Display(Name = "Show Trade Max Open PnL (Current)",
+        Description = "Shows the maximum unrealized profit reached during the currently open trade (peak Open PnL while the position is open).",
+        GroupName = _rowsGroupTrade, Order = 50)]
     public bool ShowTradeMaxOpenPnlCurrentRow { get; set; } = true;
 
-    [Display(Name = "Show Trade Max Open PnL (Last)", GroupName = _rowsGroupTrade, Order = 51)]
+    [Display(Name = "Show Trade Max Open PnL (Last)",
+        Description = "Shows the maximum unrealized profit reached during the previous trade. The value is frozen at trade close and displayed while flat.",
+        GroupName = _rowsGroupTrade, Order = 51)]
     public bool ShowTradeMaxOpenPnlLastRow { get; set; } = true;
 
-    [Display(Name = "Show Last Closed Trade PnL", GroupName = _rowsGroupTrade, Order = 52)]
+    [Display(Name = "Show Last Closed Trade PnL",
+        Description = "Shows the realized PnL of the last completed trade, calculated as the change in Closed PnL between trade open and trade close.",
+        GroupName = _rowsGroupTrade, Order = 52)]
     public bool ShowLastClosedTradePnlRow { get; set; } = true;
 
     // Position rows (Group: Rows / Position)
-    [Display(Name = "Show Position Snapshot", GroupName = _rowsGroupPosition, Order = 60)]
+    [Display(Name = "Show Position Snapshot",
+        Description = "Shows position direction, quantity, and entry price while a position is open.",
+        GroupName = _rowsGroupPosition, Order = 60)]
     public bool ShowPositionSnapshot { get; set; } = true;
 
-    [Display(Name = "Show FLAT Row", GroupName = _rowsGroupPosition, Order = 61)]
+    [Display(Name = "Show FLAT Row",
+        Description = "Shows a 'FLAT' status row when there is no open position.",
+        GroupName = _rowsGroupPosition, Order = 61)]
     public bool ShowFlatRow { get; set; } = true;
 
     // Daily rails rows (Group: Rows / Daily Rails)
-    [Display(Name = "Show Daily Start Equity", GroupName = _rowsGroupDailyRails, Order = 70)]
+    [Display(Name = "Show Daily Start Equity",
+        Description = "Shows the equity captured at the daily reset time. Daily PnL is calculated from this value.",
+        GroupName = _rowsGroupDailyRails, Order = 70)]
     public bool ShowDailyStartEquityRow { get; set; } = true;
 
-    [Display(Name = "Show Daily PnL", GroupName = _rowsGroupDailyRails, Order = 71)]
+    [Display(Name = "Show Daily PnL",
+        Description = "Shows current daily PnL as (Equity - Daily Start Equity).",
+        GroupName = _rowsGroupDailyRails, Order = 71)]
     public bool ShowDailyPnlRow { get; set; } = true;
 
-    [Display(Name = "Show Daily Loss Base", GroupName = _rowsGroupDailyRails, Order = 72)]
+    [Display(Name = "Show Daily Loss Base",
+        Description = "Shows the equity reference used to compute the daily loss stop (daily start or intraday peak, depending on mode).",
+        GroupName = _rowsGroupDailyRails, Order = 72)]
     public bool ShowDailyLossBaseRow { get; set; } = true;
 
-    [Display(Name = "Show Daily Stop Equity", GroupName = _rowsGroupDailyRails, Order = 73)]
+    [Display(Name = "Show Daily Stop Equity",
+        Description = "Shows the daily loss stop equity (Loss Base minus Daily Loss Limit).",
+        GroupName = _rowsGroupDailyRails, Order = 73)]
     public bool ShowDailyStopEquityRow { get; set; } = true;
 
-    [Display(Name = "Show Remaining Daily Loss", GroupName = _rowsGroupDailyRails, Order = 74)]
+    [Display(Name = "Show Remaining Daily Loss",
+        Description = "Shows how much equity can still be lost today before the daily loss stop is reached. Positive = safe, negative = breached.",
+        GroupName = _rowsGroupDailyRails, Order = 74)]
     public bool ShowRemainingDailyLossRow { get; set; } = true;
 
-    [Display(Name = "Show Daily Profit Cap", GroupName = _rowsGroupDailyRails, Order = 75)]
+    [Display(Name = "Show Daily Profit Cap",
+        Description = "Shows the configured daily profit cap amount (non-trailing).",
+        GroupName = _rowsGroupDailyRails, Order = 75)]
     public bool ShowDailyProfitCapRow { get; set; } = true;
 
-    [Display(Name = "Show Remaining to Profit Cap", GroupName = _rowsGroupDailyRails, Order = 76)]
+    [Display(Name = "Show Remaining to Profit Cap",
+        Description = "Shows how much profit remains until the daily profit cap is reached. Zero or below means the cap has been met.",
+        GroupName = _rowsGroupDailyRails, Order = 76)]
     public bool ShowRemainingToProfitCapRow { get; set; } = true;
 
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.HorizontalPosition),
-		GroupName = nameof(Strings.LayoutGroup))]
-	public HorizontalAlignment HorizontalPosition { get; set; } = HorizontalAlignment.Left;
-
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.VerticalPosition),
-		GroupName = nameof(Strings.LayoutGroup))]
-	public VerticalAlignment VerticalPosition { get; set; } = VerticalAlignment.Bottom;
-
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.OffsetX),
-		Description = nameof(Strings.OffsetXDescription), GroupName = nameof(Strings.LayoutGroup))]
-	[Range(0, 1000)]
-	public int OffsetX { get; set; } = 20;
-
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.OffsetY),
-		Description = nameof(Strings.OffsetYDescription), GroupName = nameof(Strings.LayoutGroup))]
-	[Range(0, 1000)]
-	public int OffsetY { get; set; } = 20;
-
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.ColumnSpacing),
-		Description = nameof(Strings.ColumnSpacingDescription), GroupName = nameof(Strings.LayoutGroup))]
-	[Range(5, 50)]
-	public int ColumnSpacing { get; set; } = 15;
+    // ==============================
+    // Funding / Trailing DD (Per-account defaults)
+    // ==============================
 
     #region Trailing Drawdown Settings
 
@@ -469,7 +526,7 @@ public class AccountInfoDisplay : Indicator
         Name = "Enable Trailing Drawdown",
         Description = "Enable trailing drawdown tracking based on peak equity.",
         GroupName = "Funding / Trailing DD",
-        Order = 10
+        Order = 100
     )]
     public bool DefaultEnableTrailingDrawdown
     {
@@ -493,7 +550,7 @@ public class AccountInfoDisplay : Indicator
         Name = "Max Trailing Drawdown",
         Description = "Maximum allowed trailing drawdown from peak equity (absolute currency amount).",
         GroupName = "Funding / Trailing DD",
-        Order = 11
+        Order = 101
     )]
     [Range(0, 1_000_000)]
     public decimal DefaultMaxTrailingDrawdown
@@ -503,7 +560,6 @@ public class AccountInfoDisplay : Indicator
         {
             _maxTrailingDrawdownDefault = value;
 
-            // write into active account state as well
             var state = TryGetActiveState();
             if (state != null)
                 state.MaxTrailingDrawdown = value;
@@ -515,9 +571,9 @@ public class AccountInfoDisplay : Indicator
 
     [Display(
         Name = "Initialization Mode",
-        Description = "How the trailing drawdown state is initialized.",
+        Description = "Defines how Start/Peak equity are initialized (manual stop equity or current equity).",
         GroupName = "Funding / Trailing DD",
-        Order = 12
+        Order = 102
     )]
     public TrailingInitMode DefaultInitializationMode
     {
@@ -537,9 +593,9 @@ public class AccountInfoDisplay : Indicator
 
     [Display(
         Name = "Manual Stop Equity",
-        Description = "Current liquidation/stop equity level (bootstrap). Peak is derived as Stop + Max DD.",
+        Description = "Bootstrap stop equity for funded accounts. Peak is derived as (Stop Equity + Max Trailing Drawdown).",
         GroupName = "Funding / Trailing DD",
-        Order = 13
+        Order = 103
     )]
     [Range(-1_000_000, 10_000_000)]
     public decimal DefaultManualStopEquity
@@ -559,14 +615,14 @@ public class AccountInfoDisplay : Indicator
     }
 
     [Display(
-     Name = "Reinitialize Now",
-     Description = "Forces trailing drawdown state re-initialization on next render.",
-     GroupName = "Funding / Trailing DD",
-     Order = 14
- )]
+        Name = "Reinitialize Now",
+        Description = "Forces trailing drawdown state re-initialization on next render.",
+        GroupName = "Funding / Trailing DD",
+        Order = 104
+    )]
     public bool ReinitializeNow
     {
-        get => false; // always show unchecked (button-like)
+        get => false;
         set
         {
             if (!value)
@@ -580,11 +636,11 @@ public class AccountInfoDisplay : Indicator
     private bool _reinitializeNow;
 
     [Display(
-    Name = "Peak Update Mode",
-    Description = "Controls when Peak Equity is allowed to update. Realtime updates continuously; EndOfDay updates only once per day at the configured EOD time.",
-    GroupName = "Funding / Trailing DD",
-    Order = 15
-)]
+        Name = "Peak Update Mode",
+        Description = "Realtime updates Peak Equity continuously; EndOfDay updates Peak Equity only once per day at the configured EOD time.",
+        GroupName = "Funding / Trailing DD",
+        Order = 105
+    )]
     public TrailingPeakUpdateMode DefaultPeakUpdateMode
     {
         get => _defaultPeakUpdateMode;
@@ -596,7 +652,7 @@ public class AccountInfoDisplay : Indicator
             if (state != null)
             {
                 state.PeakUpdateMode = value;
-                state.LastEodCaptureDate = default; // allow EOD capture immediately if applicable
+                state.LastEodCaptureDate = default;
             }
 
             TouchActiveAccountAndScheduleSave(force: false);
@@ -606,16 +662,15 @@ public class AccountInfoDisplay : Indicator
 
     [Display(
         Name = "EOD Time (Local)",
-        Description = "End-of-day time used when Peak Update Mode is EndOfDay. Uses the PC local clock (DateTime.Now). Default 17:00 (Bulenox CT).",
+        Description = "End-of-day time used when Peak Update Mode is EndOfDay. Uses the PC local clock (DateTime.Now).",
         GroupName = "Funding / Trailing DD",
-        Order = 16
+        Order = 106
     )]
     public TimeSpan DefaultEodTimeLocal
     {
         get => _defaultEodTimeLocal;
         set
         {
-            // Defensive clamp: keep it within a day range
             if (value < TimeSpan.Zero)
                 value = TimeSpan.Zero;
             if (value >= TimeSpan.FromDays(1))
@@ -625,9 +680,9 @@ public class AccountInfoDisplay : Indicator
 
             var state = TryGetActiveState();
             if (state != null)
-            { 
-                state.EodTimeLocal = value; 
-                state.LastEodCaptureDate = default; 
+            {
+                state.EodTimeLocal = value;
+                state.LastEodCaptureDate = default;
             }
 
             TouchActiveAccountAndScheduleSave(force: false);
@@ -639,13 +694,11 @@ public class AccountInfoDisplay : Indicator
 
     #region Trailing Reset Settings
 
-    // ---------- Monthly reset ----------
-
     [Display(
         Name = "Enable Monthly Reset",
-        Description = "Resets trailing drawdown at a fixed day of each month (per account).",
+        Description = "Resets trailing drawdown state on a fixed day of each month (per account).",
         GroupName = "Funding / Trailing DD",
-        Order = 20
+        Order = 120
     )]
     public bool DefaultEnableMonthlyReset
     {
@@ -665,9 +718,9 @@ public class AccountInfoDisplay : Indicator
 
     [Display(
         Name = "Monthly Reset Day",
-        Description = "Day of month when trailing drawdown resets (1–31). If the month has fewer days, last day is used.",
+        Description = "Day of month when trailing drawdown resets (1–31). If the month has fewer days, the last day is used.",
         GroupName = "Funding / Trailing DD",
-        Order = 21
+        Order = 121
     )]
     [Range(1, 31)]
     public int DefaultMonthlyResetDay
@@ -688,9 +741,17 @@ public class AccountInfoDisplay : Indicator
 
     #endregion
 
+    // ==============================
+    // Daily Rails (Rules / Controls)
+    // ==============================
+
     #region Daily Rails
 
-    [Display(GroupName = "Daily Rails", Name = "Enable Daily Loss Limit", Order = 10)]
+    [Display(
+        GroupName = "Daily Rails",
+        Name = "Enable Daily Loss Limit",
+        Description = "Enables the daily loss limit. When enabled, the panel shows the daily stop level and remaining daily loss.",
+        Order = 200)]
     public bool EnableDailyLossLimit
     {
         get => _enableDailyLossLimit;
@@ -707,7 +768,11 @@ public class AccountInfoDisplay : Indicator
         }
     }
 
-    [Display(GroupName = "Daily Rails", Name = "Daily Loss Limit", Order = 11)]
+    [Display(
+        GroupName = "Daily Rails",
+        Name = "Daily Loss Limit",
+        Description = "Maximum allowed loss for the day (absolute currency amount).",
+        Order = 201)]
     public decimal DailyLossLimit
     {
         get => _dailyLossLimit;
@@ -724,7 +789,11 @@ public class AccountInfoDisplay : Indicator
         }
     }
 
-    [Display(GroupName = "Daily Rails", Name = "Daily Loss Mode", Order = 12)]
+    [Display(
+        GroupName = "Daily Rails",
+        Name = "Daily Loss Mode",
+        Description = "Selects the daily loss reference: FromSessionStart uses Daily Start Equity; FromSessionPeak uses the intraday peak equity as the loss base.",
+        Order = 202)]
     public DailyLossModeKind DailyLossMode
     {
         get => _dailyLossMode;
@@ -741,7 +810,11 @@ public class AccountInfoDisplay : Indicator
         }
     }
 
-    [Display(GroupName = "Daily Rails", Name = "Enable Daily Profit Cap", Order = 13)]
+    [Display(
+        GroupName = "Daily Rails",
+        Name = "Enable Daily Profit Cap",
+        Description = "Enables the daily profit cap (non-trailing). When reached, remaining-to-cap becomes zero or negative.",
+        Order = 203)]
     public bool EnableDailyProfitCap
     {
         get => _enableDailyProfitCap;
@@ -758,7 +831,11 @@ public class AccountInfoDisplay : Indicator
         }
     }
 
-    [Display(GroupName = "Daily Rails", Name = "Daily Profit Cap", Order = 14)]
+    [Display(
+        GroupName = "Daily Rails",
+        Name = "Daily Profit Cap",
+        Description = "Daily profit cap amount measured from Daily Start Equity (non-trailing).",
+        Order = 204)]
     public decimal DailyProfitCap
     {
         get => _dailyProfitCap;
@@ -775,7 +852,11 @@ public class AccountInfoDisplay : Indicator
         }
     }
 
-    [Display(GroupName = "Daily Rails", Name = "Daily Reset Mode", Order = 15)]
+    [Display(
+        GroupName = "Daily Rails",
+        Name = "Daily Reset Mode",
+        Description = "Defines when daily rails reset. NewYork1700 uses the America/New_York 17:00 session cut; LocalCustomTime uses the local time configured below.",
+        Order = 205)]
     public DailyResetModeKind DailyResetMode
     {
         get => _dailyResetMode;
@@ -792,13 +873,16 @@ public class AccountInfoDisplay : Indicator
         }
     }
 
-    [Display(GroupName = "Daily Rails", Name = "Daily Reset Time (Local)", Order = 16)]
+    [Display(
+        GroupName = "Daily Rails",
+        Name = "Daily Reset Time (Local)",
+        Description = "Local reset time used only when Daily Reset Mode is LocalCustomTime.",
+        Order = 206)]
     public TimeSpan DailyResetTimeLocal
     {
         get => _dailyResetTimeLocal;
         set
         {
-            // Defensive clamp (same style you used for EOD)
             if (value < TimeSpan.Zero)
                 value = TimeSpan.Zero;
             if (value >= TimeSpan.FromDays(1))
@@ -816,8 +900,6 @@ public class AccountInfoDisplay : Indicator
     }
 
     #endregion
-
-
 
     #endregion
 

--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -41,12 +41,18 @@ public class AccountInfoDisplay : Indicator
 
     private sealed class TrailingDdState
     {
+        public bool IsInitialized { get; set; }
+
         public decimal StartEquity { get; set; }
         public decimal PeakEquity { get; set; }
         public decimal MaxOpenPnL { get; set; }
         public DateTime InitializedAtUtc { get; set; }
 
-        public bool IsInitialized { get; set; }
+        // Per-account config
+        public bool EnableTrailingDrawdown { get; set; }
+        public decimal MaxTrailingDrawdown { get; set; }
+        public TrailingInitMode InitializationMode { get; set; }
+        public decimal ManualStopEquity { get; set; }
     }
     #endregion
 
@@ -66,7 +72,12 @@ public class AccountInfoDisplay : Indicator
 
 	private Portfolio _currentPortfolio;
 
-    private TrailingDdState _trailingState = new();
+    private readonly Dictionary<string, TrailingDdState> _trailingStatesByAccount = new();
+    private string _activeAccountKey;
+
+    private bool _defaultEnableTrailingDrawdown = true;
+    private TrailingInitMode _defaultInitializationMode = TrailingInitMode.AutoFromCurrentEquity;
+    private decimal _defaultManualStopEquity = 0m;
 
     #endregion
 
@@ -194,7 +205,22 @@ public class AccountInfoDisplay : Indicator
         GroupName = "Funding / Trailing DD",
         Order = 10
     )]
-    public bool EnableTrailingDrawdown { get; set; } = true;
+    public bool DefaultEnableTrailingDrawdown
+    {
+        get => _defaultEnableTrailingDrawdown;
+        set
+        {
+            _defaultEnableTrailingDrawdown = value;
+
+            var state = TryGetActiveState();
+            if (state != null)
+                state.EnableTrailingDrawdown = value;
+
+            RedrawChart();
+        }
+    }
+
+    private decimal _maxTrailingDrawdownDefault = 2500m;
 
     [Display(
         Name = "Max Trailing Drawdown",
@@ -203,7 +229,21 @@ public class AccountInfoDisplay : Indicator
         Order = 11
     )]
     [Range(0, 1_000_000)]
-    public decimal MaxTrailingDrawdown { get; set; } = 2500m;
+    public decimal DefaultMaxTrailingDrawdown
+    {
+        get => _maxTrailingDrawdownDefault;
+        set
+        {
+            _maxTrailingDrawdownDefault = value;
+
+            // write into active account state as well
+            var state = TryGetActiveState();
+            if (state != null)
+                state.MaxTrailingDrawdown = value;
+
+            RedrawChart();
+        }
+    }
 
     [Display(
         Name = "Initialization Mode",
@@ -211,7 +251,20 @@ public class AccountInfoDisplay : Indicator
         GroupName = "Funding / Trailing DD",
         Order = 12
     )]
-    public TrailingInitMode InitializationMode { get; set; } = TrailingInitMode.AutoFromCurrentEquity;
+    public TrailingInitMode DefaultInitializationMode
+    {
+        get => _defaultInitializationMode;
+        set
+        {
+            _defaultInitializationMode = value;
+
+            var state = TryGetActiveState();
+            if (state != null)
+                state.InitializationMode = value;
+
+            RedrawChart();
+        }
+    }
 
     [Display(
         Name = "Manual Stop Equity",
@@ -220,7 +273,20 @@ public class AccountInfoDisplay : Indicator
         Order = 13
     )]
     [Range(-1_000_000, 10_000_000)]
-    public decimal ManualStopEquity { get; set; } = 0m;
+    public decimal DefaultManualStopEquity
+    {
+        get => _defaultManualStopEquity;
+        set
+        {
+            _defaultManualStopEquity = value;
+
+            var state = TryGetActiveState();
+            if (state != null)
+                state.ManualStopEquity = value;
+
+            RedrawChart();
+        }
+    }
 
     [Display(
      Name = "Reinitialize Now",
@@ -312,13 +378,16 @@ public class AccountInfoDisplay : Indicator
         if (portfolio == null)
             return;
 
+        _activeAccountKey = GetAccountKey(portfolio);
+        var state = GetOrCreateTrailingState(_activeAccountKey);
+
         // Phase 2: equity and trailing DD state
         var equity = portfolio.Balance + portfolio.OpenPnL;
 
-        InitializeTrailingState(portfolio, equity);
-        UpdateTrailingState(portfolio, equity);
+        InitializeTrailingState(state, portfolio, equity);
+        UpdateTrailingState(state, portfolio, equity);
 
-        var rows = BuildRows(portfolio, equity); // updated signature
+        var rows = BuildRows(state, portfolio, equity); // updated signature
         if (rows == null || rows.Count == 0)
             return;
 
@@ -366,13 +435,17 @@ public class AccountInfoDisplay : Indicator
     #region Private Methods
 
     private void OnPortfolioSelected(Portfolio portfolio)
-	{
-		_currentPortfolio = portfolio;
-        ResetTrailingState();
-        RedrawChart();
-	}
+    {
+        _currentPortfolio = portfolio;
+        _activeAccountKey = GetAccountKey(portfolio);
 
-    private List<DisplayRow> BuildRows(Portfolio portfolio, decimal equity)
+        var state = GetOrCreateTrailingState(_activeAccountKey);
+        SyncUiFromState(state);
+
+        RedrawChart();
+    }
+
+    private List<DisplayRow> BuildRows(TrailingDdState state, Portfolio portfolio, decimal equity)
     {
         var rows = new List<DisplayRow>();
 
@@ -411,15 +484,15 @@ public class AccountInfoDisplay : Indicator
         }
 
         // --- Trailing Drawdown block (Phase 2) ---
-        if (EnableTrailingDrawdown && _trailingState.IsInitialized)
+        if (state.EnableTrailingDrawdown && state.IsInitialized)
         {
-            var stopEquity = _trailingState.PeakEquity - MaxTrailingDrawdown;
-            var currentDd = _trailingState.PeakEquity - equity;
+            var stopEquity = state.PeakEquity - state.MaxTrailingDrawdown;
+            var currentDd = state.PeakEquity - equity;
             var remainingDd = equity - stopEquity;
 
             rows.Add(new DisplayRow("Equity", FormatCurrency(equity)));
-            rows.Add(new DisplayRow("Start Equity", FormatCurrency(_trailingState.StartEquity)));
-            rows.Add(new DisplayRow("Peak Equity", FormatCurrency(_trailingState.PeakEquity)));
+            rows.Add(new DisplayRow("Start Equity", FormatCurrency(state.StartEquity)));
+            rows.Add(new DisplayRow("Peak Equity", FormatCurrency(state.PeakEquity)));
             rows.Add(new DisplayRow("Stop Equity", FormatCurrency(stopEquity)));
 
             // Remaining DD: positive => safe (green), negative => breached (red)
@@ -429,7 +502,7 @@ public class AccountInfoDisplay : Indicator
             // We keep numericValue as negative magnitude so existing color rules (pos=green, neg=red) still work.
             rows.Add(new DisplayRow("Current DD", FormatCurrency(currentDd), numericValue: -currentDd));
 
-            rows.Add(new DisplayRow("Max Open PnL", FormatCurrency(_trailingState.MaxOpenPnL), numericValue: _trailingState.MaxOpenPnL));
+            rows.Add(new DisplayRow("Max Open PnL", FormatCurrency(state.MaxOpenPnL), numericValue: state.MaxOpenPnL));
         }
 
         return rows;
@@ -498,55 +571,115 @@ public class AccountInfoDisplay : Indicator
 
     #region Trailing Drawdown Helpers
 
-    private void ResetTrailingState()
+    private void ResetActiveAccountState(TrailingDdState state)
     {
-        _trailingState = new TrailingDdState();
+        state.IsInitialized = false;
+        state.StartEquity = 0m;
+        state.PeakEquity = 0m;
+        state.MaxOpenPnL = 0m;
+        state.InitializedAtUtc = default;
+
         _reinitializeNow = false;
     }
 
-    private void InitializeTrailingState(Portfolio portfolio, decimal equity)
+    private void ResetAllAccountStates()
     {
-        if (!EnableTrailingDrawdown)
+        _trailingStatesByAccount.Clear();
+        _reinitializeNow = false;
+    }
+
+    private void InitializeTrailingState(TrailingDdState state, Portfolio portfolio, decimal equity)
+    {
+        if (!state.EnableTrailingDrawdown)
             return;
 
 
         // One-shot init unless forced.
-        if (_trailingState.IsInitialized && !_reinitializeNow)
+        if (state.IsInitialized && !_reinitializeNow)
             return;
 
-        _trailingState.IsInitialized = true;
-        _trailingState.InitializedAtUtc = DateTime.UtcNow;
+        state.IsInitialized = true;
+        state.InitializedAtUtc = DateTime.UtcNow;
 
-        _trailingState.StartEquity = equity;
+        state.StartEquity = equity;
 
-        if (InitializationMode == TrailingInitMode.ManualStopEquity && MaxTrailingDrawdown > 0m)
+        if (state.InitializationMode == TrailingInitMode.ManualStopEquity && state.MaxTrailingDrawdown > 0m)
         {
             // Bootstrap using user-provided stop equity:
             // PeakEquity is derived so that: StopEquity = PeakEquity - MaxDD == ManualStopEquity
-            _trailingState.PeakEquity = ManualStopEquity + MaxTrailingDrawdown;
+            state.PeakEquity = state.ManualStopEquity + state.MaxTrailingDrawdown;
         }
         else
         {
             // Default: start from current equity
-            _trailingState.PeakEquity = equity;
+            state.PeakEquity = equity;
         }
 
-        _trailingState.MaxOpenPnL = portfolio.OpenPnL;
+        state.MaxOpenPnL = portfolio.OpenPnL;
 
         // Consume the pulse
         _reinitializeNow = false;
     }
 
-    private void UpdateTrailingState(Portfolio portfolio, decimal equity)
+    private void UpdateTrailingState(TrailingDdState state, Portfolio portfolio, decimal equity)
     {
-        if (!EnableTrailingDrawdown || !_trailingState.IsInitialized)
+        if (!state.EnableTrailingDrawdown || !state.IsInitialized)
             return;
 
-        if (equity > _trailingState.PeakEquity)
-            _trailingState.PeakEquity = equity;
+        if (equity > state.PeakEquity)
+            state.PeakEquity = equity;
 
-        if (portfolio.OpenPnL > _trailingState.MaxOpenPnL)
-            _trailingState.MaxOpenPnL = portfolio.OpenPnL;
+        if (portfolio.OpenPnL > state.MaxOpenPnL)
+            state.MaxOpenPnL = portfolio.OpenPnL;
+    }
+
+    #endregion
+
+    #region Multi account helpers
+
+    private string GetAccountKey(Portfolio portfolio)
+    {
+        // Prefer AccountID if present; fallback to a stable placeholder
+        if (!string.IsNullOrWhiteSpace(portfolio?.AccountID))
+            return portfolio.AccountID;
+
+        // Worst-case fallback: single bucket to avoid exceptions
+        return "DEFAULT";
+    }
+
+    private TrailingDdState GetOrCreateTrailingState(string accountKey)
+    {
+        if (_trailingStatesByAccount.TryGetValue(accountKey, out var state))
+            return state;
+
+        state = new TrailingDdState
+        {
+            EnableTrailingDrawdown = DefaultEnableTrailingDrawdown,
+            MaxTrailingDrawdown = DefaultMaxTrailingDrawdown,
+            InitializationMode = DefaultInitializationMode,
+            ManualStopEquity = DefaultManualStopEquity
+        };
+
+        _trailingStatesByAccount[accountKey] = state;
+        return state;
+    }
+
+    private void SyncUiFromState(TrailingDdState state)
+    {
+        _maxTrailingDrawdownDefault = state.MaxTrailingDrawdown;
+        _defaultInitializationMode = state.InitializationMode;
+        _defaultManualStopEquity = state.ManualStopEquity;
+        _defaultEnableTrailingDrawdown = state.EnableTrailingDrawdown;
+    }
+
+    private TrailingDdState TryGetActiveState()
+    {
+        if (string.IsNullOrEmpty(_activeAccountKey))
+            return null;
+
+        return _trailingStatesByAccount.TryGetValue(_activeAccountKey, out var state)
+            ? state
+            : null;
     }
 
     #endregion

--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -141,7 +141,7 @@ public class AccountInfoDisplay : Indicator
         public bool IsInitialized { get; set; }
         public decimal StartEquity { get; set; }
         public decimal PeakEquity { get; set; }
-        public decimal MaxOpenPnL { get; set; }
+        public decimal MaxOpenPnL { get; set; } // legacy v0/v1; kept for backward compatibility (no longer used)
 
         public string InitializedAtUtc { get; set; }           // "O"
         public string LastEodCaptureDate { get; set; }         // "yyyy-MM-dd" (date only)
@@ -174,6 +174,7 @@ public class AccountInfoDisplay : Indicator
 
     #region Fields
 
+    private Rectangle? _lastPanelRect;
     private Color _backgroundColor = Color.FromArgb(200, 20, 25, 35);
 	private Color _textColor = Color.FromArgb(220, 220, 220);
 	private Color _positiveColor = Color.FromArgb(0, 230, 118);
@@ -256,26 +257,41 @@ public class AccountInfoDisplay : Indicator
 
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.BackGround),
 		Description = nameof(Strings.LabelFillColorDescription), GroupName = nameof(Strings.Visualization))]
-	public CrossColor BackgroundColor
-	{
-		get => _backgroundColor.Convert();
-		set => _backgroundColor = value.Convert();
-	}
+    public CrossColor BackgroundColor
+    {
+        get => _backgroundColor.Convert();
+        set
+        {
+            _backgroundColor = value.Convert();
+            _lastPanelRect = null;
+            RedrawChart();
+        }
+    }
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.TextColor),
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.TextColor),
 		Description = nameof(Strings.LabelTextColorDescription), GroupName = nameof(Strings.Visualization))]
 	public CrossColor TextColor
 	{
 		get => _textColor.Convert();
-		set => _textColor = value.Convert();
-	}
+        set
+        {
+            _textColor = value.Convert();
+            _lastPanelRect = null;
+            RedrawChart();
+        }
+    }
 
 	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.PositiveColor),
 		Description = nameof(Strings.PositiveColorDescription), GroupName = nameof(Strings.Visualization))]
 	public CrossColor PositiveColor
 	{
 		get => _positiveColor.Convert();
-		set => _positiveColor = value.Convert();
+        set
+        {
+            _positiveColor = value.Convert();
+            _lastPanelRect = null;
+            RedrawChart();
+        }
 	}
 
 	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.NegativeColor),
@@ -283,7 +299,12 @@ public class AccountInfoDisplay : Indicator
 	public CrossColor NegativeColor
 	{
 		get => _negativeColor.Convert();
-		set => _negativeColor = value.Convert();
+        set
+        {
+            _negativeColor = value.Convert();
+            _lastPanelRect = null;
+            RedrawChart();
+        }
 	}
 
 	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.NeutralColor),
@@ -291,19 +312,34 @@ public class AccountInfoDisplay : Indicator
 	public CrossColor NeutralColor
 	{
 		get => _neutralColor.Convert();
-		set => _neutralColor = value.Convert();
+        set
+        {
+            _neutralColor = value.Convert();
+            _lastPanelRect = null;
+            RedrawChart();
+        }
 	}
 
 	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.FontSize),
 		Description = nameof(Strings.FontSizeDescription), GroupName = nameof(Strings.Visualization))]
 	[Range(6, 30)]
-	public float FontSize
-	{
-		get => _font.Size;
-		set => _font = new RenderFont("Arial", value);
-	}
+    public float FontSize
+    {
+        get => _font.Size;
+        set
+        {
+            if (Math.Abs(_font.Size - value) < 0.001f)
+                return;
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.ShowAccountId),
+            _font = new RenderFont("Arial", value);
+
+            // Force full panel redraw and avoid using stale previous rect.
+            _lastPanelRect = null;
+            RedrawChart();
+        }
+    }
+
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.ShowAccountId),
 		Description = nameof(Strings.ShowAccountIdDescription), GroupName = nameof(Strings.Settings))]
 	public bool ShowAccountId { get; set; } = true;
 
@@ -889,7 +925,17 @@ public class AccountInfoDisplay : Indicator
         var y = CalculateYPosition(rectHeight);
 
         var rectangle = new Rectangle(x, y, rectWidth, rectHeight);
-        context.FillRectangle(_backgroundColor, rectangle);
+
+        // Clear union of old+new panel rect to avoid leftover artifacts when font/rows/position change.
+        if (_lastPanelRect.HasValue)
+        {
+            var union = Rectangle.Union(_lastPanelRect.Value, rectangle);
+            context.FillRectangle(_backgroundColor, union);
+        }
+        else
+        {
+            context.FillRectangle(_backgroundColor, rectangle);
+        }
 
         context.DrawRectangle(new RenderPen(Color.Gray, 1), rectangle);
 
@@ -901,6 +947,8 @@ public class AccountInfoDisplay : Indicator
         );
 
         DrawColoredRows(context, rows, textRect, portfolio, maxLabelWidth);
+
+        _lastPanelRect = rectangle;
 
         // Throttled autosave (only if dirty)
         if (_isDirty)

--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -52,9 +52,10 @@ public class AccountInfoDisplay : Indicator
         public decimal PeakEquity { get; set; }
 
         // Phase 1: per-trade max open pnl (NOT historical)
-        public decimal TradeMaxOpenPnL { get; set; }
-        public bool WasPositionOpen { get; set; }
-        public decimal TradeOpenPnlBaseline { get; set; }   // portfolio.OpenPnL en el momento de apertura
+        public decimal TradeOpenPnlBaseline { get; set; }      // OpenPnL at trade open (baseline)
+        public decimal TradeMaxOpenPnL { get; set; }           // Max OpenPnL since entry (current trade)
+        public decimal LastTradeMaxOpenPnL { get; set; }       // Max OpenPnL since entry (last closed trade)
+        public bool WasPositionOpen { get; set; }              // Lifecycle flag for FLAT<->OPEN transitions
 
         public DateTime InitializedAtUtc { get; set; }
 
@@ -813,7 +814,11 @@ public class AccountInfoDisplay : Indicator
             // We keep numericValue as negative magnitude so existing color rules (pos=green, neg=red) still work.
             rows.Add(new DisplayRow("Current DD", FormatCurrency(currentDd), numericValue: -currentDd));
 
-            rows.Add(new DisplayRow("Trade Max Open PnL", FormatCurrency(state.TradeMaxOpenPnL), numericValue: state.TradeMaxOpenPnL));
+            if (state.WasPositionOpen == true)
+                rows.Add(new DisplayRow("Trade Max Open PnL (Current)", FormatCurrency(state.TradeMaxOpenPnL), numericValue: state.TradeMaxOpenPnL));
+
+            if (state.WasPositionOpen == false)
+                rows.Add(new DisplayRow("Trade Max Open PnL (Last)", FormatCurrency(state.LastTradeMaxOpenPnL), numericValue: state.LastTradeMaxOpenPnL));
 
         }
 
@@ -909,6 +914,7 @@ public class AccountInfoDisplay : Indicator
         state.InitializedAtUtc = default;
         state.LastEodCaptureDate = default;
         state.TradeOpenPnlBaseline = 0m;
+        state.LastTradeMaxOpenPnL = 0m;
 
         _reinitializeNow = false;
     }
@@ -949,6 +955,7 @@ public class AccountInfoDisplay : Indicator
         state.TradeMaxOpenPnL = 0m;
         state.WasPositionOpen = false;
         state.TradeOpenPnlBaseline = 0m;
+        state.LastTradeMaxOpenPnL = 0m;
 
         // Consume the pulse
         _reinitializeNow = false;
@@ -959,31 +966,35 @@ public class AccountInfoDisplay : Indicator
         if (!state.EnableTrailingDrawdown || !state.IsInitialized)
             return;
 
-        // Phase 1: per-trade tracking (single open position assumption)
+        // Phase 1: per-account per-trade tracking (single open position assumption)
         var isOpen = IsActivePositionOpen(portfolio);
 
-        if (!isOpen)
+        // OPEN event: FLAT -> OPEN
+        if (!state.WasPositionOpen && isOpen)
         {
-            state.TradeMaxOpenPnL = 0m;
+            state.TradeOpenPnlBaseline = portfolio.OpenPnL; // baseline at entry
+            state.TradeMaxOpenPnL = 0m;                     // current trade starts at 0
+            state.WasPositionOpen = true;
+        }
+        // CLOSE event: OPEN -> FLAT
+        else if (state.WasPositionOpen && !isOpen)
+        {
+            // Store the final max of the trade that just closed
+            state.LastTradeMaxOpenPnL = state.TradeMaxOpenPnL;
+
+            // Reset current-trade runtime (last trade remains visible)
             state.TradeOpenPnlBaseline = 0m;
+            state.TradeMaxOpenPnL = 0m;
             state.WasPositionOpen = false;
         }
-        else
+        // UPDATE while OPEN
+        else if (state.WasPositionOpen && isOpen)
         {
-            if (!state.WasPositionOpen)
-            {
-                // Trade just opened => lock baseline and reset per-trade max to 0
-                state.TradeOpenPnlBaseline = portfolio.OpenPnL;
-                state.TradeMaxOpenPnL = 0m;
-                state.WasPositionOpen = true;
-            }
-
-            // OpenPnL "since entry" (starts at 0 at trade open)
-            var tradeOpenPnl = portfolio.OpenPnL - state.TradeOpenPnlBaseline;
-
+            var tradeOpenPnl = portfolio.OpenPnL - state.TradeOpenPnlBaseline; // OpenPnL since entry
             if (tradeOpenPnl > state.TradeMaxOpenPnL)
                 state.TradeMaxOpenPnL = tradeOpenPnl;
         }
+        // UPDATE while FLAT: do nothing (LastTradeMaxOpenPnL stays visible)
 
         // PeakEquity policy
         if (state.PeakUpdateMode == TrailingPeakUpdateMode.Realtime)
@@ -1226,6 +1237,7 @@ public class AccountInfoDisplay : Indicator
         state.WasPositionOpen = false;
         state.TradeMaxOpenPnL = 0m;
         state.TradeOpenPnlBaseline = 0m;
+        state.LastTradeMaxOpenPnL = 0m;
 
         state.InitializedAtUtc = ParseDateTimeOrDefault(rt.InitializedAtUtc, default);
         state.LastEodCaptureDate = ParseDateOrDefault(rt.LastEodCaptureDate, default);

--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -382,7 +382,10 @@ public class AccountInfoDisplay : Indicator
 
             var state = TryGetActiveState();
             if (state != null)
-                state.EodTimeLocal = value;
+            { 
+                state.EodTimeLocal = value; 
+                state.LastEodCaptureDate = default; 
+            }
 
             RedrawChart();
         }
@@ -709,10 +712,7 @@ public class AccountInfoDisplay : Indicator
         state.PeakEquity = 0m;
         state.MaxOpenPnL = 0m;
         state.InitializedAtUtc = default;
-
-        // Reset markers
         state.LastEodCaptureDate = default;
-        state.LastMonthlyResetKey = 0;
 
         _reinitializeNow = false;
     }
@@ -863,11 +863,13 @@ public class AccountInfoDisplay : Indicator
             // If we're past the reset day and we haven't reset this month yet -> reset now.
             if (nowLocal.Day >= effectiveResetDay && state.LastMonthlyResetKey != monthKey)
             {
+                // Mark that we've reset this month (avoid multiple resets)
+                state.LastMonthlyResetKey = monthKey;
+
                 // Full reset for the new "monthly period"
                 ResetActiveAccountState(state);
 
-                // Mark that we've reset this month (avoid multiple resets)
-                state.LastMonthlyResetKey = monthKey;
+
 
                 // Ensure we don't immediately re-init again due to a pending UI pulse
                 _reinitializeNow = false;

--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -21,7 +21,7 @@ using System.Text.Json.Serialization;
 /// </summary>
 [HelpLink("https://help.atas.net/en/support/solutions/articles/72000648751-account-info-display")]
 [Category(IndicatorCategories.Trading)]
-[DisplayName("Account Info Display Modif")]
+[DisplayName("Account Info Display")]
 [Display(ResourceType = typeof(Strings), Description = nameof(Strings.AccountInfoDisplayDescription))]
 public class AccountInfoDisplay : Indicator
 {
@@ -52,8 +52,7 @@ public class AccountInfoDisplay : Indicator
         public decimal PeakEquity { get; set; }
 
         // Phase 1: per-trade max open pnl (NOT historical)
-        public decimal TradeOpenPnlBaseline { get; set; }      // OpenPnL at trade open (baseline)
-        public decimal TradeMaxOpenPnL { get; set; }           // Max OpenPnL since entry (current trade)
+        public decimal TradeMaxOpenPnL { get; set; }           
         public decimal LastTradeMaxOpenPnL { get; set; }       // Max OpenPnL since entry (last closed trade)
         public bool WasPositionOpen { get; set; }              // Lifecycle flag for FLAT<->OPEN transitions
 
@@ -92,6 +91,8 @@ public class AccountInfoDisplay : Indicator
         public int LastDailyResetKey { get; set; } // yyyymmdd based on trading day key (NY 17:00)
         public decimal DailyStartEquity { get; set; }
         public decimal DailyPeakEquity { get; set; }
+        public decimal TradeClosedPnlBaseline { get; set; }
+        public decimal LastClosedTradePnL { get; set; }
     }
 
     #region Persistence DTO
@@ -214,6 +215,12 @@ public class AccountInfoDisplay : Indicator
 
     private DailyResetModeKind _dailyResetMode = DailyResetModeKind.NewYork1700;
     private TimeSpan _dailyResetTimeLocal = new TimeSpan(17, 0, 0);
+
+    //Toggles
+    private const string _rowsGroupTrailingDd = "Rows / Trailing DD";
+    private const string _rowsGroupTrade = "Rows / Trade";
+    private const string _rowsGroupPosition = "Rows / Position";
+    private const string _rowsGroupDailyRails = "Rows / Daily Rails";
 
     #endregion
 
@@ -375,7 +382,65 @@ public class AccountInfoDisplay : Indicator
 		Description = nameof(Strings.ShowTotalPnLDescription), GroupName = nameof(Strings.Settings))]
 	public bool ShowTotalPnL { get; set; } = false;
 
-	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.HorizontalPosition),
+    // Trailing DD rows (Group: Rows / Trailing DD)
+    [Display(Name = "Show Equity", GroupName = _rowsGroupTrailingDd, Order = 40)]
+    public bool ShowEquityRow { get; set; } = true;
+
+    [Display(Name = "Show Start Equity", GroupName = _rowsGroupTrailingDd, Order = 41)]
+    public bool ShowStartEquityRow { get; set; } = true;
+
+    [Display(Name = "Show Peak Equity", GroupName = _rowsGroupTrailingDd, Order = 42)]
+    public bool ShowPeakEquityRow { get; set; } = true;
+
+    [Display(Name = "Show Stop Equity", GroupName = _rowsGroupTrailingDd, Order = 43)]
+    public bool ShowStopEquityRow { get; set; } = true;
+
+    [Display(Name = "Show Remaining DD", GroupName = _rowsGroupTrailingDd, Order = 44)]
+    public bool ShowRemainingDdRow { get; set; } = true;
+
+    [Display(Name = "Show Current DD", GroupName = _rowsGroupTrailingDd, Order = 45)]
+    public bool ShowCurrentDdRow { get; set; } = true;
+
+    // Trade metrics rows (Group: Rows / Trade)
+    [Display(Name = "Show Trade Max Open PnL (Current)", GroupName = _rowsGroupTrade, Order = 50)]
+    public bool ShowTradeMaxOpenPnlCurrentRow { get; set; } = true;
+
+    [Display(Name = "Show Trade Max Open PnL (Last)", GroupName = _rowsGroupTrade, Order = 51)]
+    public bool ShowTradeMaxOpenPnlLastRow { get; set; } = true;
+
+    [Display(Name = "Show Last Closed Trade PnL", GroupName = _rowsGroupTrade, Order = 52)]
+    public bool ShowLastClosedTradePnlRow { get; set; } = true;
+
+    // Position rows (Group: Rows / Position)
+    [Display(Name = "Show Position Snapshot", GroupName = _rowsGroupPosition, Order = 60)]
+    public bool ShowPositionSnapshot { get; set; } = true;
+
+    [Display(Name = "Show FLAT Row", GroupName = _rowsGroupPosition, Order = 61)]
+    public bool ShowFlatRow { get; set; } = true;
+
+    // Daily rails rows (Group: Rows / Daily Rails)
+    [Display(Name = "Show Daily Start Equity", GroupName = _rowsGroupDailyRails, Order = 70)]
+    public bool ShowDailyStartEquityRow { get; set; } = true;
+
+    [Display(Name = "Show Daily PnL", GroupName = _rowsGroupDailyRails, Order = 71)]
+    public bool ShowDailyPnlRow { get; set; } = true;
+
+    [Display(Name = "Show Daily Loss Base", GroupName = _rowsGroupDailyRails, Order = 72)]
+    public bool ShowDailyLossBaseRow { get; set; } = true;
+
+    [Display(Name = "Show Daily Stop Equity", GroupName = _rowsGroupDailyRails, Order = 73)]
+    public bool ShowDailyStopEquityRow { get; set; } = true;
+
+    [Display(Name = "Show Remaining Daily Loss", GroupName = _rowsGroupDailyRails, Order = 74)]
+    public bool ShowRemainingDailyLossRow { get; set; } = true;
+
+    [Display(Name = "Show Daily Profit Cap", GroupName = _rowsGroupDailyRails, Order = 75)]
+    public bool ShowDailyProfitCapRow { get; set; } = true;
+
+    [Display(Name = "Show Remaining to Profit Cap", GroupName = _rowsGroupDailyRails, Order = 76)]
+    public bool ShowRemainingToProfitCapRow { get; set; } = true;
+
+    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.HorizontalPosition),
 		GroupName = nameof(Strings.LayoutGroup))]
 	public HorizontalAlignment HorizontalPosition { get; set; } = HorizontalAlignment.Left;
 
@@ -995,7 +1060,9 @@ public class AccountInfoDisplay : Indicator
         if (portfolio == null)
             return rows;
 
-        // --- Existing rows (unchanged) ---
+        // -----------------------------
+        // Account / Balances / PnL
+        // -----------------------------
         if (ShowAccountId)
             rows.Add(new DisplayRow("Account", portfolio.AccountID));
 
@@ -1017,6 +1084,9 @@ public class AccountInfoDisplay : Indicator
         if (ShowOpenPnL)
             rows.Add(new DisplayRow("Open PnL", FormatCurrency(portfolio.OpenPnL), numericValue: portfolio.OpenPnL));
 
+        if (!state.WasPositionOpen && ShowLastClosedTradePnlRow)
+            rows.Add(new DisplayRow("Last Closed Trade PnL", FormatCurrency(state.LastClosedTradePnL), numericValue: state.LastClosedTradePnL));
+
         if (ShowClosedPnL)
             rows.Add(new DisplayRow("Closed PnL", FormatCurrency(portfolio.ClosedPnL), numericValue: portfolio.ClosedPnL));
 
@@ -1026,53 +1096,61 @@ public class AccountInfoDisplay : Indicator
             rows.Add(new DisplayRow("Total PnL", FormatCurrency(totalPnL), numericValue: totalPnL));
         }
 
-        // --- Trailing Drawdown block (Phase 2) ---
+        // -----------------------------
+        // Trailing Drawdown (Phase 2)
+        // -----------------------------
         if (state.EnableTrailingDrawdown && state.IsInitialized)
         {
             var stopEquity = state.PeakEquity - state.MaxTrailingDrawdown;
-            var currentDd = state.PeakEquity - equity;
-            var remainingDd = equity - stopEquity;
+            var currentDd = state.PeakEquity - equity;     // magnitude (positive when in drawdown)
+            var remainingDd = equity - stopEquity;         // positive = safe, negative = breached
 
-            rows.Add(new DisplayRow("Equity", FormatCurrency(equity)));
-            rows.Add(new DisplayRow("Start Equity", FormatCurrency(state.StartEquity)));
-            rows.Add(new DisplayRow("Peak Equity", FormatCurrency(state.PeakEquity)));
-            rows.Add(new DisplayRow("Stop Equity", FormatCurrency(stopEquity)));
+            if (ShowEquityRow)
+                rows.Add(new DisplayRow("Equity", FormatCurrency(equity)));
 
-            // Remaining DD: positive => safe (green), negative => breached (red)
-            rows.Add(new DisplayRow("Remaining DD", FormatCurrency(remainingDd), numericValue: remainingDd));
+            if (ShowStartEquityRow)
+                rows.Add(new DisplayRow("Start Equity", FormatCurrency(state.StartEquity)));
 
-            // Current DD: show as positive magnitude but color should reflect "bad when larger".
-            // We keep numericValue as negative magnitude so existing color rules (pos=green, neg=red) still work.
-            rows.Add(new DisplayRow("Current DD", FormatCurrency(currentDd), numericValue: -currentDd));
+            if (ShowPeakEquityRow)
+                rows.Add(new DisplayRow("Peak Equity", FormatCurrency(state.PeakEquity)));
 
-            if (state.WasPositionOpen == true)
+            if (ShowStopEquityRow)
+                rows.Add(new DisplayRow("Stop Equity", FormatCurrency(stopEquity)));
+
+            if (ShowRemainingDdRow)
+                rows.Add(new DisplayRow("Remaining DD", FormatCurrency(remainingDd), numericValue: remainingDd));
+
+            if (ShowCurrentDdRow)
+            {
+                // We want "bigger DD is worse" while reusing the existing color rules:
+                // positive => green, negative => red. So we pass -currentDd as numericValue.
+                rows.Add(new DisplayRow("Current DD", FormatCurrency(currentDd), numericValue: -currentDd));
+            }
+
+            // Per-trade metrics (Phase 5-1)
+            if (state.WasPositionOpen && ShowTradeMaxOpenPnlCurrentRow)
                 rows.Add(new DisplayRow("Trade Max Open PnL (Current)", FormatCurrency(state.TradeMaxOpenPnL), numericValue: state.TradeMaxOpenPnL));
 
-            if (state.WasPositionOpen == false)
+            if (!state.WasPositionOpen && ShowTradeMaxOpenPnlLastRow)
                 rows.Add(new DisplayRow("Trade Max Open PnL (Last)", FormatCurrency(state.LastTradeMaxOpenPnL), numericValue: state.LastTradeMaxOpenPnL));
-
         }
 
-        // --- Phase 1: Current position snapshot (debug/info) ---
-        if (_posSnapshot != null && _posSnapshot.IsOpen)
-        {
-            rows.Add(new DisplayRow("Pos Dir", _posSnapshot.Direction.ToString()));
-            rows.Add(new DisplayRow("Pos Qty", _posSnapshot.Volume.ToString("N0")));
-            rows.Add(new DisplayRow("Pos Entry", _posSnapshot.AvgEntryPrice.ToString("N2")));
-        }
-        else
-        {
-            rows.Add(new DisplayRow("Pos", "FLAT"));
-        }
+        // -----------------------------
+        // Daily Rails (Phase 5-2)
+        // -----------------------------
+        var dailyRailsEnabled =
+            (state.EnableDailyLossLimit && state.DailyLossLimit > 0m) ||
+            (state.EnableDailyProfitCap && state.DailyProfitCap > 0m);
 
-        // --- Daily Rails (Phase 2) ---
-        if ((state.EnableDailyLossLimit && state.DailyLossLimit > 0m) ||
-            (state.EnableDailyProfitCap && state.DailyProfitCap > 0m))
+        if (dailyRailsEnabled)
         {
             var dailyPnl = equity - state.DailyStartEquity;
 
-            rows.Add(new DisplayRow("Daily Start Equity", FormatCurrency(state.DailyStartEquity)));
-            rows.Add(new DisplayRow("Daily PnL", FormatCurrency(dailyPnl), numericValue: dailyPnl));
+            if (ShowDailyStartEquityRow)
+                rows.Add(new DisplayRow("Daily Start Equity", FormatCurrency(state.DailyStartEquity)));
+
+            if (ShowDailyPnlRow)
+                rows.Add(new DisplayRow("Daily PnL", FormatCurrency(dailyPnl), numericValue: dailyPnl));
 
             if (state.EnableDailyLossLimit && state.DailyLossLimit > 0m)
             {
@@ -1083,9 +1161,14 @@ public class AccountInfoDisplay : Indicator
                 var dailyStopEquity = lossBase - state.DailyLossLimit;
                 var remainingLoss = equity - dailyStopEquity;
 
-                rows.Add(new DisplayRow("Daily Loss Base", FormatCurrency(lossBase)));
-                rows.Add(new DisplayRow("Daily Stop Equity", FormatCurrency(dailyStopEquity)));
-                rows.Add(new DisplayRow("Remaining Daily Loss", FormatCurrency(remainingLoss), numericValue: remainingLoss));
+                if (ShowDailyLossBaseRow)
+                    rows.Add(new DisplayRow("Daily Loss Base", FormatCurrency(lossBase)));
+
+                if (ShowDailyStopEquityRow)
+                    rows.Add(new DisplayRow("Daily Stop Equity", FormatCurrency(dailyStopEquity)));
+
+                if (ShowRemainingDailyLossRow)
+                    rows.Add(new DisplayRow("Remaining Daily Loss", FormatCurrency(remainingLoss), numericValue: remainingLoss));
             }
 
             if (state.EnableDailyProfitCap && state.DailyProfitCap > 0m)
@@ -1094,13 +1177,31 @@ public class AccountInfoDisplay : Indicator
                 var profitAchieved = Math.Max(0m, dailyPnl);
                 var remainingToCap = state.DailyProfitCap - profitAchieved;
 
-                rows.Add(new DisplayRow("Daily Profit Cap", FormatCurrency(state.DailyProfitCap)));
-                rows.Add(new DisplayRow("Remaining to Profit Cap", FormatCurrency(remainingToCap), numericValue: remainingToCap));
+                if (ShowDailyProfitCapRow)
+                    rows.Add(new DisplayRow("Daily Profit Cap", FormatCurrency(state.DailyProfitCap)));
+
+                if (ShowRemainingToProfitCapRow)
+                    rows.Add(new DisplayRow("Remaining to Profit Cap", FormatCurrency(remainingToCap), numericValue: remainingToCap));
             }
+        }
+
+        // -----------------------------
+        // Position Snapshot (Phase 5-1)
+        // -----------------------------
+        if (ShowPositionSnapshot && _posSnapshot != null && _posSnapshot.IsOpen)
+        {
+            rows.Add(new DisplayRow("Pos Dir", _posSnapshot.Direction.ToString()));
+            rows.Add(new DisplayRow("Pos Qty", _posSnapshot.Volume.ToString("N0")));
+            rows.Add(new DisplayRow("Pos Entry", _posSnapshot.AvgEntryPrice.ToString("N2")));
+        }
+        else if (ShowFlatRow)
+        {
+            rows.Add(new DisplayRow("Pos", "FLAT"));
         }
 
         return rows;
     }
+
 
     private void DrawColoredRows(RenderContext context, List<DisplayRow> rows, Rectangle textRect, Portfolio portfolio, int maxLabelWidth)
     {
@@ -1188,7 +1289,6 @@ public class AccountInfoDisplay : Indicator
         state.WasPositionOpen = false;
         state.InitializedAtUtc = default;
         state.LastEodCaptureDate = default;
-        state.TradeOpenPnlBaseline = 0m;
         state.LastTradeMaxOpenPnL = 0m;
 
 
@@ -1230,7 +1330,6 @@ public class AccountInfoDisplay : Indicator
 
         state.TradeMaxOpenPnL = 0m;
         state.WasPositionOpen = false;
-        state.TradeOpenPnlBaseline = 0m;
         state.LastTradeMaxOpenPnL = 0m;
 
         // Consume the pulse
@@ -1248,9 +1347,9 @@ public class AccountInfoDisplay : Indicator
         // OPEN event: FLAT -> OPEN
         if (!state.WasPositionOpen && isOpen)
         {
-            state.TradeOpenPnlBaseline = portfolio.OpenPnL; // baseline at entry
             state.TradeMaxOpenPnL = 0m;                     // current trade starts at 0
             state.WasPositionOpen = true;
+            state.TradeClosedPnlBaseline = portfolio.ClosedPnL;
         }
         // CLOSE event: OPEN -> FLAT
         else if (state.WasPositionOpen && !isOpen)
@@ -1258,17 +1357,18 @@ public class AccountInfoDisplay : Indicator
             // Store the final max of the trade that just closed
             state.LastTradeMaxOpenPnL = state.TradeMaxOpenPnL;
 
+            //Store the PnL of the trade that just closed
+            state.LastClosedTradePnL = portfolio.ClosedPnL - state.TradeClosedPnlBaseline;
+
             // Reset current-trade runtime (last trade remains visible)
-            state.TradeOpenPnlBaseline = 0m;
             state.TradeMaxOpenPnL = 0m;
             state.WasPositionOpen = false;
         }
         // UPDATE while OPEN
         else if (state.WasPositionOpen && isOpen)
         {
-            var tradeOpenPnl = portfolio.OpenPnL - state.TradeOpenPnlBaseline; // OpenPnL since entry
-            if (tradeOpenPnl > state.TradeMaxOpenPnL)
-                state.TradeMaxOpenPnL = tradeOpenPnl;
+            if (portfolio.OpenPnL > state.TradeMaxOpenPnL)
+                state.TradeMaxOpenPnL = portfolio.OpenPnL;
         }
         // UPDATE while FLAT: do nothing (LastTradeMaxOpenPnL stays visible)
 
@@ -1537,7 +1637,6 @@ public class AccountInfoDisplay : Indicator
         state.PeakEquity = rt.PeakEquity;
         state.WasPositionOpen = false;
         state.TradeMaxOpenPnL = 0m;
-        state.TradeOpenPnlBaseline = 0m;
         state.LastTradeMaxOpenPnL = 0m;
 
         state.InitializedAtUtc = ParseDateTimeOrDefault(rt.InitializedAtUtc, default);

--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -60,6 +60,13 @@ public class AccountInfoDisplay : Indicator
 
         // Marker to ensure we capture EOD only once per local day
         public DateTime LastEodCaptureDate { get; set; } // Date component only
+
+        // Reset policy (per-account)
+        public bool EnableMonthlyReset { get; set; }
+        public int MonthlyResetDay { get; set; }   // 1..31 (validaremos)
+
+        // Reset markers (per-account)
+        public int LastMonthlyResetKey { get; set; } // yyyymm, e.g. 202512
     }
     #endregion
 
@@ -90,6 +97,9 @@ public class AccountInfoDisplay : Indicator
 
     // Bulenox default: 17:00 CT (user can change depending on local timezone)
     private TimeSpan _defaultEodTimeLocal = new(17, 0, 0);
+
+    private bool _defaultEnableMonthlyReset = true;
+    private int _defaultMonthlyResetDay = 1;
 
     #endregion
 
@@ -380,6 +390,55 @@ public class AccountInfoDisplay : Indicator
 
     #endregion
 
+    #region Trailing Reset Settings
+
+    // ---------- Monthly reset ----------
+
+    [Display(
+        Name = "Enable Monthly Reset",
+        Description = "Resets trailing drawdown at a fixed day of each month (per account).",
+        GroupName = "Funding / Trailing DD",
+        Order = 20
+    )]
+    public bool DefaultEnableMonthlyReset
+    {
+        get => _defaultEnableMonthlyReset;
+        set
+        {
+            _defaultEnableMonthlyReset = value;
+
+            var state = TryGetActiveState();
+            if (state != null)
+                state.EnableMonthlyReset = value;
+
+            RedrawChart();
+        }
+    }
+
+    [Display(
+        Name = "Monthly Reset Day",
+        Description = "Day of month when trailing drawdown resets (1–31). If the month has fewer days, last day is used.",
+        GroupName = "Funding / Trailing DD",
+        Order = 21
+    )]
+    [Range(1, 31)]
+    public int DefaultMonthlyResetDay
+    {
+        get => _defaultMonthlyResetDay;
+        set
+        {
+            _defaultMonthlyResetDay = value;
+
+            var state = TryGetActiveState();
+            if (state != null)
+                state.MonthlyResetDay = value;
+
+            RedrawChart();
+        }
+    }
+
+    #endregion
+
     #endregion
 
     #region Enums
@@ -453,6 +512,8 @@ public class AccountInfoDisplay : Indicator
         // Phase 2: equity and trailing DD state
         var equity = portfolio.Balance + portfolio.OpenPnL;
         var nowLocal = DateTime.Now;
+
+        MaybeResetForSchedule(state, portfolio, equity, nowLocal);
 
         InitializeTrailingState(state, portfolio, equity);
         UpdateTrailingState(state, portfolio, equity, nowLocal);
@@ -648,7 +709,10 @@ public class AccountInfoDisplay : Indicator
         state.PeakEquity = 0m;
         state.MaxOpenPnL = 0m;
         state.InitializedAtUtc = default;
+
+        // Reset markers
         state.LastEodCaptureDate = default;
+        state.LastMonthlyResetKey = 0;
 
         _reinitializeNow = false;
     }
@@ -741,7 +805,9 @@ public class AccountInfoDisplay : Indicator
 
             PeakUpdateMode = DefaultPeakUpdateMode,
             EodTimeLocal = DefaultEodTimeLocal,
-            LastEodCaptureDate = default
+            LastEodCaptureDate = default,
+            EnableMonthlyReset = DefaultEnableMonthlyReset,
+            MonthlyResetDay = DefaultMonthlyResetDay
         };
 
         _trailingStatesByAccount[accountKey] = state;
@@ -757,6 +823,9 @@ public class AccountInfoDisplay : Indicator
 
         _defaultPeakUpdateMode = state.PeakUpdateMode;
         _defaultEodTimeLocal = state.EodTimeLocal;
+
+        _defaultEnableMonthlyReset = state.EnableMonthlyReset;
+        _defaultMonthlyResetDay = state.MonthlyResetDay;
     }
 
     private TrailingDdState TryGetActiveState()
@@ -767,6 +836,43 @@ public class AccountInfoDisplay : Indicator
         return _trailingStatesByAccount.TryGetValue(_activeAccountKey, out var state)
             ? state
             : null;
+    }
+
+    private void MaybeResetForSchedule(TrailingDdState state, Portfolio portfolio, decimal equity, DateTime nowLocal)
+    {
+        if (state == null || portfolio == null)
+            return;
+
+        // ---------------------------------------------------------------------
+        // 1) Monthly reset (per account)
+        // Resets the whole trailing state once per month when Day >= MonthlyResetDay.
+        // If MonthlyResetDay exceeds the days in the month, the last day is used.
+        // ---------------------------------------------------------------------
+        if (state.EnableMonthlyReset)
+        {
+            var daysInMonth = DateTime.DaysInMonth(nowLocal.Year, nowLocal.Month);
+
+            // Defensive clamp (state.MonthlyResetDay is UI-ranged, but keep it safe)
+            var requestedDay = state.MonthlyResetDay;
+            if (requestedDay < 1) requestedDay = 1;
+
+            var effectiveResetDay = requestedDay > daysInMonth ? daysInMonth : requestedDay;
+
+            var monthKey = (nowLocal.Year * 100) + nowLocal.Month; // yyyymm
+
+            // If we're past the reset day and we haven't reset this month yet -> reset now.
+            if (nowLocal.Day >= effectiveResetDay && state.LastMonthlyResetKey != monthKey)
+            {
+                // Full reset for the new "monthly period"
+                ResetActiveAccountState(state);
+
+                // Mark that we've reset this month (avoid multiple resets)
+                state.LastMonthlyResetKey = monthKey;
+
+                // Ensure we don't immediately re-init again due to a pending UI pulse
+                _reinitializeNow = false;
+            }
+        }
     }
 
     private void MaybeCaptureEodPeak(TrailingDdState state, decimal equity, DateTime nowLocal)

--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -10,6 +10,11 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Drawing;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Security.Cryptography;
 
 /// <summary>
 /// Displays account information on the chart including account ID, balance, blocked margin, available balance, and PnL.
@@ -68,6 +73,53 @@ public class AccountInfoDisplay : Indicator
         // Reset markers (per-account)
         public int LastMonthlyResetKey { get; set; } // yyyymm, e.g. 202512
     }
+
+    #region Persistence DTO
+
+    private sealed class PersistedRootV1
+    {
+        public int SchemaVersion { get; set; } = _schemaVersion;
+        public string UpdatedAtUtc { get; set; } = DateTime.UtcNow.ToString("O");
+
+        // Key: accountKey (AccountID or fallback)
+        public Dictionary<string, PersistedAccountV1> Accounts { get; set; } = new();
+    }
+
+    private sealed class PersistedAccountV1
+    {
+        public PersistedConfigV1 Config { get; set; } = new();
+        public PersistedRuntimeV1 Runtime { get; set; } = new();
+    }
+
+    private sealed class PersistedConfigV1
+    {
+        public bool EnableTrailingDrawdown { get; set; }
+        public decimal MaxTrailingDrawdown { get; set; }
+        public int InitializationMode { get; set; }            // enum as int
+        public decimal ManualStopEquity { get; set; }
+
+        public int PeakUpdateMode { get; set; }                // enum as int
+        public string EodTimeLocal { get; set; }               // "HH:mm:ss"
+
+        public bool EnableMonthlyReset { get; set; }
+        public int MonthlyResetDay { get; set; }
+    }
+
+    private sealed class PersistedRuntimeV1
+    {
+        public bool IsInitialized { get; set; }
+        public decimal StartEquity { get; set; }
+        public decimal PeakEquity { get; set; }
+        public decimal MaxOpenPnL { get; set; }
+
+        public string InitializedAtUtc { get; set; }           // "O"
+        public string LastEodCaptureDate { get; set; }         // "yyyy-MM-dd" (date only)
+
+        public int LastMonthlyResetKey { get; set; }           // yyyymm
+    }
+
+    #endregion
+
     #endregion
 
     #region Fields
@@ -100,6 +152,35 @@ public class AccountInfoDisplay : Indicator
 
     private bool _defaultEnableMonthlyReset = true;
     private int _defaultMonthlyResetDay = 1;
+
+    #endregion
+
+    #region Persistence
+
+    private const int _schemaVersion = 1;
+    private const string _stateFileName = "AccountInfoDisplay.states.v1.json";
+
+    private string _stateFilePath;
+
+    private PersistedRootV1 _persistedRoot;
+
+    // Dirty + throttle
+    private bool _isDirty;
+    private DateTime _lastSaveUtc = DateTime.MinValue;
+    private readonly TimeSpan _minSaveInterval = TimeSpan.FromSeconds(10);
+
+    // Fingerprint to skip redundant disk writes
+    private string _lastSavedHash = string.Empty;
+
+    // Json options
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        WriteIndented = true,
+        AllowTrailingCommas = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        PropertyNameCaseInsensitive = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
 
     #endregion
 
@@ -238,6 +319,7 @@ public class AccountInfoDisplay : Indicator
             if (state != null)
                 state.EnableTrailingDrawdown = value;
 
+            TouchActiveAccountAndScheduleSave(force: false);
             RedrawChart();
         }
     }
@@ -263,6 +345,7 @@ public class AccountInfoDisplay : Indicator
             if (state != null)
                 state.MaxTrailingDrawdown = value;
 
+            TouchActiveAccountAndScheduleSave(force: false);
             RedrawChart();
         }
     }
@@ -284,6 +367,7 @@ public class AccountInfoDisplay : Indicator
             if (state != null)
                 state.InitializationMode = value;
 
+            TouchActiveAccountAndScheduleSave(force: false);
             RedrawChart();
         }
     }
@@ -306,6 +390,7 @@ public class AccountInfoDisplay : Indicator
             if (state != null)
                 state.ManualStopEquity = value;
 
+            TouchActiveAccountAndScheduleSave(force: false);
             RedrawChart();
         }
     }
@@ -357,6 +442,7 @@ public class AccountInfoDisplay : Indicator
                 state.LastEodCaptureDate = default; // allow EOD capture immediately if applicable
             }
 
+            TouchActiveAccountAndScheduleSave(force: false);
             RedrawChart();
         }
     }
@@ -387,6 +473,7 @@ public class AccountInfoDisplay : Indicator
                 state.LastEodCaptureDate = default; 
             }
 
+            TouchActiveAccountAndScheduleSave(force: false);
             RedrawChart();
         }
     }
@@ -414,6 +501,7 @@ public class AccountInfoDisplay : Indicator
             if (state != null)
                 state.EnableMonthlyReset = value;
 
+            TouchActiveAccountAndScheduleSave(force: false);
             RedrawChart();
         }
     }
@@ -436,6 +524,7 @@ public class AccountInfoDisplay : Indicator
             if (state != null)
                 state.MonthlyResetDay = value;
 
+            TouchActiveAccountAndScheduleSave(force: false);
             RedrawChart();
         }
     }
@@ -485,15 +574,50 @@ public class AccountInfoDisplay : Indicator
 			TradingManager.PortfolioSelected += OnPortfolioSelected;
 			_currentPortfolio = TradingManager.Portfolio;
 		}
-	}
 
-	protected override void OnDispose()
+        InitPersistencePath();
+        LoadStateFromDisk();
+
+        // Ensure active portfolio state is created, then apply persisted data if present
+        var portfolio = _currentPortfolio ?? TradingManager?.Portfolio;
+        if (portfolio != null)
+        {
+            _activeAccountKey = GetAccountKey(portfolio);
+
+            // Create state with defaults
+            var state = GetOrCreateTrailingState(_activeAccountKey);
+
+            // Apply persisted data (if any)
+            ApplyLoadedStateToAccount(_activeAccountKey);
+
+            // Sync UI from loaded state (so UI shows per-account values)
+            SyncUiFromState(state);
+
+            RedrawChart();
+        }
+
+    }
+
+    protected override void OnDispose()
 	{
 		if (TradingManager != null)
 		{
 			TradingManager.PortfolioSelected -= OnPortfolioSelected;
 		}
-	}
+
+        try
+        {
+            if (!string.IsNullOrEmpty(_activeAccountKey))
+            {
+                PersistAccountToMemory(_activeAccountKey);
+                SaveIfNeeded(force: true);
+            }
+        }
+        catch
+        {
+            // ignore
+        }
+    }
 
 	protected override void OnCalculate(int bar, decimal value)
 	{
@@ -562,6 +686,10 @@ public class AccountInfoDisplay : Indicator
         );
 
         DrawColoredRows(context, rows, textRect, portfolio, maxLabelWidth);
+
+        // Throttled autosave (only if dirty)
+        if (_isDirty)
+            SaveIfNeeded(force: false);
     }
 
     #endregion
@@ -570,10 +698,25 @@ public class AccountInfoDisplay : Indicator
 
     private void OnPortfolioSelected(Portfolio portfolio)
     {
+        // 1) Persist previous account (upsert + save)
+        if (!string.IsNullOrEmpty(_activeAccountKey))
+        {
+            PersistAccountToMemory(_activeAccountKey);
+            MarkDirty();
+            SaveIfNeeded(force: true);
+        }
+
+        // 2) Switch
         _currentPortfolio = portfolio;
         _activeAccountKey = GetAccountKey(portfolio);
 
+        // 3) Ensure state exists
         var state = GetOrCreateTrailingState(_activeAccountKey);
+
+        // 4) Load persisted data for new account if present
+        ApplyLoadedStateToAccount(_activeAccountKey);
+
+        // 5) Sync UI from the per-account state
         SyncUiFromState(state);
 
         RedrawChart();
@@ -869,7 +1012,8 @@ public class AccountInfoDisplay : Indicator
                 // Full reset for the new "monthly period"
                 ResetActiveAccountState(state);
 
-
+                // Persist the reset (throttled)
+                TouchMonthlyResetAndScheduleSave(GetAccountKey(portfolio), force: false);
 
                 // Ensure we don't immediately re-init again due to a pending UI pulse
                 _reinitializeNow = false;
@@ -904,6 +1048,300 @@ public class AccountInfoDisplay : Indicator
     }
 
     #endregion
+
+    #region Persistence helpers
+
+    private void InitPersistencePath()
+    {
+        // %AppData%\Roaming\ATAS\JSON\AccountInfoDisplay.states.v1.json
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        var baseDir = Path.Combine(appData, "ATAS", "JSON");
+
+        Directory.CreateDirectory(baseDir);
+
+        _stateFilePath = Path.Combine(baseDir, _stateFileName);
+    }
+
+    private void LoadStateFromDisk()
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(_stateFilePath))
+                InitPersistencePath();
+
+            if (!File.Exists(_stateFilePath))
+            {
+                _persistedRoot = new PersistedRootV1();
+                return;
+            }
+
+            var json = File.ReadAllText(_stateFilePath, Encoding.UTF8);
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                _persistedRoot = new PersistedRootV1();
+                return;
+            }
+
+            var loaded = JsonSerializer.Deserialize<PersistedRootV1>(json, _jsonOptions);
+            if (loaded == null)
+            {
+                _persistedRoot = new PersistedRootV1();
+                return;
+            }
+
+            // Basic schema guard (v1 only for now)
+            if (loaded.SchemaVersion != _schemaVersion)
+            {
+                // For now: re-init, or you can implement migrations later.
+                _persistedRoot = new PersistedRootV1();
+                return;
+            }
+
+            loaded.Accounts ??= new Dictionary<string, PersistedAccountV1>();
+            _persistedRoot = loaded;
+
+            // Seed fingerprint to avoid immediate rewrite
+            _lastSavedHash = ComputeSha256(json);
+            _isDirty = false;
+        }
+        catch
+        {
+            // Fail-safe: never break indicator rendering due to IO/JSON issues.
+            _persistedRoot = new PersistedRootV1();
+        }
+    }
+
+    private void ApplyLoadedStateToAccount(string accountKey)
+    {
+        if (string.IsNullOrEmpty(accountKey))
+            return;
+
+        if (_persistedRoot?.Accounts == null)
+            return;
+
+        if (!_persistedRoot.Accounts.TryGetValue(accountKey, out var persisted))
+            return;
+
+        if (!_trailingStatesByAccount.TryGetValue(accountKey, out var state))
+            return;
+
+        var cfg = persisted.Config ?? new PersistedConfigV1();
+        var rt = persisted.Runtime ?? new PersistedRuntimeV1();
+
+        // --- Config ---
+        state.EnableTrailingDrawdown = cfg.EnableTrailingDrawdown;
+        state.MaxTrailingDrawdown = cfg.MaxTrailingDrawdown;
+        state.InitializationMode = (TrailingInitMode)cfg.InitializationMode;
+        state.ManualStopEquity = cfg.ManualStopEquity;
+
+        state.PeakUpdateMode = (TrailingPeakUpdateMode)cfg.PeakUpdateMode;
+        state.EodTimeLocal = ParseTimeSpanOrDefault(cfg.EodTimeLocal, state.EodTimeLocal);
+
+        state.EnableMonthlyReset = cfg.EnableMonthlyReset;
+        state.MonthlyResetDay = cfg.MonthlyResetDay;
+
+        // --- Runtime ---
+        state.IsInitialized = rt.IsInitialized;
+        state.StartEquity = rt.StartEquity;
+        state.PeakEquity = rt.PeakEquity;
+        state.MaxOpenPnL = rt.MaxOpenPnL;
+
+        state.InitializedAtUtc = ParseDateTimeOrDefault(rt.InitializedAtUtc, default);
+        state.LastEodCaptureDate = ParseDateOrDefault(rt.LastEodCaptureDate, default);
+
+        state.LastMonthlyResetKey = rt.LastMonthlyResetKey;
+
+        // IMPORTANT: loading should not mark dirty.
+    }
+
+    private void PersistAccountToMemory(string accountKey)
+    {
+        if (string.IsNullOrEmpty(accountKey))
+            return;
+
+        if (_persistedRoot == null)
+            _persistedRoot = new PersistedRootV1();
+
+        _persistedRoot.Accounts ??= new Dictionary<string, PersistedAccountV1>();
+
+        if (!_trailingStatesByAccount.TryGetValue(accountKey, out var state))
+            return;
+
+        if (!_persistedRoot.Accounts.TryGetValue(accountKey, out var persisted))
+        {
+            persisted = new PersistedAccountV1();
+            _persistedRoot.Accounts[accountKey] = persisted;
+        }
+
+        persisted.Config ??= new PersistedConfigV1();
+        persisted.Runtime ??= new PersistedRuntimeV1();
+
+        // --- Config ---
+        persisted.Config.EnableTrailingDrawdown = state.EnableTrailingDrawdown;
+        persisted.Config.MaxTrailingDrawdown = state.MaxTrailingDrawdown;
+        persisted.Config.InitializationMode = (int)state.InitializationMode;
+        persisted.Config.ManualStopEquity = state.ManualStopEquity;
+
+        persisted.Config.PeakUpdateMode = (int)state.PeakUpdateMode;
+        persisted.Config.EodTimeLocal = FormatTimeSpan(state.EodTimeLocal);
+
+        persisted.Config.EnableMonthlyReset = state.EnableMonthlyReset;
+        persisted.Config.MonthlyResetDay = state.MonthlyResetDay;
+
+        // --- Runtime ---
+        persisted.Runtime.IsInitialized = state.IsInitialized;
+        persisted.Runtime.StartEquity = state.StartEquity;
+        persisted.Runtime.PeakEquity = state.PeakEquity;
+        persisted.Runtime.MaxOpenPnL = state.MaxOpenPnL;
+
+        persisted.Runtime.InitializedAtUtc = state.InitializedAtUtc == default
+            ? null
+            : state.InitializedAtUtc.ToString("O");
+
+        persisted.Runtime.LastEodCaptureDate = state.LastEodCaptureDate == default
+            ? null
+            : state.LastEodCaptureDate.Date.ToString("yyyy-MM-dd");
+
+        persisted.Runtime.LastMonthlyResetKey = state.LastMonthlyResetKey;
+
+        _persistedRoot.UpdatedAtUtc = DateTime.UtcNow.ToString("O");
+    }
+
+    private void SaveIfNeeded(bool force)
+    {
+        if (_persistedRoot == null)
+            return;
+
+        if (string.IsNullOrEmpty(_stateFilePath))
+            InitPersistencePath();
+
+        if (!force)
+        {
+            if (!_isDirty)
+                return;
+
+            var nowUtc = DateTime.UtcNow;
+            if (nowUtc - _lastSaveUtc < _minSaveInterval)
+                return;
+        }
+
+        try
+        {
+            var json = JsonSerializer.Serialize(_persistedRoot, _jsonOptions);
+            var hash = ComputeSha256(json);
+
+            // Skip disk write if content identical
+            if (!force && string.Equals(hash, _lastSavedHash, StringComparison.Ordinal))
+            {
+                _isDirty = false;
+                return;
+            }
+
+            // Atomic-ish write: write temp then replace
+            var tmp = _stateFilePath + ".tmp";
+            File.WriteAllText(tmp, json, Encoding.UTF8);
+
+            if (File.Exists(_stateFilePath))
+            {
+                // Replace destination atomically; no need to delete first
+                File.Replace(tmp, _stateFilePath, null);
+            }
+
+            else
+
+            {
+                // First-time save
+                File.Move(tmp, _stateFilePath);
+            }
+
+            _lastSavedHash = hash;
+            _lastSaveUtc = DateTime.UtcNow;
+            _isDirty = false;
+        }
+        catch
+        {
+            // Never break indicator due to IO errors.
+            // Keep dirty true so we can retry later.
+            _isDirty = true;
+        }
+    }
+
+    private void MarkDirty()
+    {
+        _isDirty = true;
+    }
+
+    private static string ComputeSha256(string text)
+    {
+        if (text == null)
+            return string.Empty;
+
+        using var sha = SHA256.Create();
+        var bytes = Encoding.UTF8.GetBytes(text);
+        var hash = sha.ComputeHash(bytes);
+        return Convert.ToHexString(hash);
+    }
+
+    private static TimeSpan ParseTimeSpanOrDefault(string value, TimeSpan fallback)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return fallback;
+
+        return TimeSpan.TryParse(value, out var ts) ? ts : fallback;
+    }
+
+    private static string FormatTimeSpan(TimeSpan value)
+    {
+        // HH:mm:ss (safe, stable)
+        var h = (int)value.TotalHours;
+        var m = value.Minutes;
+        var s = value.Seconds;
+        return $"{h:00}:{m:00}:{s:00}";
+    }
+
+    private static DateTime ParseDateTimeOrDefault(string value, DateTime fallback)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return fallback;
+
+        return DateTime.TryParse(value, null, System.Globalization.DateTimeStyles.RoundtripKind, out var dt)
+            ? dt
+            : fallback;
+    }
+
+    private static DateTime ParseDateOrDefault(string value, DateTime fallback)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return fallback;
+
+        return DateTime.TryParseExact(value, "yyyy-MM-dd", null, System.Globalization.DateTimeStyles.None, out var dt)
+            ? dt.Date
+            : fallback;
+    }
+
+    private void TouchActiveAccountAndScheduleSave(bool force = false)
+    {
+        if (string.IsNullOrEmpty(_activeAccountKey))
+            return;
+
+        PersistAccountToMemory(_activeAccountKey);
+        MarkDirty();
+        SaveIfNeeded(force);
+    }
+
+    private void TouchMonthlyResetAndScheduleSave(string accountKey, bool force = false)
+    {
+        if (string.IsNullOrEmpty(accountKey))
+            return;
+
+        PersistAccountToMemory(accountKey);
+        MarkDirty();
+        SaveIfNeeded(force);
+    }
+
+
+    #endregion
+
 
     #endregion
 }

--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -223,22 +223,20 @@ public class AccountInfoDisplay : Indicator
     public decimal ManualStopEquity { get; set; } = 0m;
 
     [Display(
-        Name = "Reinitialize Now",
-        Description = "Forces trailing drawdown state re-initialization on next render.",
-        GroupName = "Funding / Trailing DD",
-        Order = 14
-    )]
+     Name = "Reinitialize Now",
+     Description = "Forces trailing drawdown state re-initialization on next render.",
+     GroupName = "Funding / Trailing DD",
+     Order = 14
+ )]
     public bool ReinitializeNow
     {
-        get => _reinitializeNow;
+        get => false; // always show unchecked (button-like)
         set
         {
-            if (value == _reinitializeNow)
+            if (!value)
                 return;
 
-            _reinitializeNow = value;
-
-            // Re-render immediately when toggled
+            _reinitializeNow = true;
             RedrawChart();
         }
     }

--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -423,11 +423,6 @@ public class AccountInfoDisplay : Indicator
     // ==============================
 
     // Trailing DD rows (Group: Rows / Trailing DD)
-    [Display(Name = "Show Equity",
-        Description = "Shows the current account equity used by trailing drawdown calculations.",
-        GroupName = _rowsGroupTrailingDd, Order = 40)]
-    public bool ShowEquityRow { get; set; } = true;
-
     [Display(Name = "Show Start Equity",
         Description = "Shows the equity captured when trailing drawdown was initialized for this account.",
         GroupName = _rowsGroupTrailingDd, Order = 41)]
@@ -1186,9 +1181,6 @@ public class AccountInfoDisplay : Indicator
             var stopEquity = state.PeakEquity - state.MaxTrailingDrawdown;
             var currentDd = state.PeakEquity - equity;     // magnitude (positive when in drawdown)
             var remainingDd = equity - stopEquity;         // positive = safe, negative = breached
-
-            if (ShowEquityRow)
-                rows.Add(new DisplayRow("Equity", FormatCurrency(equity)));
 
             if (ShowStartEquityRow)
                 rows.Add(new DisplayRow("Start Equity", FormatCurrency(state.StartEquity)));

--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -813,6 +813,8 @@ public class AccountInfoDisplay : Indicator
             }
 
             // Draw value
+            var valueRect = new Rectangle(valueColumnX, currentY, textRect.Right - valueColumnX, lineHeight);
+            context.FillRectangle(_backgroundColor, valueRect);
             context.DrawString(valueStr, _font, valueColor, valueColumnX, currentY);
 
             currentY += lineHeight;


### PR DESCRIPTION
Phase 5-2: Daily Risk Rails (NY 17:00 reset) + Phase 2.5 UI/Render improvements

---

### Summary
This PR implements **per-account Daily Risk Rails (Phase 2)** for `AccountInfoDisplay`
and includes **Phase 2.5** improvements to make the panel usable and stable as the
number of displayed fields grows.

Daily Rails are calculation + display only. No chart lines, alerts, or trading
blocking are implemented in this PR.

---

### Phase 5-2 — Key Features (Daily Rails)
- **Daily Loss Limit (per account)**
  - Configurable limit.
  - Two calculation modes:
    - From session start equity.
    - Trailing from intraday peak equity.
- **Daily Profit Cap (per account)**
  - Calculated strictly from daily start equity (non-trailing by design).
- **Trading-day reset at 17:00 New York time**
  - DST-safe using `America/New_York`.
  - Optional local custom reset time.
- **Per-account persistence**
  - Daily rails configuration persisted in JSON.
  - Runtime daily state persisted (`DailyStartEquity`, `DailyPeakEquity`, `LastDailyResetKey`) to survive restarts.
- **Display-only**
  - Adds informational rows (Daily Start Equity, Daily PnL, Daily Loss Base, Daily Stop Equity, Remaining Daily Loss, Daily Profit Cap, Remaining to Profit Cap).

---

### Phase 5-2.5 — Key Improvements (Usability / Stability)
- **Per-row visibility toggles**
  - Granular, upstream-style toggles for Trailing DD / Trade metrics / Daily Rails / Position snapshot rows.
- **Last trade metrics**
  - Track and display:
    - Trade Max Open PnL (Current / Last)
    - Last Closed Trade PnL (realized)
- **Render cleanup**
  - Prevent panel “ghosting” artifacts when layout changes (e.g., font size/row count/position) by clearing the union of old+new panel rectangles before redraw.
- **UI documentation**
  - Add inline `Description` text to new fields so users understand what each value represents and when it updates.

---

### Design Rationale
- Daily risk rules are orthogonal to account trailing drawdown and are implemented independently.
- Trading-day reset mirrors funded-account operational rules (NY 17:00 cut) instead of local midnight.
- Profit cap is intentionally non-trailing to avoid moving targets.
- Phase 5-2.5 changes are display/UX focused and do not alter the core daily rails engine design.

---

### Scope / Non-Goals
Not included:
- Chart lines or visual rails.
- Alerts, auto-disable trading, or order blocking.
- Consistency rules (e.g. 40% rule).
- System-generated recommendations.

---

### Testing Notes
- Switch between multiple accounts and confirm states are independent.
- Verify daily reset occurs at NY 17:00 (including DST changes).
- Check both Daily Loss modes (From Start / From Peak).
- Confirm Daily Profit Cap remains based on Daily Start Equity (non-trailing).
- Open/close trades and validate:
  - Trade Max Open PnL (Current) increases and never decreases while open.
  - Trade Max Open PnL (Last) persists while flat.
  - Last Closed Trade PnL matches the realized change in ClosedPnL for the last round-trip.
- Change font size / toggle rows and confirm the panel redraws cleanly without leftover shadows.

---

### Files Changed
- `AccountInfoDisplay.cs`

---

### Checklist
- [ ] Compiles without warnings
- [ ] Daily rails are per-account
- [ ] NY 17:00 reset behaves correctly (DST-safe)
- [ ] Trade metrics behave correctly across open/close transitions
- [ ] UI toggles work per-row without breaking upstream core fields
- [ ] No render artifacts on layout changes

---

### Phase Mapping
- Phase 1: Trade snapshot + per-trade metrics ✔
- Phase 2: Daily Rails ✔
- Phase 2.5: UI visibility + last trade stats + render + UI docs ✔
- Phase 3+: Session behavior metrics, recommendations, alerts, chart rails (planned)

### Screenshots

<img width="388" height="471" alt="image" src="https://github.com/user-attachments/assets/2771f53b-07e7-411b-941c-fad173597fd4" />

<img width="386" height="608" alt="image" src="https://github.com/user-attachments/assets/0ab9a29b-b8c6-4a18-9e88-65c57c350f3e" />



