### PR TITLE
Fix: Thread-safety issues and race conditions in DomStrength

### DIFF
--- a/Technical/DomStrength.cs
+++ b/Technical/DomStrength.cs
@@ -27,8 +27,8 @@ public class DomStrength : Indicator
 	private CumulativeDelta _cDelta = new();
 	private decimal _cumAsks;
 	private decimal _cumBids;
-	private bool _initialized;
-	private object _locker = new();
+	private volatile bool _initialized;
+	private readonly object _locker = new();
 	private SortedList<decimal, decimal> _mDepthAsk = new();
 	private SortedList<decimal, decimal> _mDepthBid = new();
 	private decimal _percent = 50;
@@ -170,14 +170,17 @@ public class DomStrength : Indicator
 
 	protected override void OnNewTrade(MarketDataArg trade)
 	{
-		if (_initialized)
-			_trades.Add(trade);
-
-		if (_trades.Count > 100000)
+		lock (_locker)
 		{
-			_trades = _trades
-				.Skip(10000)
-				.ToList();
+			if (_initialized)
+				_trades.Add(trade);
+
+			if (_trades.Count > 100000)
+			{
+				_trades = _trades
+					.Skip(10000)
+					.ToList();
+			}
 		}
 	}
 
@@ -281,12 +284,18 @@ public class DomStrength : Indicator
 		var startBar = Math.Max(0, bar - Period);
 		var startTime = GetCandle(startBar).Time;
 
-		_buyVolume = _trades
-			.Where(x => x.Time >= startTime && x.Direction is TradeDirection.Buy)
+        List<MarketDataArg> tradesSnapshot;
+        lock (_locker)
+        {
+            tradesSnapshot = new List<MarketDataArg>(_trades);
+        }
+
+        _buyVolume = tradesSnapshot
+            .Where(x => x.Time >= startTime && x.Direction is TradeDirection.Buy)
 			.Sum(x => x.Volume);
 
-		_sellVolume = _trades
-			.Where(x => x.Time >= startTime && x.Direction is TradeDirection.Sell)
+		_sellVolume = tradesSnapshot
+            .Where(x => x.Time >= startTime && x.Direction is TradeDirection.Sell)
 			.Sum(x => x.Volume);
 
 		var buyRatio = (_cumAsks == 0


### PR DESCRIPTION
**Description**:
This PR addresses critical concurrency issues that can cause intermittent crashes (such as InvalidOperationException for modified collections) when the indicator processes incoming market data and calculates ratios simultaneously across different threads.

**Problems addressed**:

1. **Unprotected List writes/reads**: The _trades list was being written to and reassigned in OnNewTrade (market data thread) while simultaneously being iterated over via LINQ in CalcRatio (UI/calc thread).

2. **Missing volatile modifier**: The _initialized flag is read and written across multiple threads, risking thread-caching issues.
 
3. **Mutable lock object**: The _locker object lacked the readonly modifier, leaving it vulnerable to accidental reassignment.

**Changes proposed:**

- Marked _initialized as volatile.

- Marked _locker as readonly.

- Added lock (_locker) synchronization to all _trades list mutations in OnNewTrade.

- Implemented a fast, thread-safe snapshot of _trades inside CalcRatio (tradesSnapshot). The heavy LINQ calculations now run against this snapshot outside the lock, ensuring safety without blocking the market data ingestion.

**Impact**:

- Eliminates race conditions and collection-modified exceptions.

- Improves the overall stability of the indicator in high-volatility scenarios.

**Note for maintainers**: This is the second of three planned atomic PRs to fully stabilize this indicator. Once this is reviewed, I will submit a third and final PR to address the remaining SDK lifecycle issues (missing OnDispose for event unsubscription and OnRecalculate for state resets).