### PR TITLE
Fix: Incorrect DOM strength sell ratio calculation & off-by-one error

### DIFF
--- a/Technical/DomStrength.cs
+++ b/Technical/DomStrength.cs
@@ -346,7 +346,7 @@ public class DomStrength : Indicator
 				{
 					_cumAsks = 0;
 
-					for (var i = 0; i <= LevelDepth.Value; i++)
+					for (var i = 0; i < LevelDepth.Value; i++)
 						_cumAsks += _mDepthAsk.Values[i];
 				}
 
@@ -361,7 +361,7 @@ public class DomStrength : Indicator
 					_cumBids = 0;
 					var lastIdx = _mDepthBid.Values.Count - 1;
 
-					for (var i = 0; i <= LevelDepth.Value; i++)
+					for (var i = 0; i < LevelDepth.Value; i++)
 						_cumBids += _mDepthBid.Values[lastIdx - i];
 				}
 			}

--- a/Technical/DomStrength.cs
+++ b/Technical/DomStrength.cs
@@ -352,7 +352,7 @@ public class DomStrength : Indicator
 
 				if (_mDepthBid.Count <= LevelDepth.Value)
 				{
-					_cumBids = _mDepthAsk.Values
+					_cumBids = _mDepthBid.Values
 						.DefaultIfEmpty(0)
 						.Sum();
 				}


### PR DESCRIPTION
**Description**:

This PR addresses two calculation bugs in the DomStrength indicator that generate incorrect values for the sell series and pose an out-of-bounds risk.


**Problems addressed:**

Wrong data source for _cumBids: When the bid depth is less than or equal to LevelDepth.Value, the code was mistakenly summing _mDepthAsk.Values instead of _mDepthBid.Values due to a copy-paste error. This completely invalidated the sellRatio calculation.

Off-by-one error in depth calculation: In CalcCumulativeDepth, the for loops iterating up to LevelDepth.Value used <= instead of <. Since LevelDepth represents the number of levels (e.g., 10), iterating from 0 with <= results in 11 iterations. This caused inaccurate cumulative sums and created a risk of an IndexOutOfRangeException.


**Changes proposed:**

- Replaced _mDepthAsk with _mDepthBid in the _cumBids fallback calculation.
- Changed <= to < in the for loops within CalcCumulativeDepth.


**Impact:**

- The sell series now correctly reflects the actual bid data.
- Safer array/list traversal.
- These are isolated mathematical fixes; no structural or architectural changes were made.

**Note for maintainers**: While debugging this indicator, I noticed a few other unrelated structural issues (such as missing locks in _trades causing race conditions, and a missing OnDispose). I wanted to keep this specific PR as small and focused as possible to make your review easier. I'd be happy to open separate, atomic PRs for those other fixes later if you are open to it.