### PR TITLE
feat TradesOnChart: load trade history by chart range (independent of Statistics UI)

### DIFF
--- a/Technical/TradesOnChart.cs
+++ b/Technical/TradesOnChart.cs
@@ -1,17 +1,16 @@
 namespace ATAS.Indicators.Technical;
 
+using ATAS.DataFeedsCore;
+using OFT.Attributes;
+using OFT.Localization;
+using OFT.Rendering.Context;
+using OFT.Rendering.Tools;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Drawing;
 using System.Linq;
-using ATAS.DataFeedsCore;
-using OFT.Attributes;
-using OFT.Localization;
-using OFT.Rendering.Context;
-using OFT.Rendering.Tools;
-
 using Color = System.Drawing.Color;
 using DashStyle = System.Drawing.Drawing2D.DashStyle;
 using Pen = OFT.Rendering.Tools.RenderPen;
@@ -81,6 +80,9 @@ public class TradesOnChart : Indicator
     private DashStyle _lineStyle = DashStyle.Dash;
     private readonly List<Rectangle> _labelsAbove = new();
     private readonly List<Rectangle> _labelsBelow = new();
+    private volatile int _historyLoadToken;
+    private bool _isHistoryLoading;
+    private readonly HashSet<string> _seenTradeKeys = new(StringComparer.InvariantCultureIgnoreCase);
 
     #endregion
 
@@ -180,10 +182,18 @@ public class TradesOnChart : Indicator
 
     protected override void OnInitialize()
     {
-        TradingStatisticsProvider.Realtime.HistoryMyTrades.Added += OnTradeAdded;
+        TradingStatisticsProvider.Statistics.HistoryMyTrades.Added += OnTradeAdded;
         TradingManager.PortfolioSelected += TradingManager_PortfolioSelected;
 
         OnRecalculate();
+    }
+
+    protected override void OnDispose()
+    {
+        TradingStatisticsProvider.Statistics.HistoryMyTrades.Added -= OnTradeAdded;
+        TradingManager.PortfolioSelected -= TradingManager_PortfolioSelected;
+
+        base.OnDispose();
     }
 
     private void TradingManager_PortfolioSelected(Portfolio obj)
@@ -207,7 +217,10 @@ public class TradesOnChart : Indicator
         _sellPen = GetNewPen(_sellColor, _lineWidth, _lineStyle);
 
         _trades.Clear();
-        AddHistoryMyTrade();
+        _seenTradeKeys.Clear();
+
+        // Actively request stats for the chart range, independent from Statistics UI filters.
+        RequestHistoryForChartRange();
     }
 
     protected override void OnCalculate(int bar, decimal value)
@@ -452,39 +465,40 @@ public class TradesOnChart : Indicator
     #endregion
 
     #region Private Methods
-
-    private void AddHistoryMyTrade()
-    {
-	    if (TradingManager?.Portfolio == null|| TradingManager?.Security == null)
-            return;
-
-	    var allTrades = TradingStatisticsProvider?.Realtime?.HistoryMyTrades
-		    .Where(t => 
-                t.AccountID == TradingManager.Portfolio.AccountID && 
-                t.Security.SecurityId.Equals(TradingManager.Security.SecurityId, StringComparison.InvariantCultureIgnoreCase));
-
-	    foreach (var trade in allTrades)
-	    {
-		    CreateTradePair(trade);
-	    }
-    }
-
     private void OnTradeAdded(HistoryMyTrade trade)
     {
-	    if (TradingManager?.Portfolio == null || TradingManager?.Security == null)
-		    return;
+        // During bulk history loads we rebuild from the snapshot, so ignore incremental adds
+        // to prevent duplicates.
+        if (_isHistoryLoading)
+            return;
 
-        if (trade.AccountID == TradingManager.Portfolio.AccountID && trade.Security.Instrument == TradingManager.Security.Instrument)
-		    CreateTradePair(trade);        
+        if (TradingManager?.Portfolio == null || TradingManager?.Security == null)
+            return;
+
+        if (trade.AccountID != TradingManager.Portfolio.AccountID)
+            return;
+
+        if (!trade.Security.SecurityId.Equals(TradingManager.Security.SecurityId, StringComparison.InvariantCultureIgnoreCase))
+            return;
+
+        CreateTradePair(trade);
+        RedrawChart();
     }
+
 
     private void CreateTradePair(HistoryMyTrade trade)
     {
-        var enterBar = GetBarByTime(trade.OpenTime);
+        var key = GetTradeKey(trade);
+        if (!_seenTradeKeys.Add(key))
+            return;
 
-        if (enterBar < 0) return;
+        var enterBar = GetBarByTime(trade.OpenTime);
+        if (enterBar < 0)
+            return;
 
         var exitBar = GetBarByTime(trade.CloseTime);
+        if (exitBar < 0)
+            exitBar = enterBar;
 
         var tradeObj = new TradeObj(trade)
         {
@@ -494,6 +508,7 @@ public class TradesOnChart : Indicator
 
         _trades.Add(tradeObj);
     }
+
 
     private int GetBarByTime(DateTime time)
     {
@@ -546,6 +561,117 @@ public class TradesOnChart : Indicator
     {
         return new Pen(color, lineWidth) { DashStyle = lineStyle };
     }
+
+    private bool TryGetChartTimeRange(out DateTime from, out DateTime to)
+    {
+        from = default;
+        to = default;
+
+        if (CurrentBar <= 0)
+            return false;
+
+        var first = GetCandle(0);
+        var last = GetCandle(CurrentBar - 1);
+
+        // Defensive: candles can be null on some initialization phases
+        if (first == null || last == null)
+            return false;
+
+        from = first.Time;
+        to = last.Time;
+
+        // Ensure valid range
+        if (to < from)
+            (from, to) = (to, from);
+
+        return true;
+    }
+
+    private async void RequestHistoryForChartRange()
+    {
+        if (TradingManager?.Portfolio == null || TradingManager?.Security == null)
+            return;
+
+        if (!TryGetChartTimeRange(out var from, out var to))
+            return;
+
+        var token = ++_historyLoadToken;
+        _isHistoryLoading = true;
+
+        try
+        {
+            TradingStatisticsProvider.From = from;
+            TradingStatisticsProvider.To = to;
+
+            TradingStatisticsProvider.Accounts = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase)
+            {
+                TradingManager.Portfolio.AccountID
+            };
+
+            TradingStatisticsProvider.Securities = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase)
+            {
+                TradingManager.Security.SecurityId
+            };
+
+            #pragma warning disable CS0618
+            var stats = await TradingStatisticsProvider.LoadHistoryAsync(
+                from,
+                to,
+                new[] { TradingManager.Portfolio.AccountID },
+                new[] { TradingManager.Security.SecurityId }
+            );
+            #pragma warning restore CS0618
+
+            if (token != _historyLoadToken)
+                return;
+
+            _trades.Clear();
+            _seenTradeKeys.Clear();
+
+            // Build from the returned snapshot (not from Realtime cache/UI state)
+            foreach (var t in TradingStatisticsProvider.Statistics.HistoryMyTrades)
+            {
+                if (t.AccountID != TradingManager.Portfolio.AccountID)
+                    continue;
+
+                if (!t.Security.SecurityId.Equals(TradingManager.Security.SecurityId, StringComparison.InvariantCultureIgnoreCase))
+                    continue;
+
+                CreateTradePair(t);
+            }
+
+            RedrawChart();
+        }
+        finally
+        {
+            if (token == _historyLoadToken)
+                _isHistoryLoading = false;
+        }
+    }
+
+    private string GetTradeKey(HistoryMyTrade trade)
+    {
+        // Prefer the unique trade id when available (long in this build).
+        if (trade.Id != 0)
+            return trade.Id.ToString();
+
+        // Fallback: deterministic composite key (stringify everything)
+        return string.Join("|", new[]
+        {
+        trade.AccountID ?? string.Empty,
+        trade.Security?.SecurityId ?? string.Empty,
+        trade.OpenTime.Ticks.ToString(),
+        trade.CloseTime.Ticks.ToString(),
+        trade.OpenPrice.ToString(),
+        trade.ClosePrice.ToString(),
+        trade.OpenVolume.ToString(),
+        trade.CloseVolume.ToString(),
+        trade.PnL.ToString(),
+        trade.TicksPnL.ToString()
+    });
+    }
+
+
 
     #endregion
 }

