### PR TITLE
build(indicators): align Indicators.csproj with current Cross/Windows build structure

### DIFF
--- a/Technical/Indicators.csproj
+++ b/Technical/Indicators.csproj
@@ -7,47 +7,75 @@
     <SignAssembly>true</SignAssembly>
     <Configurations>Debug;Release;Publish</Configurations>
     <Platforms>AnyCPU;Cross</Platforms>
-    <UseWPF>True</UseWPF>
-    <TargetFramework>net8.0-windows</TargetFramework>
+	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	<WarningsNotAsErrors>NU1903</WarningsNotAsErrors>
   </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Platform)' == 'Cross' ">
+    <UseWPF>False</UseWPF>
+    <DefineConstants>$(DefineConstants);CROSS_PLATFORM</DefineConstants>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+	<PropertyGroup Condition=" '$(Platform)' != 'Cross' ">
+		<UseWPF>True</UseWPF>
+		<TargetFramework>net10.0-windows</TargetFramework>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<NoWarn>$(NoWarn);CA1416;CS8002</NoWarn>
+	</PropertyGroup>
 	
   <PropertyGroup Condition=" '$(Configuration)' == 'Publish' ">
     <Optimize Condition=" '$(Optimize)' == '' ">true</Optimize>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Platform)' == 'Cross' ">
+    <ATAS_BASE>C:\Program Files\ATAS X</ATAS_BASE>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Platform)' != 'Cross' ">
+    <ATAS_BASE>C:\Program Files (x86)\ATAS Platform</ATAS_BASE>
+  </PropertyGroup>
+
 	<ItemGroup>
-		<Reference Include="Newtonsoft.Json">
-			<HintPath>C:\Program Files (x86)\ATAS Platform\Newtonsoft.Json.dll</HintPath>
-		</Reference>
 		<Reference Include="OFT.Attributes">
-			<HintPath>C:\Program Files (x86)\ATAS Platform\OFT.Attributes.dll</HintPath>
+			<HintPath>$(ATAS_BASE)\OFT.Attributes.dll</HintPath>
 		</Reference>
-		<Reference Include="OFT.Editors">
-			<HintPath>C:\Program Files (x86)\ATAS Platform\OFT.Editors.dll</HintPath>
+		<Reference Include="OFT.Editors" Condition=" '$(Platform)' != 'Cross' ">
+			<HintPath>$(ATAS_BASE)\OFT.Editors.dll</HintPath>
 		</Reference>
 
 		<Reference Include="ATAS.DataFeedsCore">
-			<HintPath>C:\Program Files (x86)\ATAS Platform\ATAS.DataFeedsCore.dll</HintPath>
+			<HintPath>$(ATAS_BASE)\ATAS.DataFeedsCore.dll</HintPath>
 		</Reference>
 		<Reference Include="ATAS.Indicators">
-			<HintPath>C:\Program Files (x86)\ATAS Platform\ATAS.Indicators.dll</HintPath>
+			<HintPath>$(ATAS_BASE)\ATAS.Indicators.dll</HintPath>
 		</Reference>
 		<Reference Include="OFT.Rendering">
-			<HintPath>C:\Program Files (x86)\ATAS Platform\OFT.Rendering.dll</HintPath>
+			<HintPath>$(ATAS_BASE)\OFT.Rendering.dll</HintPath>
 		</Reference>
 		<Reference Include="Utils.Common">
-			<HintPath>C:\Program Files (x86)\ATAS Platform\Utils.Common.dll</HintPath>
+			<HintPath>$(ATAS_BASE)\Utils.Common.dll</HintPath>
 		</Reference>
-		<Reference Include="Utils.Windows">
-			<HintPath>C:\Program Files (x86)\ATAS Platform\Utils.Windows.dll</HintPath>
+		<Reference Include="Utils.Windows" Condition=" '$(Platform)' != 'Cross' ">
+			<HintPath>$(ATAS_BASE)\Utils.Windows.dll</HintPath>
 		</Reference>
 		<Reference Include="OFT.Localization">
-			<HintPath>C:\Program Files (x86)\ATAS Platform\OFT.Localization.dll</HintPath>
+			<HintPath>$(ATAS_BASE)\OFT.Localization.dll</HintPath>
+		</Reference>
+		<Reference Include="DevExpress.Data.v25.2" Condition=" '$(Platform)' != 'Cross' ">
+			<HintPath>$(ATAS_BASE)\DevExpress.Data.v25.2.dll</HintPath>
+		</Reference>
+		<Reference Include="Avalonia" Condition=" '$(Platform)' == 'Cross' ">
+			<HintPath>$(ATAS_BASE)\Avalonia.Base.dll</HintPath>
 		</Reference>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="System.Drawing.Common" Version="8.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+	</ItemGroup>
+	<ItemGroup Condition=" '$(Platform)' == 'Cross' ">
+		<PackageReference Include="System.Drawing.Common" Version="10.0.0" />
 	</ItemGroup>
   <ItemGroup Condition=" '$(Platform)' != 'Cross' ">
 	  <Compile Remove="**\*.Common.cs" />
@@ -66,4 +94,17 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
+
+  <!-- File exclusions -->
+  <ItemGroup Condition=" '$(Platform)' == 'Cross' ">
+    <Compile Remove="**\*.Windows.cs" />
+    <None Include="**\*.Windows.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+
+    <Compile Remove="**\*.xaml.cs" />
+    <None Include="**\*.xaml.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+
+    <Compile Remove="**\*.xaml" />
+    <None Include="**\*.xaml" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Updates the local-build project (`Indicators.csproj`) to better reflect the current build structure used by `Indicators.Technical.csproj`.

Key changes:

- Introduce platform-based split between Windows and Cross builds:
  - Windows → `net10.0-windows` with WPF enabled
  - Cross   → `net10.0` with `CROSS_PLATFORM` constant
- Normalize assembly references using a platform-specific base path (ATAS installation vs ATAS X installation).
- Add Avalonia references for Cross builds so that `Avalonia.Input` types used in `GlobalUsings.cs` resolve correctly.
- Enable strict warning handling (`<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` and `<WarningsNotAsErrors>NU1903</WarningsNotAsErrors>`) to match the main Technical project.
- Update `System.Drawing.Common` to `10.0.0` and scope it conditionally as a build shim for the `Cross` platform. This restores the transitive dependency (required for `Image` and `DashStyle` types) that is lost when referencing local compiled DLLs, while keeping the `net10.0-windows` build clean.
- Ensure platform-specific source files are excluded appropriately:
  - `*.Windows.cs` and XAML files excluded from Cross builds

The goal is to keep `Indicators.csproj` usable for local external builds while aligning it with the Cross/Windows split already present in the technical project, without introducing internal GitLab project references.

> Replaces #154 (closed due to branch rename from `local/build-base` → `local/build/01-base`).