### PR TITLE
fix(MultiMarketPower): thread safety, lifecycle and cleanup

### DIFF
--- a/Technical/MultiMarketPower.cs
+++ b/Technical/MultiMarketPower.cs
@@ -724,28 +724,41 @@ public class MultiMarketPower : Indicator
 
 	private void CalculateTick(MarketDataArg tick)
 	{
+		var bar = CurrentBar - 1;
+		if (bar < 0)
+			return;
+
+		if (tick.Direction is TradeDirection.Between)
+			return;
+
+		var newBar = bar != _lastBar;
+		if (newBar)
+			_lastBar = bar;
+
 		var deltaVolume = tick.Volume * (tick.Direction is TradeDirection.Buy ? 1 : -1);
 
-		if (IsFiltered(MinVolume1, MaxVolume1, tick.Volume))
+		if (IsFiltered(_minVolume1, _maxVolume1, tick.Volume))
 			_delta1 += deltaVolume;
 
-		if (IsFiltered(MinVolume2, MaxVolume2, tick.Volume))
+		if (IsFiltered(_minVolume2, _maxVolume2, tick.Volume))
 			_delta2 += deltaVolume;
 
-		if (IsFiltered(MinVolume3, MaxVolume3, tick.Volume))
+		if (IsFiltered(_minVolume3, _maxVolume3, tick.Volume))
 			_delta3 += deltaVolume;
 
-		if (IsFiltered(MinVolume4, MaxVolume4, tick.Volume))
+		if (IsFiltered(_minVolume4, _maxVolume4, tick.Volume))
 			_delta4 += deltaVolume;
 
-		if (IsFiltered(MinVolume5, MaxVolume5, tick.Volume))
+		if (IsFiltered(_minVolume5, _maxVolume5, tick.Volume))
 			_delta5 += deltaVolume;
 
-		_filter1Series[^1] = _delta1;
-		_filter2Series[^1] = _delta2;
-		_filter3Series[^1] = _delta3;
-		_filter4Series[^1] = _delta4;
-		_filter5Series[^1] = _delta5;
+		_filter1Series[bar] = _delta1;
+		_filter2Series[bar] = _delta2;
+		_filter3Series[bar] = _delta3;
+		_filter4Series[bar] = _delta4;
+		_filter5Series[bar] = _delta5;
+
+		RaiseBarValueChanged(bar);
 	}
 
 	private bool IsFiltered(decimal minFilter, decimal maxFilter, decimal volume)

--- a/Technical/MultiMarketPower.cs
+++ b/Technical/MultiMarketPower.cs
@@ -77,7 +77,7 @@ public class MultiMarketPower : Indicator
 	private decimal _lastDelta4;
 	private decimal _lastDelta5;
 	private CumulativeTrade _lastTrade;
-	private object _locker = new();
+	private readonly object _locker = new();
 	private decimal _maxVolume1 = 5;
 	private decimal _maxVolume2 = 10;
 	private decimal _maxVolume3 = 20;