--- a/Technical/TradesOnChart.cs
+++ b/Technical/TradesOnChart.cs
@@ -99,6 +99,24 @@ public class TradesOnChart : Indicator
     private string _ctxAcc;
     private string _ctxSec;
 
+    // Fast lookup to update already drawn trades when they become complete (Changed event)
+    private readonly Dictionary<long, TradeObj> _tradeById = new();
+
+    // Pending actions executed on OnCalculate (avoid UI-thread issues / race timing)
+    private volatile bool _pendingSyncClosedTrades;
+    private string _pendingSyncReason;
+    private volatile bool _pendingRedraw;
+
+    // Deferred sync retry (no timers). We retry until the provider snapshot actually includes the closed trade.
+    private int _pendingSyncRetriesLeft;
+    private DateTime _lastSnapshotMaxCloseTime = DateTime.MinValue;
+
+    private bool _subscriptionsAttached;
+    private readonly int _instanceTag = Environment.TickCount; // simple per-instance tag for logs
+
+    // Pending history reload executed on OnCalculate
+    private volatile bool _pendingHistoryReload;
+    private string _pendingHistoryReason;
 
     #endregion
 
@@ -201,18 +219,48 @@ public class TradesOnChart : Indicator
 
     protected override void OnInitialize()
     {
-        Dbg("OnInitialize: debug logging enabled.");
-        TradingStatisticsProvider.Statistics.HistoryMyTrades.Added += OnTradeAdded;
+        Dbg($"OnInitialize: debug logging enabled. instance={_instanceTag}");
+
+        if (_subscriptionsAttached)
+        {
+            Dbg($"OnInitialize skipped: subscriptions already attached. instance={_instanceTag}");
+            return;
+        }
+
+        _subscriptionsAttached = true;
+
         TradingManager.PortfolioSelected += TradingManager_PortfolioSelected;
+        TradingManager.PositionChanged += TradingManager_PositionChanged;
 
         OnRecalculate();
     }
 
     protected override void OnDispose()
     {
-        TradingStatisticsProvider.Statistics.HistoryMyTrades.Added -= OnTradeAdded;
-        TradingManager.PortfolioSelected -= TradingManager_PortfolioSelected;
+        var rtHist = TradingStatisticsProvider?.Realtime?.HistoryMyTrades;
+        if (rtHist != null)
+        {
+            rtHist.Added -= OnTradeAdded;
+            rtHist.Changed -= OnTradeChanged;
+            rtHist.Removed -= OnTradeRemoved;
+            rtHist.Cleared -= OnTradesCleared;
+        }
+        else
+        {
+            var hist = TradingStatisticsProvider?.Statistics?.HistoryMyTrades;
+            if (hist != null)
+            {
+                hist.Added -= OnTradeAdded;
+                hist.Changed -= OnTradeChanged;
+                hist.Removed -= OnTradeRemoved;
+                hist.Cleared -= OnTradesCleared;
+            }
+        }
 
+        TradingManager.PortfolioSelected -= TradingManager_PortfolioSelected;
+        TradingManager.PositionChanged -= TradingManager_PositionChanged;
+
+        _subscriptionsAttached = false;
         base.OnDispose();
     }
 
@@ -275,8 +323,52 @@ public class TradesOnChart : Indicator
 
     protected override void OnCalculate(int bar, decimal value)
     {
-       
+        if (_pendingHistoryReload)
+        {
+            var reason = _pendingHistoryReason ?? "Unknown";
+            _pendingHistoryReload = false;
+            _pendingHistoryReason = null;
+
+            Dbg($"OnCalculate -> executing deferred RequestHistoryForChartRange. reason={reason}, bar={bar}, CurrentBar={CurrentBar}");
+            RequestHistoryForChartRange();
+        }
+
+        // Execute deferred sync/redraw inside the indicator lifecycle (no timers).
+        if (_pendingSyncClosedTrades)
+        {
+            var reason = _pendingSyncReason ?? "Unknown";
+
+            Dbg($"OnCalculate -> executing deferred SyncClosedTrades. reason={reason}, bar={bar}, CurrentBar={CurrentBar}, retriesLeft={_pendingSyncRetriesLeft}");
+
+            var beforeMaxClose = _lastSnapshotMaxCloseTime;
+
+            SyncClosedTradesFromHistorySnapshot(reason);
+
+            // If provider snapshot did not advance yet, keep retrying on next OnCalculate (bounded, no timers).
+            if (_lastSnapshotMaxCloseTime <= beforeMaxClose && _pendingSyncRetriesLeft > 0)
+            {
+                _pendingSyncRetriesLeft--;
+                _pendingSyncClosedTrades = true; // keep pending
+                _pendingRedraw = true;
+                Dbg($"OnCalculate -> provider snapshot not advanced yet. Will retry. newRetriesLeft={_pendingSyncRetriesLeft}");
+            }
+            else
+            {
+                _pendingSyncClosedTrades = false;
+                _pendingSyncReason = null;
+                _pendingSyncRetriesLeft = 0;
+                Dbg("OnCalculate -> deferred SyncClosedTrades completed (snapshot advanced or retries exhausted).");
+            }
+        }
+
+        if (_pendingRedraw)
+        {
+            _pendingRedraw = false;
+            Dbg($"OnCalculate -> RedrawChart requested. bar={bar}, CurrentBar={CurrentBar}");
+            RedrawChart();
+        }
     }
+
 
     #region Rendering
 
@@ -556,10 +648,17 @@ public class TradesOnChart : Indicator
             }
         }
 
+        if (!trade.IsComplete)
+        {
+            Dbg("Statistics.Added ignored: trade not complete yet (waiting for Changed).");
+            return;
+        }
+
         CreateTradePairNoDedupe(trade);
 
         Dbg("Statistics.Added accepted: trade created, RedrawChart requested.");
-        RedrawChart();
+        _pendingRedraw = true;
+        Dbg("Realtime event -> pending redraw set (will redraw on OnCalculate).");
     }
 
 
@@ -705,8 +804,21 @@ public class TradesOnChart : Indicator
                 return;
             }
 
