### PR TITLE
fix: improve SDK lifecycle management and resource handling

### DIFF
--- a/Technical/DomStrength.cs
+++ b/Technical/DomStrength.cs
@@ -56,10 +56,8 @@ public class DomStrength : Indicator
 			_period = value;
 			_buySeries.Clear();
 			_sellSeries.Clear();
-
-			if (_buySeries.Count > 0)
-				OnCalculate(CurrentBar - 1, 0);
-		}
+            RecalculateValues();
+        }
 	}
 
     [Parameter]
@@ -73,10 +71,8 @@ public class DomStrength : Indicator
 			_percent = value;
 			_buySeries.Clear();
 			_sellSeries.Clear();
-
-			if (_buySeries.Count > 0)
-				OnCalculate(CurrentBar - 1, 0);
-		}
+            RecalculateValues();
+        }
 	}
 
 	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Color80), GroupName = nameof(Strings.Color), Description = nameof(Strings.PercentColorDescription), Order = 200)]
@@ -124,12 +120,13 @@ public class DomStrength : Indicator
 		if (ChartInfo is null)
 			return;
 
-		var candles = (CandleDataSeries)DataSeries[0];
-
-		candles.UpCandleColor = ChartInfo.ColorsStore.UpCandleColor.Convert();
-		candles.DownCandleColor = ChartInfo.ColorsStore.DownCandleColor.Convert();
-		candles.BorderColor = ChartInfo.ColorsStore.BarBorderPen.Color.Convert();
-	}
+        if (DataSeries[0] is CandleDataSeries candles)
+        {
+            candles.UpCandleColor = ChartInfo.ColorsStore.UpCandleColor.Convert();
+            candles.DownCandleColor = ChartInfo.ColorsStore.DownCandleColor.Convert();
+            candles.BorderColor = ChartInfo.ColorsStore.BarBorderPen.Color.Convert();
+        }
+    }
 
 	protected override void OnInitialize()
 	{
@@ -275,11 +272,30 @@ public class DomStrength : Indicator
 		}
 	}
 
-	#endregion
+    protected override void OnDispose()
+    {
+        LevelDepth.PropertyChanged -= FilterDepthChanged;
+    }
 
-	#region Private methods
+    protected override void OnRecalculate()
+    {
+        lock (_locker)
+        {
+            _mDepthAsk.Clear();
+            _mDepthBid.Clear();
+        }
 
-	private void CalcRatio(int bar)
+        _buyVolume = 0;
+        _sellVolume = 0;
+        _cumAsks = 0;
+        _cumBids = 0;
+    }
+
+    #endregion
+
+    #region Private methods
+
+    private void CalcRatio(int bar)
 	{
 		var startBar = Math.Max(0, bar - Period);
 		var startTime = GetCandle(startBar).Time;


### PR DESCRIPTION
## Description
This PR enhances the stability and efficiency of the SDK lifecycle by refining state management, optimizing resource cleanup, and improving type safety within the component.

## Key Changes

* **Logic Optimization:** Refactored the `Period` and `Percent` setters to use `RecalculateValues()`. This replaces dead conditional logic (the previous branch was guarded by `_buySeries.Count > 0` immediately after `_buySeries.Clear()`, so it never executed) and ensures UI parameter changes consistently trigger a recalculation.
* **Enhanced Type Safety:** Introduced pattern matching in `OnApplyDefaultColors` for `DataSeries` handling. This prevents `InvalidCastException` if the nested data series type ever changes.
* **Resource Management:** Implemented `OnDispose` to unsubscribe from the `LevelDepth.PropertyChanged` event. This resolves a memory/event leak when the indicator is removed from a chart.
* **Depth-Cache Reset on Recalculation:** Implemented `OnRecalculate` to clear the market-depth snapshot maps (`_mDepthAsk`, `_mDepthBid`) so they are rebuilt from scratch at the start of each recalculation cycle. The cumulative-trades cache (`_trades`) and the `_initialized` gate are intentionally **not** reset, because `RequestForCumulativeTrades` is a one-shot initialization that only runs in `OnInitialize` — clearing them here would leave the indicator stuck in a non-initialized state and stop it from calculating after a `RecalculateValues()` call.

## Impact

* **Stability:** Eliminates the event-handler leak on dispose and avoids the lifecycle pitfall of resetting initialization-only state during recalculation.
* **Reactivity:** Provides a more predictable user experience when adjusting `Period` / `Percent` via the UI — changes now take effect immediately and the indicator keeps calculating without interruption.
* **Maintainability:** Adopts modern C# patterns and removes dead conditional logic from the setters.

## How to Test

1. Verify that changes to `Period` or `Percent` in the settings panel trigger an immediate visual update on the chart.
2. Repeatedly add/remove the indicator from a chart and confirm there is no growth in the `LevelDepth` event subscriber count (no leak).
3. After the indicator is fully initialized (cumulative trades received), change `Period` and `Percent` several times in succession and confirm the indicator keeps calculating — i.e. it does **not** freeze due to losing its initialization state.
4. Switch timeframes and confirm the depth snapshot is rebuilt cleanly and historical bars render without stale depth data leaking across sessions.

---
Contributions and feedback are welcome as we continue to improve the SDK's robustness.