@@ -400,7 +400,7 @@ public class MultiMarketPower : Indicator
 	
 	protected override void OnCalculate(int bar, decimal value)
 	{
-		if (!_bigTradesIsReceived || bar != CurrentBar - 1)
+		if (!_bigTradesIsReceived || bar != CurrentBar - 1 || bar == 0)
 			return;
 
 		DataSeries.ForEach(ds =>
@@ -414,8 +414,12 @@ public class MultiMarketPower : Indicator
 	{
 		_bigTradesIsReceived = false;
 
-        _ticks.Clear();
-		_trades.Clear();
+		lock (_locker)
+		{
+			_ticks.Clear();
+			_trades.Clear();
+		}
+
 		var totalBars = CurrentBar - 1;
 		_sessionBegin = totalBars;
 		_lastBar = totalBars;
@@ -454,7 +458,10 @@ public class MultiMarketPower : Indicator
 
 		if (!_bigTradesIsReceived)
 		{
-			_ticks.Add(trade);
+			lock (_locker)
+			{
+				_ticks.Add(trade);
+			}
 			return;
 		}
 
@@ -473,7 +480,10 @@ public class MultiMarketPower : Indicator
 
 		if (!_bigTradesIsReceived)
 		{
-			_trades.Add(trade);
+			lock (_locker)
+			{
+				_trades.Add(trade);
+			}
 			return;
 		}
 
@@ -492,8 +502,11 @@ public class MultiMarketPower : Indicator
 
 		if (!_bigTradesIsReceived)
 		{
-			if (_trades.Count != 0)
-				_trades[^1] = trade;
+			lock (_locker)
+			{
+				if (_trades.Count != 0)
+					_trades[^1] = trade;
+			}
 			return;
 		}
 
@@ -598,43 +611,57 @@ public class MultiMarketPower : Indicator
 
 	private void CalculateHistory(List<CumulativeTrade> trades)
 	{
-		try
+		if (CurrentBar <= 0)
+			return;
+
+		List<MarketDataArg> ticksSnapshot;
+		List<CumulativeTrade> tradesSnapshot;
+
+		lock (_locker)
 		{
-			if(trades.Count is 0)
-				return;
-			
-			var searchIdx = 0;
+			ticksSnapshot = new List<MarketDataArg>(_ticks);
+			tradesSnapshot = new List<CumulativeTrade>(_trades);
+			_ticks.Clear();
+			_trades.Clear();
+		}
 
-            if (CumulativeTrades)
+		var searchIdx = 0;
+
+		if (CumulativeTrades)
+		{
+			trades = trades.OrderBy(t => t.Time).ToList();
+            
+			for (var i = _sessionBegin; i <= CurrentBar - 1; i++)
 			{
-				trades = trades.OrderBy(t => t.Time).ToList();
-                
-				for (var i = _sessionBegin; i <= CurrentBar - 1; i++)
-					CalculateBarTrades(trades, i, ref searchIdx);
-
-				foreach (var trade in _trades)
-					CalculateTrade(trade, false, false);
-			}
-			else
-			{
-				var ticks = trades
-					.SelectMany(x => x.Ticks)
-					.OrderBy(t=>t.Time)
-					.ToList();
-
-				for (var i = _sessionBegin; i <= CurrentBar - 1; i++)
-					CalculateBarTicks(ticks, i, ref searchIdx);
-
-				foreach (var tick in _ticks)
-					CalculateTick(tick);
+				if (GetCandle(i) is null)
+					return;
+					
+				CalculateBarTrades(trades, i, ref searchIdx);
 			}
 
-			RedrawChart();
+			foreach (var trade in tradesSnapshot)
+				CalculateTrade(trade, false, false);
 		}
-		catch (NullReferenceException)
+		else
 		{
-			//on reset exception ignored
+			var ticks = trades
+				.SelectMany(x => x.Ticks)
+				.OrderBy(t => t.Time)
+				.ToList();
+
+			for (var i = _sessionBegin; i <= CurrentBar - 1; i++)
+			{
+				if (GetCandle(i) is null)
+					return;
+					
+				CalculateBarTicks(ticks, i, ref searchIdx);
+			}
+
+			foreach (var tick in ticksSnapshot)
+				CalculateTick(tick);
 		}
+
+		RedrawChart();
 	}
 
 	private void CalculateBarTicks(List<MarketDataArg> trades, int i, ref int searchIdx)

--- a/Technical/MultiMarketPower.cs
+++ b/Technical/MultiMarketPower.cs
@@ -71,11 +71,6 @@ public class MultiMarketPower : Indicator
 	private decimal _delta4;
 	private decimal _delta5;
 	private int _lastBar = -1;
-	private decimal _lastDelta1;
-	private decimal _lastDelta2;
-	private decimal _lastDelta3;
-	private decimal _lastDelta4;
-	private decimal _lastDelta5;
 	private CumulativeTrade _lastTrade;
 	private readonly object _locker = new();
 	private decimal _maxVolume1 = 5;
@@ -159,17 +154,17 @@ public class MultiMarketPower : Indicator
 	{
 		get => _filter1Series.Color;
 		set => _filter1Series.Color = value;
-    }
+	}
 
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.LineWidth), GroupName = nameof(Strings.Filter1), Description = nameof(Strings.LineWidthDescription), Order = 160)]
-    [Range(1, 100)]
-    public int LineWidth1
-    {
-        get => _filter1Series.Width;
-        set => _filter1Series.Width = value;
-    }
+	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.LineWidth), GroupName = nameof(Strings.Filter1), Description = nameof(Strings.LineWidthDescription), Order = 160)]
+	[Range(1, 100)]
+	public int LineWidth1
+	{
+		get => _filter1Series.Width;
+		set => _filter1Series.Width = value;
+	}
 
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Enabled), GroupName = nameof(Strings.Filter2), Description = nameof(Strings.UseFilterDescription), Order = 200)]
+	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Enabled), GroupName = nameof(Strings.Filter2), Description = nameof(Strings.UseFilterDescription), Order = 200)]
 	public bool UseFilter2
 	{
 		get => _useFilter2;
@@ -211,17 +206,17 @@ public class MultiMarketPower : Indicator
 	{
 		get => _filter2Series.Color;
 		set => _filter2Series.Color = value;
-    }
+	}
 
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.LineWidth), GroupName = nameof(Strings.Filter2), Description = nameof(Strings.LineWidthDescription), Order = 260)]
-    [Range(1, 100)]
-    public int LineWidth2
-    {
-        get => _filter2Series.Width;
-        set => _filter2Series.Width = value;
-    }
+	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.LineWidth), GroupName = nameof(Strings.Filter2), Description = nameof(Strings.LineWidthDescription), Order = 260)]
+	[Range(1, 100)]
+	public int LineWidth2
+	{
+		get => _filter2Series.Width;
+		set => _filter2Series.Width = value;
+	}
 
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Enabled), GroupName = nameof(Strings.Filter3), Description = nameof(Strings.UseFilterDescription), Order = 300)]
+	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Enabled), GroupName = nameof(Strings.Filter3), Description = nameof(Strings.UseFilterDescription), Order = 300)]
 	public bool UseFilter3
 	{
 		get => _useFilter3;
@@ -263,17 +258,17 @@ public class MultiMarketPower : Indicator
 	{
 		get => _filter3Series.Color;
 		set => _filter3Series.Color = value;
-    }
+	}
 
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.LineWidth), GroupName = nameof(Strings.Filter3), Description = nameof(Strings.LineWidthDescription), Order = 360)]
-    [Range(1, 100)]
-    public int LineWidth3
-    {
-        get => _filter3Series.Width;
-        set => _filter3Series.Width = value;
-    }
+	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.LineWidth), GroupName = nameof(Strings.Filter3), Description = nameof(Strings.LineWidthDescription), Order = 360)]
+	[Range(1, 100)]
+	public int LineWidth3
+	{
+		get => _filter3Series.Width;
+		set => _filter3Series.Width = value;
+	}
 
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Enabled), GroupName = nameof(Strings.Filter4), Description = nameof(Strings.UseFilterDescription), Order = 400)]
+	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Enabled), GroupName = nameof(Strings.Filter4), Description = nameof(Strings.UseFilterDescription), Order = 400)]
 	public bool UseFilter4
 	{
 		get => _useFilter4;
@@ -315,17 +310,17 @@ public class MultiMarketPower : Indicator
 	{
 		get => _filter4Series.Color;
 		set => _filter4Series.Color = value;
-    }
+	}
 
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.LineWidth), GroupName = nameof(Strings.Filter4), Description = nameof(Strings.LineWidthDescription), Order = 460)]
-    [Range(1, 100)]
-    public int LineWidth4
-    {
-        get => _filter4Series.Width;
-        set => _filter4Series.Width = value;
-    }
+	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.LineWidth), GroupName = nameof(Strings.Filter4), Description = nameof(Strings.LineWidthDescription), Order = 460)]
+	[Range(1, 100)]
+	public int LineWidth4
+	{
+		get => _filter4Series.Width;
+		set => _filter4Series.Width = value;
+	}
 
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Enabled), GroupName = nameof(Strings.Filter5), Description = nameof(Strings.UseFilterDescription), Order = 500)]
+	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.Enabled), GroupName = nameof(Strings.Filter5), Description = nameof(Strings.UseFilterDescription), Order = 500)]
 	public bool UseFilter5
 	{
 		get => _useFilter5;
@@ -367,21 +362,21 @@ public class MultiMarketPower : Indicator
 	{
 		get => _filter5Series.Color;
 		set => _filter5Series.Color = value;
-    }
+	}
 