-            // NOTE: do not clear _seenTradeKeys here unless you want rebuild to re-add everything.
-            // In Phase 1, we rebuild trades list but keep dedupe to avoid re-adding duplicates from re-emissions.
+            // Take a filtered snapshot FIRST. If it's empty, do NOT wipe existing drawn trades.
+            // This prevents a race where LoadHistoryAsync completes but provider snapshot is not yet populated.
+            var providerTrades = TradingStatisticsProvider.Statistics.HistoryMyTrades;
+            var filtered = providerTrades
+                .Where(t =>
+                    string.Equals(t.AccountID, acc, StringComparison.InvariantCultureIgnoreCase) &&
+                    t.Security.SecurityId.Equals(sec, StringComparison.InvariantCultureIgnoreCase))
+                .ToList();
+
+            if (filtered.Count == 0)
+            {
+                Dbg($"Rebuild skipped: provider snapshot empty for context. Keeping existing trades. acc={acc}, secId={sec}, globalHistoryCount={providerTrades.Count()}");
+                return;
+            }
+
             lock (_tradesSync)
             {
                 _trades.Clear();
@@ -718,21 +830,13 @@ public class TradesOnChart : Indicator
             int total = 0, matchedRaw = 0, matchedUnique = 0, duplicates = 0, created = 0;
             var snapshotKeys = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
 
-            foreach (var t in TradingStatisticsProvider.Statistics.HistoryMyTrades)
+            foreach (var t in filtered)
             {
                 total++;
-
-                if (!string.Equals(t.AccountID, acc, StringComparison.InvariantCultureIgnoreCase))
-                    continue;
-
-                if (!t.Security.SecurityId.Equals(sec, StringComparison.InvariantCultureIgnoreCase))
-                    continue;
-
                 matchedRaw++;
 
                 var key = GetTradeKey(t);
 
-                // Snapshot duplicates (provider returned same trade multiple times)
                 if (!snapshotKeys.Add(key))
                 {
                     duplicates++;
@@ -741,29 +845,21 @@ public class TradesOnChart : Indicator
 
                 matchedUnique++;
 
-                // Cross-reload duplicates (ATAS re-emits; we already saw it earlier)
                 bool isNewKey;
                 lock (_tradesSync)
                     isNewKey = _seenTradeKeys.Add(key);
 
-                if (!isNewKey)
-                {
-                    // We still want it on chart after rebuild, so we must recreate the visual trade object
-                    // BUT without increasing dedupe counts. We'll create it anyway.
-                    // If you prefer, you can allow recreation always during rebuild.
-                }
-
                 var before = _trades.Count;
 
-                CreateTradePairNoDedupe(t); // see next section
+                CreateTradePairNoDedupe(t);
 
                 if (_trades.Count > before)
                     created++;
             }
 
             Dbg($"Rebuild END total={total}, matchedRaw={matchedRaw}, matchedUnique={matchedUnique}, duplicates={duplicates}, created={created}");
-
             RedrawChart();
+
         }
         finally
         {
@@ -833,8 +929,224 @@ public class TradesOnChart : Indicator
         };
 
         lock (_tradesSync)
+        {
             _trades.Add(tradeObj);
+
+            // Index by Id if available for in-place updates on Changed
+            if (trade.Id != 0)
+                _tradeById[trade.Id] = tradeObj;
+        }
     }
+
+    private void OnTradeChanged(HistoryMyTrade trade)
+    {
+        Dbg($"HistoryMyTrades.Changed: id={trade.Id}, complete={trade.IsComplete}, acc={trade.AccountID}, secId={trade.Security?.SecurityId}, open={trade.OpenTime:O}, close={trade.CloseTime:O}, pnl={trade.PnL}");
+
+        if (_isHistoryLoading)
+            return;
+
+        if (TradingManager?.Portfolio == null || TradingManager?.Security == null)
+            return;
+
+        if (!string.Equals(trade.AccountID, TradingManager.Portfolio.AccountID, StringComparison.InvariantCultureIgnoreCase))
+            return;
+
+        if (!trade.Security.SecurityId.Equals(TradingManager.Security.SecurityId, StringComparison.InvariantCultureIgnoreCase))
+            return;
+
+        if (!trade.IsComplete)
+            return;
+
+        bool updated = false;
+
+        lock (_tradesSync)
+        {
+            if (trade.Id != 0 && _tradeById.TryGetValue(trade.Id, out var existing))
+            {
+                existing.ClosePrice = trade.ClosePrice;
+                existing.CloseTime = trade.CloseTime;
+                existing.PnL = trade.PnL;
+                existing.PnLTicks = trade.TicksPnL;
+                existing.CloseBar = Math.Max(GetBarByTime(trade.CloseTime), existing.OpenBar);
+                updated = true;
+            }
+        }
+
+        if (!updated)
+            CreateTradePairNoDedupe(trade);
+
+        _pendingRedraw = true;
+        Dbg("Realtime event -> pending redraw set (will redraw on OnCalculate).");
+    }
+
+
+    private void OnTradeRemoved(HistoryMyTrade trade)
+    {
+        Dbg($"HistoryMyTrades.Removed: id={trade.Id}, acc={trade.AccountID}, secId={trade.Security?.SecurityId}, close={trade.CloseTime:O}");
+
+        if (trade.Id == 0)
+            return;
+
+        lock (_tradesSync)
+        {
+            if (_tradeById.Remove(trade.Id, out var obj))
+                _trades.Remove(obj);
+        }
+
+        _pendingRedraw = true;
+        Dbg("Realtime event -> pending redraw set (will redraw on OnCalculate).");
+    }
+
+    private void OnTradesCleared()
+    {
+        Dbg("HistoryMyTrades.Cleared");
+
+        lock (_tradesSync)
+        {
+            _trades.Clear();
+            _tradeById.Clear();
+            // Nota: _seenTradeKeys NO lo toco aquí porque tú lo gestionas por contexto.
+            // Si quieres que un cleared permita re-crear todo, se podría limpiar, pero no lo hacemos ahora.
+        }
+
+        _pendingRedraw = true;
+        Dbg("Realtime event -> pending redraw set (will redraw on OnCalculate).");
+    }
+
+    private void TradingManager_PositionChanged(Position pos)
+    {
+        if (pos == null)
+            return;
+
+        if (TradingManager?.Portfolio == null || TradingManager?.Security == null)
+            return;
+
+        if (!string.Equals(pos.AccountID, TradingManager.Portfolio.AccountID, StringComparison.InvariantCultureIgnoreCase))
+            return;
+
+        if (!pos.Security.SecurityId.Equals(TradingManager.Security.SecurityId, StringComparison.InvariantCultureIgnoreCase))
+            return;
+
+        // We only care about closures (position flat). This is the earliest reliable signal.
+        if (pos.Volume != 0)
+            return;
+
+        // Force next history request to NOT be skipped by the "same signature" guard.
+        // We only invalidate the "to" component; "from" remains untouched.
+        lock (_requestSync)
+        {
+            _lastReqTo = DateTime.MinValue;
+        }
+
+        // IMPORTANT: when position becomes flat, refresh provider range (To) so current candle is included
+        _pendingHistoryReload = true;
+        _pendingHistoryReason = "PositionFlat";
+        _pendingRedraw = true;
+
+        Dbg($"PositionChanged FLAT -> defer sync to OnCalculate. acc={pos.AccountID}, secId={pos.Security.SecurityId}");
+
+        // Defer: HistoryMyTrades may not be updated yet at this instant.
+        _pendingSyncClosedTrades = true;
+        _pendingSyncReason = "PositionFlat";
+        // Retry budget: enough to catch provider lag but bounded to avoid endless work.
+        _pendingSyncRetriesLeft = 30;
+
+        _pendingRedraw = true;
+    }
+
+
+
+    private void SyncClosedTradesFromHistorySnapshot(string reason)
+    {
+        if (_isHistoryLoading)
+        {
+            Dbg($"SyncClosedTrades skipped: history loading. reason={reason}");
+            return;
+        }
+
+        // Prefer realtime history snapshot if available, else fallback to Statistics.
+        var src = TradingStatisticsProvider?.Realtime?.HistoryMyTrades
+                  ?? TradingStatisticsProvider?.Statistics?.HistoryMyTrades;
+
+        if (src == null)
+        {
+            Dbg($"SyncClosedTrades aborted: HistoryMyTrades null. reason={reason}");
+            return;
+        }
+
+        int total = 0;
+        int accepted = 0;
+        int updated = 0;
+        var snapshotKeys = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+        DateTime snapshotMaxClose = DateTime.MinValue;
+
+        // Iterate snapshot and add only completed trades for current context.
+        foreach (var t in src)
+        {
+            total++;
+
+            if (!t.IsComplete)
+                continue;
+
+            if (!string.Equals(t.AccountID, TradingManager.Portfolio.AccountID, StringComparison.InvariantCultureIgnoreCase))
+                continue;
+
+            if (!t.Security.SecurityId.Equals(TradingManager.Security.SecurityId, StringComparison.InvariantCultureIgnoreCase))
+                continue;
+
+            var key = GetTradeKey(t);
+            if (!snapshotKeys.Add(key))
+                continue;
+
+            if (t.CloseTime > snapshotMaxClose)
+                snapshotMaxClose = t.CloseTime;
+
+            bool wasUpdated = false;
+
+            lock (_tradesSync)
+            {
+                // Update in-place if we already have it indexed.
+                if (t.Id != 0 && _tradeById.TryGetValue(t.Id, out var existing))
+                {
+                    existing.ClosePrice = t.ClosePrice;
+                    existing.CloseTime = t.CloseTime;
+                    existing.PnL = t.PnL;
+                    existing.PnLTicks = t.TicksPnL;
+                    existing.CloseBar = Math.Max(GetBarByTime(t.CloseTime), existing.OpenBar);
+
+                    wasUpdated = true;
+                }
+            }
+
+            if (wasUpdated)
+            {
+                updated++;
+                continue;
+            }
+
+            bool isNewKey;
+            lock (_tradesSync)
+                isNewKey = _seenTradeKeys.Add(key);
+
+            if (!isNewKey)
+                continue;
+
+            CreateTradePairNoDedupe(t);
+            accepted++;
+        }
+
+        if (accepted > 0 || updated > 0)
+            RedrawChart();
+
+        Dbg($"SyncClosedTrades snapshot: uniqueComplete={snapshotKeys.Count}, maxClose={snapshotMaxClose:O}, lastMaxClose={_lastSnapshotMaxCloseTime:O}");
+        Dbg($"SyncClosedTrades done. reason={reason}, total={total}, created={accepted}, updated={updated}");
+
+        if (snapshotMaxClose > DateTime.MinValue)
+            _lastSnapshotMaxCloseTime = snapshotMaxClose;
+    }
+
+
+
 
 
 

--- a/Technical/TradesOnChart.cs
+++ b/Technical/TradesOnChart.cs
@@ -11,7 +11,6 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Drawing;
 using System.Linq;
-using Utils.Common.Logging;
 using Color = System.Drawing.Color;
 using DashStyle = System.Drawing.Drawing2D.DashStyle;
 using Pen = OFT.Rendering.Tools.RenderPen;
@@ -86,9 +85,6 @@ public class TradesOnChart : Indicator
     private bool _isHistoryLoading;
     // Keep a persistent dedupe set per context; do NOT clear on every recalc.
     private readonly HashSet<string> _seenTradeKeys = new(StringComparer.InvariantCultureIgnoreCase);
-    private int _recalcCount;
-    private int _historyRequestCount;
-    private int _statsAddedCount;
     // Request signature caching.
     private readonly object _requestSync = new();
     private string _lastReqAcc;
@@ -112,7 +108,6 @@ public class TradesOnChart : Indicator
     private DateTime _lastSnapshotMaxCloseTime = DateTime.MinValue;
 
     private bool _subscriptionsAttached;
-    private readonly int _instanceTag = Environment.TickCount; // simple per-instance tag for logs
 
     // Pending history reload executed on OnCalculate
     private volatile bool _pendingHistoryReload;
@@ -196,9 +191,6 @@ public class TradesOnChart : Indicator
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Size), GroupName = nameof(Strings.Visualization))]
     public int MarkerSize { get; set; } = 2;
 
-    [Display(Name = "Debug logs", GroupName = "Debug", Description = "Enable verbose diagnostic logs for TradesOnChart.")]
-    public bool DebugLogs { get; set; } = false;
-
     #endregion
 
     #region ctor
@@ -219,11 +211,9 @@ public class TradesOnChart : Indicator
 
     protected override void OnInitialize()
     {
-        Dbg($"OnInitialize: debug logging enabled. instance={_instanceTag}");
 
         if (_subscriptionsAttached)
         {
-            Dbg($"OnInitialize skipped: subscriptions already attached. instance={_instanceTag}");
             return;
         }
 
@@ -266,7 +256,6 @@ public class TradesOnChart : Indicator
 
     private void TradingManager_PortfolioSelected(Portfolio obj)
     {
-        Dbg($"PortfolioSelected: {obj?.AccountID ?? "null"}");
         OnRecalculate();
     }
 
@@ -282,11 +271,9 @@ public class TradesOnChart : Indicator
 
     protected override void OnRecalculate()
     {
-        _recalcCount++;
         var acc = TradingManager?.Portfolio?.AccountID;
         var sec = TradingManager?.Security?.SecurityId;
 
-        Dbg($"OnRecalculate #{_recalcCount}. CurrentBar={CurrentBar}, Acc={acc ?? "null"}, SecId={sec ?? "null"}, Code={TradingManager?.Security?.Code ?? "null"}");
 
         _buyPen = GetNewPen(_buyColor, _lineWidth, _lineStyle);
         _sellPen = GetNewPen(_sellColor, _lineWidth, _lineStyle);
@@ -294,7 +281,6 @@ public class TradesOnChart : Indicator
         // If we are already loading, do not start another load.
         if (_isHistoryLoading)
         {
-            Dbg("OnRecalculate ignored: history loading in progress.");
             return;
         }
 
@@ -305,8 +291,6 @@ public class TradesOnChart : Indicator
 
         if (ctxChanged)
         {
-            Dbg($"Context changed -> reset caches. oldAcc={_ctxAcc ?? "null"}, newAcc={acc ?? "null"}, oldSec={_ctxSec ?? "null"}, newSec={sec ?? "null"}");
-
             _ctxAcc = acc;
             _ctxSec = sec;
 
@@ -329,7 +313,6 @@ public class TradesOnChart : Indicator
             _pendingHistoryReload = false;
             _pendingHistoryReason = null;
 
-            Dbg($"OnCalculate -> executing deferred RequestHistoryForChartRange. reason={reason}, bar={bar}, CurrentBar={CurrentBar}");
             RequestHistoryForChartRange();
         }
 
@@ -337,8 +320,6 @@ public class TradesOnChart : Indicator
         if (_pendingSyncClosedTrades)
         {
             var reason = _pendingSyncReason ?? "Unknown";
-
-            Dbg($"OnCalculate -> executing deferred SyncClosedTrades. reason={reason}, bar={bar}, CurrentBar={CurrentBar}, retriesLeft={_pendingSyncRetriesLeft}");
 
             var beforeMaxClose = _lastSnapshotMaxCloseTime;
 
@@ -350,21 +331,18 @@ public class TradesOnChart : Indicator
                 _pendingSyncRetriesLeft--;
                 _pendingSyncClosedTrades = true; // keep pending
                 _pendingRedraw = true;
-                Dbg($"OnCalculate -> provider snapshot not advanced yet. Will retry. newRetriesLeft={_pendingSyncRetriesLeft}");
             }
             else
             {
                 _pendingSyncClosedTrades = false;
                 _pendingSyncReason = null;
                 _pendingSyncRetriesLeft = 0;
-                Dbg("OnCalculate -> deferred SyncClosedTrades completed (snapshot advanced or retries exhausted).");
             }
         }
 
         if (_pendingRedraw)
         {
             _pendingRedraw = false;
-            Dbg($"OnCalculate -> RedrawChart requested. bar={bar}, CurrentBar={CurrentBar}");
             RedrawChart();
         }
     }