-    [Display(ResourceType = typeof(Strings), Name = nameof(Strings.LineWidth), GroupName = nameof(Strings.Filter5), Description = nameof(Strings.LineWidthDescription), Order = 560)]
-    [Range(1, 100)]
-    public int LineWidth5
-    {
-        get => _filter5Series.Width;
-        set => _filter5Series.Width = value;
-    }
+	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.LineWidth), GroupName = nameof(Strings.Filter5), Description = nameof(Strings.LineWidthDescription), Order = 560)]
+	[Range(1, 100)]
+	public int LineWidth5
+	{
+		get => _filter5Series.Width;
+		set => _filter5Series.Width = value;
+	}
 
-    #endregion
+	#endregion
 
-    #region ctor
+	#region ctor
 
-    public MultiMarketPower()
+	public MultiMarketPower()
 		: base(true)
 	{
 		Panel = IndicatorDataProvider.NewPanel;
@@ -436,7 +431,7 @@ public class MultiMarketPower : Indicator
 		var request = new CumulativeTradesRequest(GetCandle(_sessionBegin).Time);
 		_requestId = request.RequestId;
 		RequestForCumulativeTrades(request);
-    }
+	}
 	
 	protected override void OnCumulativeTradesResponse(CumulativeTradesRequest request, IEnumerable<CumulativeTrade> cumulativeTrades)
 	{
@@ -560,34 +555,34 @@ public class MultiMarketPower : Indicator
 
 				if (_lastTrade.Volume >= _minVolume2 && (_lastTrade.Volume <= _maxVolume2 || _maxVolume2 == 0))
 				{
+					_delta2 -= lastVolume;
 					if (prevBarReset)
 						_filter2Series[CurrentBar - 2] -= lastVolume;
 
-					_delta2 -= lastVolume;
 				}
 
 				if (_lastTrade.Volume >= _minVolume3 && (_lastTrade.Volume <= _maxVolume3 || _maxVolume3 == 0))
 				{
+					_delta3 -= lastVolume;
 					if (prevBarReset)
 						_filter3Series[CurrentBar - 2] -= lastVolume;
 
-					_delta3 -= lastVolume;
 				}
 
 				if (_lastTrade.Volume >= _minVolume4 && (_lastTrade.Volume <= _maxVolume4 || _maxVolume4 == 0))
 				{
+					_delta4 -= lastVolume;
 					if (prevBarReset)
 						_filter4Series[CurrentBar - 2] -= lastVolume;
 
-					_delta4 -= lastVolume;
 				}
 
 				if (_lastTrade.Volume >= _minVolume5 && (_lastTrade.Volume <= _maxVolume5 || _maxVolume5 == 0))
 				{
+					_delta5 -= lastVolume;
 					if (prevBarReset)
 						_filter5Series[CurrentBar - 2] -= lastVolume;
 
-					_delta5 -= lastVolume;
 				}
 			}
 		}