@@ -613,12 +591,8 @@ public class TradesOnChart : Indicator
     #region Private Methods
     private void OnTradeAdded(HistoryMyTrade trade)
     {
-        _statsAddedCount++;
-        Dbg($"Statistics.Added #{_statsAddedCount}: id={trade.Id}, acc={trade.AccountID}, secId={trade.Security?.SecurityId}, code={trade.Security?.Code}, open={trade.OpenTime:O}, close={trade.CloseTime:O}, pnl={trade.PnL}, vol={trade.OpenVolume}");
-
         if (_isHistoryLoading)
         {
-            Dbg("Statistics.Added ignored: history loading.");
             return;
         }
 
@@ -627,13 +601,11 @@ public class TradesOnChart : Indicator
 
         if (!string.Equals(trade.AccountID, TradingManager.Portfolio.AccountID, StringComparison.InvariantCultureIgnoreCase))
         {
-            Dbg("Statistics.Added ignored: account mismatch.");
             return;
         }
 
         if (!trade.Security.SecurityId.Equals(TradingManager.Security.SecurityId, StringComparison.InvariantCultureIgnoreCase))
         {
-            Dbg("Statistics.Added ignored: security mismatch.");
             return;
         }
 
@@ -643,22 +615,18 @@ public class TradesOnChart : Indicator
         {
             if (!_seenTradeKeys.Add(key))
             {
-                Dbg($"Statistics.Added duplicate ignored: key={key}, id={trade.Id}");
                 return;
             }
         }
 
         if (!trade.IsComplete)
         {
-            Dbg("Statistics.Added ignored: trade not complete yet (waiting for Changed).");
             return;
         }
 
         CreateTradePairNoDedupe(trade);
 
-        Dbg("Statistics.Added accepted: trade created, RedrawChart requested.");
         _pendingRedraw = true;
-        Dbg("Realtime event -> pending redraw set (will redraw on OnCalculate).");
     }
 
 
@@ -737,15 +705,11 @@ public class TradesOnChart : Indicator
         if (to < from)
             (from, to) = (to, from);
 
-        Dbg($"ChartRange: CurrentBar={CurrentBar}, from={from:O}, to={to:O}");
         return true;
     }
 
     private async void RequestHistoryForChartRange()
     {
-        _historyRequestCount++;
-        Dbg($"RequestHistoryForChartRange #{_historyRequestCount} START. CurrentBar={CurrentBar}");
-
         if (TradingManager?.Portfolio == null || TradingManager?.Security == null)
             return;
 
@@ -759,8 +723,6 @@ public class TradesOnChart : Indicator
         from = TruncateToSeconds(from);
         to = TruncateToSeconds(to);
 
-        Dbg($"RequestHistoryForChartRange #{_historyRequestCount} Range: from={from:O}, to={to:O}");
-
         // 1) Signature guard FIRST (no token/flags touched).
         lock (_requestSync)
         {
@@ -769,7 +731,6 @@ public class TradesOnChart : Indicator
                 _lastReqFrom == from &&
                 _lastReqTo == to)
             {
-                Dbg($"RequestHistoryForChartRange skipped: same signature acc={acc}, secId={sec}, from={from:O}, to={to:O}");
                 return;
             }
 
@@ -790,17 +751,14 @@ public class TradesOnChart : Indicator
             TradingStatisticsProvider.Accounts = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase) { acc };
             TradingStatisticsProvider.Securities = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase) { sec };
 
-            Dbg($"LoadHistoryAsync BEGIN token={token}, acc={acc}, secId={sec}");
-
-#pragma warning disable CS0618
+            // LoadHistoryAsync is obsolete in this build; we keep it scoped here because it is required to
+            // force provider refresh for the chart time range using the current recommended statistics source.
+            #pragma warning disable CS0618
             var stats = await TradingStatisticsProvider.LoadHistoryAsync(from, to, new[] { acc }, new[] { sec });
-#pragma warning restore CS0618
-
-            Dbg($"LoadHistoryAsync END token={token}, currentToken={_historyLoadToken}, statsNull={(stats is null)}, globalHistoryCount={TradingStatisticsProvider.Statistics.HistoryMyTrades.Count()}");
+            #pragma warning restore CS0618
 
             if (token != _historyLoadToken)
             {
-                Dbg("LoadHistoryAsync ignored: outdated token.");
                 return;
             }
 
@@ -815,7 +773,6 @@ public class TradesOnChart : Indicator
 
             if (filtered.Count == 0)
             {
-                Dbg($"Rebuild skipped: provider snapshot empty for context. Keeping existing trades. acc={acc}, secId={sec}, globalHistoryCount={providerTrades.Count()}");
                 return;
             }
 
@@ -824,8 +781,6 @@ public class TradesOnChart : Indicator
                 _trades.Clear();
                 // _seenTradeKeys is kept to prevent duplicates across reloads.
             }
-
-            Dbg("Rebuild BEGIN from TradingStatisticsProvider.Statistics.HistoryMyTrades");
 
             int total = 0, matchedRaw = 0, matchedUnique = 0, duplicates = 0, created = 0;
             var snapshotKeys = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
@@ -857,7 +812,6 @@ public class TradesOnChart : Indicator
                     created++;
             }
 
-            Dbg($"Rebuild END total={total}, matchedRaw={matchedRaw}, matchedUnique={matchedUnique}, duplicates={duplicates}, created={created}");
             RedrawChart();
 
         }
@@ -891,15 +845,6 @@ public class TradesOnChart : Indicator
     });
     }
 
-    private void Dbg(string message)
-    {
-        if (!DebugLogs)
-            return;
-
-        // Official ATAS logging mechanism (shown in ATAS log window)
-        this.LogInfo($"[TradesOnChart] {message}");
-    }
-
     private static DateTime TruncateToSeconds(DateTime dt)
     {
         var ticks = dt.Ticks - (dt.Ticks % TimeSpan.TicksPerSecond);
@@ -911,14 +856,12 @@ public class TradesOnChart : Indicator
         var enterBar = GetBarByTime(trade.OpenTime);
         if (enterBar < 0)
         {
-            Dbg($"CreateTradePairNoDedupe aborted: enterBar<0 id={trade.Id}, open={trade.OpenTime:O}, CurrentBar={CurrentBar}");
             return;
         }
 
         var exitBar = GetBarByTime(trade.CloseTime);
         if (exitBar < 0)
         {
-            Dbg($"CreateTradePairNoDedupe: exitBar<0 -> using enterBar. id={trade.Id}, close={trade.CloseTime:O}");
             exitBar = enterBar;
         }
 
@@ -940,8 +883,6 @@ public class TradesOnChart : Indicator
 
     private void OnTradeChanged(HistoryMyTrade trade)
     {
-        Dbg($"HistoryMyTrades.Changed: id={trade.Id}, complete={trade.IsComplete}, acc={trade.AccountID}, secId={trade.Security?.SecurityId}, open={trade.OpenTime:O}, close={trade.CloseTime:O}, pnl={trade.PnL}");
-
         if (_isHistoryLoading)
             return;
 
@@ -976,13 +917,11 @@ public class TradesOnChart : Indicator
             CreateTradePairNoDedupe(trade);
 
         _pendingRedraw = true;
-        Dbg("Realtime event -> pending redraw set (will redraw on OnCalculate).");
     }
 
 
     private void OnTradeRemoved(HistoryMyTrade trade)
     {
-        Dbg($"HistoryMyTrades.Removed: id={trade.Id}, acc={trade.AccountID}, secId={trade.Security?.SecurityId}, close={trade.CloseTime:O}");
 
         if (trade.Id == 0)
             return;
@@ -994,23 +933,21 @@ public class TradesOnChart : Indicator
         }
 
         _pendingRedraw = true;
-        Dbg("Realtime event -> pending redraw set (will redraw on OnCalculate).");
     }
 
     private void OnTradesCleared()
     {
-        Dbg("HistoryMyTrades.Cleared");
 
         lock (_tradesSync)
         {
             _trades.Clear();
             _tradeById.Clear();
-            // Nota: _seenTradeKeys NO lo toco aquí porque tú lo gestionas por contexto.
-            // Si quieres que un cleared permita re-crear todo, se podría limpiar, pero no lo hacemos ahora.
+            // Note: we intentionally do NOT clear _seenTradeKeys here because it is managed per context.
+            // If we wanted a "cleared" event to allow a full rebuild from scratch, we could clear it,
+            // but we are not doing that in this version to avoid duplicate churn.
         }
 
         _pendingRedraw = true;
-        Dbg("Realtime event -> pending redraw set (will redraw on OnCalculate).");
     }
 
     private void TradingManager_PositionChanged(Position pos)
@@ -1043,8 +980,6 @@ public class TradesOnChart : Indicator
         _pendingHistoryReason = "PositionFlat";
         _pendingRedraw = true;
 
-        Dbg($"PositionChanged FLAT -> defer sync to OnCalculate. acc={pos.AccountID}, secId={pos.Security.SecurityId}");
-
         // Defer: HistoryMyTrades may not be updated yet at this instant.
         _pendingSyncClosedTrades = true;
         _pendingSyncReason = "PositionFlat";
@@ -1060,7 +995,6 @@ public class TradesOnChart : Indicator
     {
         if (_isHistoryLoading)
         {
-            Dbg($"SyncClosedTrades skipped: history loading. reason={reason}");
             return;
         }
 
@@ -1070,7 +1004,6 @@ public class TradesOnChart : Indicator
 
         if (src == null)
         {
-            Dbg($"SyncClosedTrades aborted: HistoryMyTrades null. reason={reason}");
             return;
         }
 
@@ -1137,9 +1070,6 @@ public class TradesOnChart : Indicator
 
         if (accepted > 0 || updated > 0)
             RedrawChart();
-
-        Dbg($"SyncClosedTrades snapshot: uniqueComplete={snapshotKeys.Count}, maxClose={snapshotMaxClose:O}, lastMaxClose={_lastSnapshotMaxCloseTime:O}");
-        Dbg($"SyncClosedTrades done. reason={reason}, total={total}, created={accepted}, updated={updated}");
 
         if (snapshotMaxClose > DateTime.MinValue)
             _lastSnapshotMaxCloseTime = snapshotMaxClose;

--- a/Technical/TradesOnChart.cs
+++ b/Technical/TradesOnChart.cs
@@ -11,6 +11,7 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Drawing;
 using System.Linq;
+using Utils.Common.Logging;
 using Color = System.Drawing.Color;
 using DashStyle = System.Drawing.Drawing2D.DashStyle;
 using Pen = OFT.Rendering.Tools.RenderPen;
@@ -83,7 +84,21 @@ public class TradesOnChart : Indicator
     private readonly List<Rectangle> _labelsBelow = new();
     private volatile int _historyLoadToken;
     private bool _isHistoryLoading;
+    // Keep a persistent dedupe set per context; do NOT clear on every recalc.
     private readonly HashSet<string> _seenTradeKeys = new(StringComparer.InvariantCultureIgnoreCase);
+    private int _recalcCount;
+    private int _historyRequestCount;
+    private int _statsAddedCount;
+    // Request signature caching.
+    private readonly object _requestSync = new();
+    private string _lastReqAcc;
+    private string _lastReqSec;
+    private DateTime _lastReqFrom;
+    private DateTime _lastReqTo;
+    // Context signature for "current" chart stats.
+    private string _ctxAcc;
+    private string _ctxSec;
+
 
     #endregion
 
@@ -163,6 +178,9 @@ public class TradesOnChart : Indicator
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Size), GroupName = nameof(Strings.Visualization))]
     public int MarkerSize { get; set; } = 2;
 
+    [Display(Name = "Debug logs", GroupName = "Debug", Description = "Enable verbose diagnostic logs for TradesOnChart.")]
+    public bool DebugLogs { get; set; } = false;
+
     #endregion
 
     #region ctor