@@ -641,7 +636,7 @@ public class MultiMarketPower : Indicator
 		if (CumulativeTrades)
 		{
 			trades = trades.OrderBy(t => t.Time).ToList();
-            
+			
 			for (var i = _sessionBegin; i <= CurrentBar - 1; i++)
 			{
 				if (GetCandle(i) is null)
@@ -685,7 +680,7 @@ public class MultiMarketPower : Indicator
 		{
 			var trade = trades[bar];
 			searchIdx = bar;
-            
+			
 			if (trade.Direction is TradeDirection.Between)
 				continue;
 
@@ -698,7 +693,7 @@ public class MultiMarketPower : Indicator
 			candleTrades.Add(trade);
 		}
 
-        foreach (var tick in candleTrades)
+		foreach (var tick in candleTrades)
 		{
 			var deltaVolume = tick.Volume * (tick.Direction is TradeDirection.Buy ? 1 : -1);
 
@@ -758,16 +753,8 @@ public class MultiMarketPower : Indicator
 		return volume >= minFilter && (volume <= maxFilter || maxFilter == 0);
 	}
 
-	private void CalculateBarTrades(List<CumulativeTrade> trades, int bar, ref int searchIdx, bool realTime = false, bool newBar = false)
+	private void CalculateBarTrades(List<CumulativeTrade> trades, int bar, ref int searchIdx)
 	{
-		if (CumulativeTrades && realTime && !newBar)
-		{
-			_delta1 -= _lastDelta1;
-			_delta2 -= _lastDelta2;
-			_delta3 -= _lastDelta3;
-			_delta4 -= _lastDelta4;
-			_delta5 -= _lastDelta5;
-		}
 
 		var candle = GetCandle(bar);
 
@@ -792,43 +779,33 @@ public class MultiMarketPower : Indicator
 			candleTrades.Add(trade);
 		}
 
-        _lastDelta1 = candleTrades
-			.Where(x => x.Volume >= _minVolume1 && (x.Volume <= _maxVolume1 || _maxVolume1 == 0))
+        _delta1 += candleTrades
+            .Where(x => x.Volume >= _minVolume1 && (x.Volume <= _maxVolume1 || _maxVolume1 == 0))
 			.Sum(x => x.Volume * (x.Direction == TradeDirection.Buy ? 1 : -1));
-
-		_delta1 += _lastDelta1;
 
 		_filter1Series[bar] = _delta1;
 
-		_lastDelta2 = candleTrades
+        _delta2 += candleTrades
 			.Where(x => x.Volume >= _minVolume2 && (x.Volume <= _maxVolume2 || _maxVolume2 == 0))
 			.Sum(x => x.Volume * (x.Direction == TradeDirection.Buy ? 1 : -1));
 
-		_delta2 += _lastDelta2;
-
 		_filter2Series[bar] = _delta2;
 
-		_lastDelta3 = candleTrades
+        _delta3 += candleTrades
 			.Where(x => x.Volume >= _minVolume3 && (x.Volume <= _maxVolume3 || _maxVolume3 == 0))
 			.Sum(x => x.Volume * (x.Direction == TradeDirection.Buy ? 1 : -1));
 
-		_delta3 += _lastDelta3;
-
 		_filter3Series[bar] = _delta3;
 
-		_lastDelta4 = candleTrades
+        _delta4 += candleTrades
 			.Where(x => x.Volume >= _minVolume4 && (x.Volume <= _maxVolume4 || _maxVolume4 == 0))
 			.Sum(x => x.Volume * (x.Direction == TradeDirection.Buy ? 1 : -1));
 
-		_delta4 += _lastDelta4;
-
 		_filter4Series[bar] = _delta4;
 
-		_lastDelta5 = candleTrades
+        _delta5 += candleTrades
 			.Where(x => x.Volume >= _minVolume5 && (x.Volume <= _maxVolume5 || _maxVolume5 == 0))
 			.Sum(x => x.Volume * (x.Direction == TradeDirection.Buy ? 1 : -1));
-
-		_delta5 += _lastDelta5;
 
 		_filter5Series[bar] = _delta5;
 

--- a/Technical/MultiMarketPower.cs
+++ b/Technical/MultiMarketPower.cs
@@ -518,6 +518,17 @@ public class MultiMarketPower : Indicator
 		CalculateTrade(trade, true, newBar);
 	}
 
+	protected override void OnDispose()
+	{
+		lock (_locker)
+		{
+			_ticks.Clear();
+			_trades.Clear();
+		}
+		
+		base.OnDispose();
+	}
+
 	#endregion
 
 	#region Private methods


### PR DESCRIPTION
### Summary
 
Hardens `MultiMarketPower` (CVD pro (multi) / Multi Market Powers) across its real-time cumulative-trades pipeline, adds the missing `OnDispose`, fixes incorrect indexing in the tick-processing path, and removes a small amount of dead code. Three long-standing reliability issues are resolved:

1. The shared buffers `_ticks` and `_trades` were mutated from the market-data callbacks (`OnNewTrade`, `OnCumulativeTrade`, `OnUpdateCumulativeTrade`) and enumerated from `CalculateHistory` without synchronization. Under sustained tick load this could raise `InvalidOperationException: Collection was modified; enumeration operation may not execute` during recalculation.
2. `CalculateHistory` wrapped its per-bar loop in a blanket `catch (NullReferenceException) { /* ignored */ }`, masking any real null-dereference and making this class of bug silently invisible.
3. `CalculateTick` used `_filterNSeries[^1]` (last-element syntax) to write series values and accessed volume thresholds through public property getters (`MinVolume1`, `MaxVolume1`, …) in the hot path instead of the backing fields. The `[^1]` indexing is semantically correct when the current bar is the last bar, but breaks silently if `CurrentBar` advances between the filter writes, and is inconsistent with every other write site in the class which uses an explicit bar index.

Several smaller correctness and cleanup items are also addressed.
 
### Commits
 
The PR is split into four thematic commits so each concern can be reviewed, reverted or bisected independently.
 
1. **`fix: enhance thread safety and stability in real-time recalculations`**
   - `_locker` is now `readonly`.
   - All access to `_ticks` / `_trades` from the real-time callbacks (`OnNewTrade`, `OnCumulativeTrade`, `OnUpdateCumulativeTrade`) is guarded by `_locker`.
   - `CalculateHistory` takes a snapshot of both buffers under lock, clears the originals, and then iterates the snapshots — eliminating the "collection modified during enumeration" race.
   - The `Clear()` in `OnFinishRecalculate` is now also inside `lock (_locker)` so the invariant holds across the whole pipeline.
   - The blanket `catch (NullReferenceException)` in `CalculateHistory` is replaced with an explicit `if (GetCandle(i) is null) return;` guard at each candle access, so real NREs surface normally.
   - The empty-response path in `CalculateHistory` no longer short-circuits early; ticks and trades buffered during the request are always drained, even when the service responds with an empty history.
   - `OnCalculate` is guarded with `bar == 0` to avoid reading `vds[-1]` on the degenerate single-bar chart case.
2. **`feat: add lifecycle management and resource cleanup`**
   - `OnDispose` is introduced to clear `_ticks` and `_trades` under `_locker`, ensuring no lingering references when the indicator is removed or the chart is reloaded.
3. **`style: standardize formatting and calculation sequences`**
   - Indentation normalized to tabs in the `LineWidth{1..5}` property blocks (they previously mixed spaces).
   - The five filter branches in `CalculateTrade` now apply their updates in a consistent order (delta first, then historical-series correction).
   - Removed the unused `realTime` parameter from `CalculateBarTrades`.
   - Removed the unused `newBar` parameter from `CalculateBarTrades` (declared with a default, never referenced in the body, never passed by any caller).
   - Removed the five instance fields `_lastDelta1`..`_lastDelta5`, which were written in `CalculateBarTrades` but never read elsewhere. Their computed value is inlined directly into the corresponding `_deltaN` accumulator.
4. **`fix: use explicit bar index and backing fields in CalculateTick`**
   * `CalculateTick` now computes `bar = CurrentBar - 1` once at entry and writes all five filter series at `[bar]` instead of `[^1]`, matching the convention used in `CalculateBarTicks`, `CalculateBarTrades`, and `CalculateTrade`.
   - An early return guards against `bar < 0` (degenerate zero-bar chart).
   * `TradeDirection.Between` ticks are now skipped, matching the historical tick-processing behaviour in `CalculateBarTicks` which already filters them out.
   - The five `IsFiltered(MinVolumeN, MaxVolumeN, …)` calls are replaced with `IsFiltered(_minVolumeN, _maxVolumeN, …)`, avoiding the property-getter overhead on every incoming tick. The property getters are trivial today, but accessing the backing field directly is both faster and consistent with `CalculateBarTicks`.
   - A `RaiseBarValueChanged(bar)` call is added at the end, which was missing — without it, the panel does not repaint after a tick update until the next cumulative-trade event or bar change.
   - New-bar detection (`bar != _lastBar`) is added so `_lastBar` stays current in the tick path, consistent with `OnCumulativeTrade` / `OnUpdateCumulativeTrade`.

### Behaviour
 
No functional or visual change to the indicator's formula (cumulative delta partitioned by five configurable trade-size buckets), its outputs, or its public properties. Values produced on a given replay before and after the patch match bit-for-bit, with two exceptions:

- The empty-response path in `CalculateHistory`, which previously discarded the real-time buffer and now drains it as intended.
- The tick path now skips `TradeDirection.Between` prints and forces a repaint via `RaiseBarValueChanged`, so in non-cumulative mode the panel updates on every tick instead of waiting for the next bar boundary. This is a correction, not a regression — the historical path already excluded Between prints and the cumulative path already raised the event.
 
### Compatibility
 
Compatible with all SDK flavors (stable → x_alpha). The indicator uses `CrossColor` and `DefaultColors.*.Convert()` from the classic color API; both are handled transparently on ATAS X via runtime auto-conversion of Windows-specific types. No WPF custom editors are introduced, so no ATAS X restriction applies.
 
### Test plan
 
- [ ] Load the indicator on a live ES/NQ chart with all five filters enabled; confirm each line renders and accumulates correctly across the session boundary.
- [ ] Stress-reload the chart repeatedly while trades are streaming; confirm no `InvalidOperationException` is logged.
- [ ] Toggle the `CumulativeTrades` switch on and off during live streaming; confirm recalculation completes without lost, duplicated, or mis-assigned trades.
- [ ] Force an empty `CumulativeTradesResponse` (e.g. a fresh instrument with no history); confirm that buffered real-time trades are still applied once the response arrives.
- [ ] Run a replay session and compare the five series against the pre-patch baseline on the same data; values must match exactly.
- [ ] Remove the indicator from the chart while trades are streaming; confirm no warnings or leaked references.
- [ ] Open the indicator properties panel and confirm all five filter groups (`Enabled`, `MinimumVolume`, `MaximumVolume`, `Color`, `LineWidth`) still display and apply correctly.
- [ ] Switch to non-cumulative tick mode (`CumulativeTrades = false`) on a live chart; confirm the five filter lines update smoothly tick-by-tick without visual stalls between bar boundaries.
- [ ] Verify that `TradeDirection.Between` prints (common on crypto venues) do not move any filter line in either cumulative or tick mode.
### Notes for reviewers
 
- The snapshot-under-lock pattern in `CalculateHistory` follows the canonical ATAS OrderFlow pattern: take a shallow copy of the shared buffer under the lock, clear the source, release the lock, then iterate the copy. The critical section is bounded to pointer operations.
- The previous `catch (NullReferenceException)` originated from a race during the reset path; the explicit `GetCandle(i) is null` guard is the precise check that was being relied upon implicitly. Any null observed here from now on is a genuine data race worth surfacing, not something to swallow.
- The cleanup commit is strictly a readability patch: no compiled IL in the hot path changes beyond the loss of five field writes that had no readers.