@@ -183,6 +201,7 @@ public class TradesOnChart : Indicator
 
     protected override void OnInitialize()
     {
+        Dbg("OnInitialize: debug logging enabled.");
         TradingStatisticsProvider.Statistics.HistoryMyTrades.Added += OnTradeAdded;
         TradingManager.PortfolioSelected += TradingManager_PortfolioSelected;
 
@@ -199,7 +218,8 @@ public class TradesOnChart : Indicator
 
     private void TradingManager_PortfolioSelected(Portfolio obj)
     {
-	    OnRecalculate();
+        Dbg($"PortfolioSelected: {obj?.AccountID ?? "null"}");
+        OnRecalculate();
     }
 
     protected override void OnApplyDefaultColors()
@@ -214,18 +234,44 @@ public class TradesOnChart : Indicator
 
     protected override void OnRecalculate()
     {
+        _recalcCount++;
+        var acc = TradingManager?.Portfolio?.AccountID;
+        var sec = TradingManager?.Security?.SecurityId;
+
+        Dbg($"OnRecalculate #{_recalcCount}. CurrentBar={CurrentBar}, Acc={acc ?? "null"}, SecId={sec ?? "null"}, Code={TradingManager?.Security?.Code ?? "null"}");
+
         _buyPen = GetNewPen(_buyColor, _lineWidth, _lineStyle);
         _sellPen = GetNewPen(_sellColor, _lineWidth, _lineStyle);
 
-        lock (_tradesSync)
+        // If we are already loading, do not start another load.
+        if (_isHistoryLoading)
         {
-            _trades.Clear();
-            _seenTradeKeys.Clear();
+            Dbg("OnRecalculate ignored: history loading in progress.");
+            return;
         }
 
-        // Actively request stats for the chart range, independent from Statistics UI filters.
+        // Only reset caches when context changed (account/security).
+        var ctxChanged =
+            !string.Equals(_ctxAcc, acc, StringComparison.InvariantCultureIgnoreCase) ||
+            !string.Equals(_ctxSec, sec, StringComparison.InvariantCultureIgnoreCase);
+
+        if (ctxChanged)
+        {
+            Dbg($"Context changed -> reset caches. oldAcc={_ctxAcc ?? "null"}, newAcc={acc ?? "null"}, oldSec={_ctxSec ?? "null"}, newSec={sec ?? "null"}");
+
+            _ctxAcc = acc;
+            _ctxSec = sec;
+
+            lock (_tradesSync)
+            {
+                _trades.Clear();
+                _seenTradeKeys.Clear();
+            }
+        }
+
         RequestHistoryForChartRange();
     }
+
 
     protected override void OnCalculate(int bar, decimal value)
     {
@@ -475,52 +521,47 @@ public class TradesOnChart : Indicator
     #region Private Methods
     private void OnTradeAdded(HistoryMyTrade trade)
     {
-        // During bulk history loads we rebuild from the snapshot, so ignore incremental adds
-        // to prevent duplicates.
+        _statsAddedCount++;
+        Dbg($"Statistics.Added #{_statsAddedCount}: id={trade.Id}, acc={trade.AccountID}, secId={trade.Security?.SecurityId}, code={trade.Security?.Code}, open={trade.OpenTime:O}, close={trade.CloseTime:O}, pnl={trade.PnL}, vol={trade.OpenVolume}");
+
         if (_isHistoryLoading)
+        {
+            Dbg("Statistics.Added ignored: history loading.");
             return;
+        }
 
         if (TradingManager?.Portfolio == null || TradingManager?.Security == null)
             return;
 
-        if (trade.AccountID != TradingManager.Portfolio.AccountID)
+        if (!string.Equals(trade.AccountID, TradingManager.Portfolio.AccountID, StringComparison.InvariantCultureIgnoreCase))
+        {
+            Dbg("Statistics.Added ignored: account mismatch.");
             return;
+        }
 
         if (!trade.Security.SecurityId.Equals(TradingManager.Security.SecurityId, StringComparison.InvariantCultureIgnoreCase))
+        {
+            Dbg("Statistics.Added ignored: security mismatch.");
             return;
+        }
 
-        CreateTradePair(trade);
-        RedrawChart();
-    }
-
-
-    private void CreateTradePair(HistoryMyTrade trade)
-    {
         var key = GetTradeKey(trade);
 
         lock (_tradesSync)
         {
             if (!_seenTradeKeys.Add(key))
+            {
+                Dbg($"Statistics.Added duplicate ignored: key={key}, id={trade.Id}");
                 return;
+            }
         }
 
-        var enterBar = GetBarByTime(trade.OpenTime);
-        if (enterBar < 0)
-            return;
+        CreateTradePairNoDedupe(trade);
 
-        var exitBar = GetBarByTime(trade.CloseTime);
-        if (exitBar < 0)
-            exitBar = enterBar;
-
-        var tradeObj = new TradeObj(trade)
-        {
-            OpenBar = enterBar,
-            CloseBar = exitBar,
-        };
-
-        lock (_tradesSync)
-            _trades.Add(tradeObj);
+        Dbg("Statistics.Added accepted: trade created, RedrawChart requested.");
+        RedrawChart();
     }
+
 
 
     private int GetBarByTime(DateTime time)
@@ -597,17 +638,49 @@ public class TradesOnChart : Indicator
         if (to < from)
             (from, to) = (to, from);
 
+        Dbg($"ChartRange: CurrentBar={CurrentBar}, from={from:O}, to={to:O}");
         return true;
     }
 
     private async void RequestHistoryForChartRange()
     {
+        _historyRequestCount++;
+        Dbg($"RequestHistoryForChartRange #{_historyRequestCount} START. CurrentBar={CurrentBar}");
+
         if (TradingManager?.Portfolio == null || TradingManager?.Security == null)
             return;
 
         if (!TryGetChartTimeRange(out var from, out var to))
             return;
 
+        var acc = TradingManager.Portfolio.AccountID;
+        var sec = TradingManager.Security.SecurityId;
+
+        // Normalize to seconds to avoid micro-deltas spamming requests.
+        from = TruncateToSeconds(from);
+        to = TruncateToSeconds(to);
+
+        Dbg($"RequestHistoryForChartRange #{_historyRequestCount} Range: from={from:O}, to={to:O}");
+
+        // 1) Signature guard FIRST (no token/flags touched).
+        lock (_requestSync)
+        {
+            if (string.Equals(_lastReqAcc, acc, StringComparison.InvariantCultureIgnoreCase) &&
+                string.Equals(_lastReqSec, sec, StringComparison.InvariantCultureIgnoreCase) &&
+                _lastReqFrom == from &&
+                _lastReqTo == to)
+            {
+                Dbg($"RequestHistoryForChartRange skipped: same signature acc={acc}, secId={sec}, from={from:O}, to={to:O}");
+                return;
+            }
+
+            _lastReqAcc = acc;
+            _lastReqSec = sec;
+            _lastReqFrom = from;
+            _lastReqTo = to;
+        }
+
+        // 2) Now we can mark a real load attempt.
         var token = ++_historyLoadToken;
         _isHistoryLoading = true;
 
@@ -615,46 +688,80 @@ public class TradesOnChart : Indicator
         {
             TradingStatisticsProvider.From = from;
             TradingStatisticsProvider.To = to;
+            TradingStatisticsProvider.Accounts = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase) { acc };
+            TradingStatisticsProvider.Securities = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase) { sec };
 
-            TradingStatisticsProvider.Accounts = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase)
-            {
-                TradingManager.Portfolio.AccountID
-            };
+            Dbg($"LoadHistoryAsync BEGIN token={token}, acc={acc}, secId={sec}");
 
-            TradingStatisticsProvider.Securities = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase)
-            {
-                TradingManager.Security.SecurityId
-            };
+#pragma warning disable CS0618
+            var stats = await TradingStatisticsProvider.LoadHistoryAsync(from, to, new[] { acc }, new[] { sec });
+#pragma warning restore CS0618
 
-            #pragma warning disable CS0618
-            var stats = await TradingStatisticsProvider.LoadHistoryAsync(
-                from,
-                to,
-                new[] { TradingManager.Portfolio.AccountID },
-                new[] { TradingManager.Security.SecurityId }
-            );
-            #pragma warning restore CS0618
+            Dbg($"LoadHistoryAsync END token={token}, currentToken={_historyLoadToken}, statsNull={(stats is null)}, globalHistoryCount={TradingStatisticsProvider.Statistics.HistoryMyTrades.Count()}");
 
             if (token != _historyLoadToken)
+            {
+                Dbg("LoadHistoryAsync ignored: outdated token.");
                 return;
+            }
 
+            // NOTE: do not clear _seenTradeKeys here unless you want rebuild to re-add everything.
+            // In Phase 1, we rebuild trades list but keep dedupe to avoid re-adding duplicates from re-emissions.
             lock (_tradesSync)
             {
                 _trades.Clear();
-                _seenTradeKeys.Clear();
+                // _seenTradeKeys is kept to prevent duplicates across reloads.
             }
 
-            // Build from the returned snapshot (not from Realtime cache/UI state)
+            Dbg("Rebuild BEGIN from TradingStatisticsProvider.Statistics.HistoryMyTrades");
+
+            int total = 0, matchedRaw = 0, matchedUnique = 0, duplicates = 0, created = 0;
+            var snapshotKeys = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+
             foreach (var t in TradingStatisticsProvider.Statistics.HistoryMyTrades)
             {
-                if (t.AccountID != TradingManager.Portfolio.AccountID)
+                total++;
+
+                if (!string.Equals(t.AccountID, acc, StringComparison.InvariantCultureIgnoreCase))
                     continue;
 
-                if (!t.Security.SecurityId.Equals(TradingManager.Security.SecurityId, StringComparison.InvariantCultureIgnoreCase))
+                if (!t.Security.SecurityId.Equals(sec, StringComparison.InvariantCultureIgnoreCase))
                     continue;
 
-                CreateTradePair(t);
+                matchedRaw++;
+
+                var key = GetTradeKey(t);
+
+                // Snapshot duplicates (provider returned same trade multiple times)
+                if (!snapshotKeys.Add(key))
+                {
+                    duplicates++;
+                    continue;
+                }
+
+                matchedUnique++;
+
+                // Cross-reload duplicates (ATAS re-emits; we already saw it earlier)
+                bool isNewKey;
+                lock (_tradesSync)
+                    isNewKey = _seenTradeKeys.Add(key);
+
+                if (!isNewKey)
+                {
+                    // We still want it on chart after rebuild, so we must recreate the visual trade object
+                    // BUT without increasing dedupe counts. We'll create it anyway.
+                    // If you prefer, you can allow recreation always during rebuild.
+                }
+
+                var before = _trades.Count;
+
+                CreateTradePairNoDedupe(t); // see next section
+
+                if (_trades.Count > before)
+                    created++;
             }
+
+            Dbg($"Rebuild END total={total}, matchedRaw={matchedRaw}, matchedUnique={matchedUnique}, duplicates={duplicates}, created={created}");
 
             RedrawChart();
         }
@@ -664,6 +771,7 @@ public class TradesOnChart : Indicator
                 _isHistoryLoading = false;
         }
     }
+
 
     private string GetTradeKey(HistoryMyTrade trade)
     {
@@ -686,6 +794,48 @@ public class TradesOnChart : Indicator
         trade.TicksPnL.ToString()
     });
     }
+
+    private void Dbg(string message)
+    {
+        if (!DebugLogs)
+            return;
+
+        // Official ATAS logging mechanism (shown in ATAS log window)
+        this.LogInfo($"[TradesOnChart] {message}");
+    }
+
+    private static DateTime TruncateToSeconds(DateTime dt)
+    {
+        var ticks = dt.Ticks - (dt.Ticks % TimeSpan.TicksPerSecond);
+        return new DateTime(ticks, dt.Kind);
+    }
+
+    private void CreateTradePairNoDedupe(HistoryMyTrade trade)
+    {
+        var enterBar = GetBarByTime(trade.OpenTime);
+        if (enterBar < 0)
+        {
+            Dbg($"CreateTradePairNoDedupe aborted: enterBar<0 id={trade.Id}, open={trade.OpenTime:O}, CurrentBar={CurrentBar}");
+            return;
+        }
+
+        var exitBar = GetBarByTime(trade.CloseTime);
+        if (exitBar < 0)
+        {
+            Dbg($"CreateTradePairNoDedupe: exitBar<0 -> using enterBar. id={trade.Id}, close={trade.CloseTime:O}");
+            exitBar = enterBar;
+        }
+
+        var tradeObj = new TradeObj(trade)
+        {
+            OpenBar = enterBar,
+            CloseBar = exitBar,
+        };
+
+        lock (_tradesSync)
+            _trades.Add(tradeObj);
+    }
+
 
 
 

--- a/Technical/TradesOnChart.cs
+++ b/Technical/TradesOnChart.cs
@@ -70,6 +70,7 @@ public class TradesOnChart : Indicator
     private RenderFont _labelFont = new RenderFont("Arial", 8F, FontStyle.Regular, GraphicsUnit.Point, 204);
     private RenderStringFormat _stringFormat = new RenderStringFormat() { Alignment = StringAlignment.Near, LineAlignment = StringAlignment.Center };
     private readonly List<TradeObj> _trades = new();
+    private readonly object _tradesSync = new();
     private Pen _buyPen;
     private Pen _sellPen;
     private Color _buyColor;
@@ -216,8 +217,11 @@ public class TradesOnChart : Indicator
         _buyPen = GetNewPen(_buyColor, _lineWidth, _lineStyle);
         _sellPen = GetNewPen(_sellColor, _lineWidth, _lineStyle);
 
-        _trades.Clear();
-        _seenTradeKeys.Clear();
+        lock (_tradesSync)
+        {
+            _trades.Clear();
+            _seenTradeKeys.Clear();
+        }
 
         // Actively request stats for the chart range, independent from Statistics UI filters.
         RequestHistoryForChartRange();
@@ -244,8 +248,12 @@ public class TradesOnChart : Indicator
         _labelsAbove.Clear();
         _labelsBelow.Clear();
 
-	    foreach (var trade in _trades)
-	    {
+        TradeObj[] tradesSnapshot;
+        lock (_tradesSync)
+            tradesSnapshot = _trades.ToArray();
+
+        foreach (var trade in tradesSnapshot)
+        {
 	        if (trade.OpenBar > LastVisibleBarNumber || trade.CloseBar < FirstVisibleBarNumber)
                 continue;
 
@@ -489,8 +497,12 @@ public class TradesOnChart : Indicator
     private void CreateTradePair(HistoryMyTrade trade)
     {
         var key = GetTradeKey(trade);
-        if (!_seenTradeKeys.Add(key))
-            return;
+
+        lock (_tradesSync)
+        {
+            if (!_seenTradeKeys.Add(key))
+                return;
+        }
 
         var enterBar = GetBarByTime(trade.OpenTime);
         if (enterBar < 0)
@@ -506,7 +518,8 @@ public class TradesOnChart : Indicator
             CloseBar = exitBar,
         };
 
-        _trades.Add(tradeObj);
+        lock (_tradesSync)
+            _trades.Add(tradeObj);
     }
 
 
@@ -625,8 +638,11 @@ public class TradesOnChart : Indicator
             if (token != _historyLoadToken)
                 return;
 
-            _trades.Clear();
-            _seenTradeKeys.Clear();
+            lock (_tradesSync)
+            {
+                _trades.Clear();
+                _seenTradeKeys.Clear();
+            }
 
             // Build from the returned snapshot (not from Realtime cache/UI state)
             foreach (var t in TradingStatisticsProvider.Statistics.HistoryMyTrades)


### PR DESCRIPTION
## Summary
This PR makes TradesOnChart independent from the Statistics tab UI filters by actively
requesting trade history for the time range currently loaded in the chart.

It also ensures that closed trades become visible on the chart immediately after a
position is closed, without requiring additional trades or manual refreshes.

## Key changes
- Compute from/to from loaded candles and configure TradingStatisticsProvider.From/To.
- Apply account and security filters directly on the statistics provider.
- Trigger an explicit history load for the current chart time range.
- Rebuild trades from TradingStatisticsProvider.Statistics.HistoryMyTrades.

## Real-time updates
- When a position transitions to FLAT, the indicator schedules a deferred synchronization
  on the next OnCalculate cycle to refresh closed trades.
- The synchronization retries until the statistics provider snapshot advances, ensuring
  newly closed trades are picked up as soon as they are available.
- The cached request signature is invalidated on position close so the history request is
  not skipped even if the chart time range itself did not change.

## Duplicate prevention
- Incremental HistoryMyTrades.Added events are ignored while a bulk history load is in
  progress to avoid creating transient duplicates.
- Trades are deduplicated using HistoryMyTrade.Id, with a deterministic fallback key when
  the Id is not available.

## Notes
- LoadHistoryAsync is marked obsolete in this ATAS build; its usage is intentionally scoped
  with a local warning suppression, as it is required to force a statistics refresh for the
  chart time range while consuming data from the recommended Statistics source.

## Screenshot
<img width="1107" height="1041" alt="image" src="https://github.com/user-attachments/assets/59066a14-3bcf-4c63-a8e3-2cf4c0dccc7b" />

<img width="311" height="247" alt="image" src="https://github.com/user-attachments/assets/c1640c03-1ff6-4064-9ee0-f1409df14970" />

