### PR TITLE
fix(delta): MinimizedMode correctness and alert handler cleanup

### DIFF
--- a/Technical/Delta.cs
+++ b/Technical/Delta.cs
@@ -632,12 +632,13 @@ public class Delta : Indicator
 
 					var candle = GetCandle(i);
 					var x = ChartInfo.PriceChartContainer.GetXByBar(i, false);
+					var region = ChartInfo.PriceChartContainer.Region;
 
 					if (_upSeries[i] != 0)
 					{
 						var yPrice = ChartInfo.PriceChartContainer.GetYByPrice(candle.Low, false) + 10;
 
-						if (yPrice <= ChartInfo.PriceChartContainer.Region.Bottom)
+						if (yPrice >= region.Top && yPrice <= region.Bottom)
 						{
 							var rect = new Rectangle(x - 5, yPrice - 4, 8, 8);
 							context.FillEllipse(_upColor, rect);
@@ -648,7 +649,7 @@ public class Delta : Indicator
 					{
 						var yPrice = ChartInfo.PriceChartContainer.GetYByPrice(candle.High, false) - 10;
 
-						if (yPrice <= ChartInfo.PriceChartContainer.Region.Bottom)
+						if (yPrice >= region.Top && yPrice <= region.Bottom)
 						{
 							var rect = new Rectangle(x - 5, yPrice - 4, 8, 8);
 							context.FillEllipse(_downColor, rect);

--- a/Technical/Delta.cs
+++ b/Technical/Delta.cs
@@ -204,11 +204,11 @@ public class Delta : Indicator
 		IgnoredByAlerts = true
 	};
 
-    #endregion
+	#endregion
 
-    #region Properties
+	#region Properties
 
-    #region Visualization
+	#region Visualization
 
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.VisualMode), GroupName = nameof(Strings.Visualization),
         Description = nameof(Strings.VisualModeDescription), Order = 10)]
@@ -220,48 +220,48 @@ public class Delta : Indicator
         {
             _mode = value;
 
-            if (_mode == DeltaVisualMode.Histogram)
-            {
-                _delta.VisualType = VisualMode.Histogram;
-                _diapasonHigh.VisualType = VisualMode.Hide;
-                _diapasonLow.VisualType = VisualMode.Hide;
-                _candles.Visible = _downCandles.Visible = false;
-                _divergenceCandles.Visible = _divergenceDownCandles.Visible = false;
-            }
-            else if (_mode == DeltaVisualMode.HighLow)
-            {
-                _delta.VisualType = VisualMode.Histogram;
-                _diapasonHigh.VisualType = VisualMode.Histogram;
-                _diapasonLow.VisualType = VisualMode.Histogram;
-                _candles.Visible = _downCandles.Visible = false;
-                _divergenceCandles.Visible = _divergenceDownCandles.Visible = false;
-            }
-            else if (_mode == DeltaVisualMode.Candles)
-            {
-                _delta.VisualType = VisualMode.Hide;
-                _diapasonHigh.VisualType = VisualMode.Hide;
-                _diapasonLow.VisualType = VisualMode.Hide;
-                _candles.Visible = _downCandles.Visible = true;
-                _candles.Mode = _downCandles.Mode = CandleVisualMode.Candles;
-                _divergenceCandles.Mode = _divergenceDownCandles.Mode = CandleVisualMode.Candles;
-            }
-            else
-            {
-                _delta.VisualType = VisualMode.Hide;
-                _diapasonHigh.VisualType = VisualMode.Hide;
-                _diapasonLow.VisualType = VisualMode.Hide;
-                _candles.Visible = _downCandles.Visible = true;
-                _candles.Mode = _downCandles.Mode = CandleVisualMode.Bars;
-                _divergenceCandles.Mode = _divergenceDownCandles.Mode = CandleVisualMode.Bars;
-            }
+			if (_mode == DeltaVisualMode.Histogram)
+			{
+				_delta.VisualType = VisualMode.Histogram;
+				_diapasonHigh.VisualType = VisualMode.Hide;
+				_diapasonLow.VisualType = VisualMode.Hide;
+				_candles.Visible = _downCandles.Visible = false;
+				_divergenceCandles.Visible = _divergenceDownCandles.Visible = false;
+			}
+			else if (_mode == DeltaVisualMode.HighLow)
+			{
+				_delta.VisualType = VisualMode.Histogram;
+				_diapasonHigh.VisualType = VisualMode.Histogram;
+				_diapasonLow.VisualType = VisualMode.Histogram;
+				_candles.Visible = _downCandles.Visible = false;
+				_divergenceCandles.Visible = _divergenceDownCandles.Visible = false;
+			}
+			else if (_mode == DeltaVisualMode.Candles)
+			{
+				_delta.VisualType = VisualMode.Hide;
+				_diapasonHigh.VisualType = VisualMode.Hide;
+				_diapasonLow.VisualType = VisualMode.Hide;
+				_candles.Visible = _downCandles.Visible = true;
+				_candles.Mode = _downCandles.Mode = CandleVisualMode.Candles;
+				_divergenceCandles.Mode = _divergenceDownCandles.Mode = CandleVisualMode.Candles;
+			}
+			else
+			{
+				_delta.VisualType = VisualMode.Hide;
+				_diapasonHigh.VisualType = VisualMode.Hide;
+				_diapasonLow.VisualType = VisualMode.Hide;
+				_candles.Visible = _downCandles.Visible = true;
+				_candles.Mode = _downCandles.Mode = CandleVisualMode.Bars;
+				_divergenceCandles.Mode = _divergenceDownCandles.Mode = CandleVisualMode.Bars;
+			}
 
-            RaisePropertyChanged("Mode");
-            RecalculateValues();
+			RaisePropertyChanged("Mode");
+			RecalculateValues();
 
 			ApplyDivergenceColorsToCurrentMode();
-            UpdateDivergenceCandlesVisibility();
-        }
-    }
+			UpdateDivergenceCandlesVisibility();
+		}
+	}
 
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.MinimizedMode), GroupName = nameof(Strings.Visualization),
         Description = nameof(Strings.HistogramMinimizedModeDescription), Order = 20)]
@@ -275,8 +275,8 @@ public class Delta : Indicator
             RaisePropertyChanged("MinimizedMode");
             RecalculateValues();
 			UpdateDivergenceCandlesVisibility();
-        }
-    }
+		}
+	}
 
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.ShowCurrentValue), GroupName = nameof(Strings.Visualization),
         Description = nameof(Strings.ShowCurrentValueDescription), Order = 30)]
@@ -334,9 +334,9 @@ public class Delta : Indicator
         }
     }
 
-    #endregion
+	#endregion
 
-    #region Filters
+	#region Filters
 
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.BarsDirection), GroupName = nameof(Strings.Filters),
         Description = nameof(Strings.BarDirectionDescription), Order = 100)]
@@ -379,11 +379,11 @@ public class Delta : Indicator
         }
     }
 
-    #endregion
+	#endregion
 
-    #region Divergence
+	#region Divergence
 
-    private Indicators.FilterColor _divergenceBarsFilter = new(true) { Enabled = false, Value = CrossColor.FromArgb(255, 255, 165, 0) };
+	private Indicators.FilterColor _divergenceBarsFilter = new(true) { Enabled = false, Value = CrossColor.FromArgb(255, 255, 165, 0) };
 
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.DivergenceDots), GroupName = nameof(Strings.Divergence),
         Description = nameof(Strings.BarDirVsDeltaDivergenceDescription), Order = 130)]
@@ -400,37 +400,37 @@ public class Delta : Indicator
             if (_divergenceBarsFilter == value)
                 return;
 
-            if (_divergenceBarsFilter != null)
-                _divergenceBarsFilter.PropertyChanged -= OnDivergenceFilterChanged;
+			if (_divergenceBarsFilter != null)
+				_divergenceBarsFilter.PropertyChanged -= OnDivergenceFilterChanged;
 
-            _divergenceBarsFilter = value;
+			_divergenceBarsFilter = value;
 
-            if (_divergenceBarsFilter != null)
-                _divergenceBarsFilter.PropertyChanged += OnDivergenceFilterChanged;
+			if (_divergenceBarsFilter != null)
+				_divergenceBarsFilter.PropertyChanged += OnDivergenceFilterChanged;
 
-            RaisePropertyChanged(nameof(DivergenceBarsFilter));
-        }
-    }
+			RaisePropertyChanged(nameof(DivergenceBarsFilter));
+		}
+	}
 
-    #endregion
+	#endregion
 
-    #region Absorption
+	#region Absorption
 
-    private readonly CandleDataSeries _absorptionCandles = new("AbsorptionDotsCandles", "Absorption Dots")
-    {
-        UpCandleColor = Color.Green.Convert(),
-        DownCandleColor = Color.Red.Convert(),
-        BorderColor = CrossColor.FromArgb(0, 0, 0, 0),
-        IsHidden = false,
-        UseMinimizedModeIfEnabled = true,
-        ShowCurrentValue = false
-    };
+	private readonly CandleDataSeries _absorptionCandles = new("AbsorptionDotsCandles", "Absorption Dots")
+	{
+		UpCandleColor = Color.Green.Convert(),
+		DownCandleColor = Color.Red.Convert(),
+		BorderColor = CrossColor.FromArgb(0, 0, 0, 0),
+		IsHidden = false,
+		UseMinimizedModeIfEnabled = true,
+		ShowCurrentValue = false
+	};
 
 #pragma warning disable CS0414
     private int _absorptionThreshold = 250;
 #pragma warning restore CS0414
 
-    private FilterInt _absorption = new(true) { Enabled = false, Value = 250 };
+	private FilterInt _absorption = new(true) { Enabled = false, Value = 250 };
 
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Absorption), GroupName = nameof(Strings.Absorption),
         Description = nameof(Strings.AbsorptionThresholdDesc), Order = 140)]
@@ -444,36 +444,36 @@ public class Delta : Indicator
             if (_absorption == value)
                 return;
 
-            if (_absorption != null)
-                _absorption.PropertyChanged -= OnAbsorptionFilterChanged;
+			if (_absorption != null)
+				_absorption.PropertyChanged -= OnAbsorptionFilterChanged;
 
-            _absorption = value;
+			_absorption = value;
 
-            if (_absorption != null)
-                _absorption.PropertyChanged += OnAbsorptionFilterChanged;
+			if (_absorption != null)
+				_absorption.PropertyChanged += OnAbsorptionFilterChanged;
 
-            RaisePropertyChanged(nameof(Absorption));
-        }
-    }
+			RaisePropertyChanged(nameof(Absorption));
+		}
+	}
 
-    // Backward compatibility properties (hidden from UI)
-    [Browsable(false)]
-    public bool ShowAbsorptionDots
-    {
-        get => Absorption.Enabled;
-        set => Absorption.Enabled = value;
-    }
+	// Backward compatibility properties (hidden from UI)
+	[Browsable(false)]
+	public bool ShowAbsorptionDots
+	{
+		get => Absorption.Enabled;
+		set => Absorption.Enabled = value;
+	}
 
-    [Browsable(false)]
-    public int AbsorptionDeltaThreshold
-    {
-        get => Absorption.Value;
-        set => Absorption.Value = value;
-    }
+	[Browsable(false)]
+	public int AbsorptionDeltaThreshold
+	{
+		get => Absorption.Value;
+		set => Absorption.Value = value;
+	}
 
-    #endregion
+	#endregion
 
-    #region Volume
+	#region Volume
 
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Show), GroupName = nameof(Strings.VolumeLabel), Order = 200,
         Description = nameof(Strings.VolumeLabelDescription))]
@@ -499,9 +499,9 @@ public class Delta : Indicator
     [Tab(TabName = nameof(Strings.Visualization), TabOrder = 1, ResourceType = typeof(Strings))]
     public FontSetting Font { get; set; } = new("Arial", 10);
 
-    #endregion
+	#endregion
 
-    #region Alerts
+	#region Alerts
 
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.UpAlert), GroupName = nameof(Strings.Alerts),
         Description = nameof(Strings.UpAlertFileFilterDescription), Order = 300)]
@@ -519,33 +519,33 @@ public class Delta : Indicator
     public Filter DownAlert { get; set; } = new()
     { Enabled = false, Value = 0 };
 
-    [Browsable(false)]
-    public bool UseAlerts
-    {
-        get => UpAlert.Enabled;
-        set => UpAlert.Enabled = value;
-    }
+	[Browsable(false)]
+	public bool UseAlerts
+	{
+		get => UpAlert.Enabled;
+		set => UpAlert.Enabled = value;
+	}
 
-    [Browsable(false)]
-    public decimal AlertFilter
-    {
-        get => UpAlert.Value;
-        set => UpAlert.Value = value;
-    }
+	[Browsable(false)]
+	public decimal AlertFilter
+	{
+		get => UpAlert.Value;
+		set => UpAlert.Value = value;
+	}
 
-    [Browsable(false)]
-    public bool UseNegativeAlerts
-    {
-        get => DownAlert.Enabled;
-        set => DownAlert.Enabled = value;
-    }
+	[Browsable(false)]
+	public bool UseNegativeAlerts
+	{
+		get => DownAlert.Enabled;
+		set => DownAlert.Enabled = value;
+	}
 
-    [Browsable(false)]
-    public decimal NegativeAlertFilter
-    {
-        get => DownAlert.Value;
-        set => DownAlert.Value = value;
-    }
+	[Browsable(false)]
+	public decimal NegativeAlertFilter
+	{
+		get => DownAlert.Value;
+		set => DownAlert.Value = value;
+	}
 
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.AlertFile), GroupName = nameof(Strings.Alerts),
         Description = nameof(Strings.AlertFileDescription), Order = 320)]
@@ -562,13 +562,13 @@ public class Delta : Indicator
     [Tab(TabName = nameof(Strings.Alerts), TabOrder = 2, ResourceType = typeof(Strings))]
     public CrossColor AlertBGColor { get; set; } = CrossColor.FromArgb(255, 75, 72, 72);
 
-    #endregion
+	#endregion
 
-    #endregion
+	#endregion
 
-    #region ctor
+	#region ctor
 
-    public Delta()
+	public Delta()
 		: base(true)
 	{
 		EnableCustomDrawing = true;
@@ -730,7 +730,7 @@ public class Delta : Indicator
 				minDelta = 0;
 			else
 				maxDelta = 0;
-        }
+		}
 
 		var isUnderFilter = absDelta < _filter;
 
@@ -804,14 +804,14 @@ public class Delta : Indicator
 			if (candle.Close > candle.Open && deltaValue < 0)
 			{
 				_downSeries[bar] = _downCandles[bar].High;
-                _upSeries[bar] = 0;
-                hasDivergence = true;
+				_upSeries[bar] = 0;
+				hasDivergence = true;
 			}
 			else if (candle.Close < candle.Open && deltaValue > 0)
 			{
 				_upSeries[bar] = _candles[bar].High;
-                _downSeries[bar] = 0;
-                hasDivergence = true;
+				_downSeries[bar] = 0;
+				hasDivergence = true;
 			}
 			else
 			{
@@ -841,7 +841,7 @@ public class Delta : Indicator
 		_divergenceBars[bar] = hasDivergence;
 
 		if (hasDivergence && DivergenceBarsFilter != null && DivergenceBarsFilter.Enabled &&
-		    (_mode == DeltaVisualMode.Candles || _mode == DeltaVisualMode.Bars))
+			(_mode == DeltaVisualMode.Candles || _mode == DeltaVisualMode.Bars))
 		{
 			if (MinimizedMode)
 			{
@@ -871,7 +871,7 @@ public class Delta : Indicator
 		_delta.Colors[bar] = deltaValue > 0 ? _upColor : _downColor;
 
 		if (DivergenceBarsFilter != null && DivergenceBarsFilter.Enabled &&
-		    (_mode == DeltaVisualMode.Histogram || _mode == DeltaVisualMode.HighLow))
+			(_mode == DeltaVisualMode.Histogram || _mode == DeltaVisualMode.HighLow))
 		{
 			if (hasDivergence)
 			{
@@ -902,7 +902,7 @@ public class Delta : Indicator
 			var negativeAlertValue = DownAlert.Value;
 
 			if ((deltaValue >= negativeAlertValue && _prevDeltaValue < negativeAlertValue) ||
-			    (deltaValue <= negativeAlertValue && _prevDeltaValue > negativeAlertValue))
+				(deltaValue <= negativeAlertValue && _prevDeltaValue > negativeAlertValue))
 			{
 				_lastBarNegativeAlert = bar;
 				AddAlert(AlertFile, InstrumentInfo.Instrument, $"Delta reached {negativeAlertValue} filter", AlertBGColor, AlertForeColor);
@@ -1000,9 +1000,9 @@ public class Delta : Indicator
 
 			if (MinimizedMode)
 			{
-				value = _candles[i].Close > _candles[i].Open
+				value = _candles[i].Close > 0
 					? _candles[i].Close
-					: -_candles[i].Open;
+					: -_downCandles[i].Close;
 			}
 			else
 				value = _candles[i].Close;

--- a/Technical/Delta.cs
+++ b/Technical/Delta.cs
@@ -426,10 +426,6 @@ public class Delta : Indicator
 		ShowCurrentValue = false
 	};
 
-#pragma warning disable CS0414
-    private int _absorptionThreshold = 250;
-#pragma warning restore CS0414
-
 	private FilterInt _absorption = new(true) { Enabled = false, Value = 250 };
 
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Absorption), GroupName = nameof(Strings.Absorption),
@@ -591,9 +587,9 @@ public class Delta : Indicator
 
 		DataSeries.Add(_absorptionCandles);
 
-        UpAlert.PropertyChanged += OnUpAlertChanged;
-        DownAlert.PropertyChanged += OnDownAlertChanged;
-        _divergenceBarsFilter.PropertyChanged += OnDivergenceFilterChanged;
+		UpAlert.PropertyChanged += OnUpAlertChanged;
+		DownAlert.PropertyChanged += OnDownAlertChanged;
+		_divergenceBarsFilter.PropertyChanged += OnDivergenceFilterChanged;
 		_absorption.PropertyChanged += OnAbsorptionFilterChanged;
 
 		UpdateDivergenceCandlesVisibility();
@@ -1013,10 +1009,7 @@ public class Delta : Indicator
 				maxLength = length;
 		}
 
-		var sampleStr = "";
-
-		for (var i = 0; i < maxLength; i++)
-			sampleStr += '0';
+		var sampleStr = new string('0', maxLength);
 
 		return context.MeasureString(sampleStr, Font.RenderObject).Width;
 	}
@@ -1099,8 +1092,8 @@ public class Delta : Indicator
 		}
 	}
 
-    private void OnUpAlertChanged(object sender, PropertyChangedEventArgs e) => _lastBarAlert = 0;
-    private void OnDownAlertChanged(object sender, PropertyChangedEventArgs e) => _lastBarNegativeAlert = 0;
+	private void OnUpAlertChanged(object sender, PropertyChangedEventArgs e) => _lastBarAlert = 0;
+	private void OnDownAlertChanged(object sender, PropertyChangedEventArgs e) => _lastBarNegativeAlert = 0;
 
-    #endregion
+	#endregion
 }

--- a/Technical/Delta.cs
+++ b/Technical/Delta.cs
@@ -804,12 +804,14 @@ public class Delta : Indicator
 			if (candle.Close > candle.Open && deltaValue < 0)
 			{
 				_downSeries[bar] = _downCandles[bar].High;
-				hasDivergence = true;
+                _upSeries[bar] = 0;
+                hasDivergence = true;
 			}
 			else if (candle.Close < candle.Open && deltaValue > 0)
 			{
 				_upSeries[bar] = _candles[bar].High;
-				hasDivergence = true;
+                _downSeries[bar] = 0;
+                hasDivergence = true;
 			}
 			else
 			{

--- a/Technical/Delta.cs
+++ b/Technical/Delta.cs
@@ -591,9 +591,9 @@ public class Delta : Indicator
 
 		DataSeries.Add(_absorptionCandles);
 
-		UpAlert.PropertyChanged += (sender, e) => _lastBarAlert = 0;
-		DownAlert.PropertyChanged += (sender, e) => _lastBarNegativeAlert = 0;
-		_divergenceBarsFilter.PropertyChanged += OnDivergenceFilterChanged;
+        UpAlert.PropertyChanged += OnUpAlertChanged;
+        DownAlert.PropertyChanged += OnDownAlertChanged;
+        _divergenceBarsFilter.PropertyChanged += OnDivergenceFilterChanged;
 		_absorption.PropertyChanged += OnAbsorptionFilterChanged;
 
 		UpdateDivergenceCandlesVisibility();
@@ -1099,5 +1099,8 @@ public class Delta : Indicator
 		}
 	}
 
-	#endregion
+    private void OnUpAlertChanged(object sender, PropertyChangedEventArgs e) => _lastBarAlert = 0;
+    private void OnDownAlertChanged(object sender, PropertyChangedEventArgs e) => _lastBarNegativeAlert = 0;
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

- **Fix**: clear the opposite divergence series in `OnCalculate` (MinimizedMode) so that flipping divergence direction on the same bar between **two divergent states** (without passing through the non-divergent `else` branch in between) no longer leaves a stale dot from the previous direction. Realistic only on the live last bar during real-time recalculation.
- **Fix**: clamp divergence dots in `OnRender` to **both** the top and bottom of the price panel. The previous guard only checked `Region.Bottom`, so under strong vertical zoom the dot could render above `Region.Top`.
- **Fix**: align `GetMinWidth` with `OnRender` for negative-delta bars in MinimizedMode. The old expression read `_candles[i]` for the negative branch, but `_candles[bar]` is reset to `new Candle()` in that branch of `OnCalculate`, so width was measured as `0` and the volume-label width gate (`minWidth > barWidth`) failed to suppress labels that did not fit.
- **Refactor**: replace the anonymous `PropertyChanged` lambdas wired to `UpAlert` / `DownAlert` with named handlers (`OnUpAlertChanged` / `OnDownAlertChanged`), matching the `+= / -=` symmetry already used for `DivergenceBarsFilter` and `Absorption`. No behavioural change.
- **Style / cleanup**: remove unused `_absorptionThreshold` field (and its `#pragma warning disable CS0414`), replace a concat loop with `new string('0', maxLength)` in `GetMinWidth`, and normalize tabs / spaces.

No behavioural changes outside the three bug fixes.

## Changes

| Commit | Area | Visibility |
|---|---|---|
| `fix(delta): clear opposite divergence series in MinimizedMode` | `OnCalculate` (MinimizedMode branch) | User-visible — no more ghost dot when divergence direction flips on the live bar |
| `fix(delta): clamp divergence dots to price panel top and bottom` | `OnRender` | User-visible — dots no longer draw above the panel under vertical zoom |
| `fix(delta): align GetMinWidth with OnRender for negative delta in MinimizedMode` | `GetMinWidth` | User-visible — volume-label width gate now fires correctly for negative-delta bars |
| `refactor(delta): replace anonymous PropertyChanged lambdas with named handlers` | ctor / event handlers | No behavioural change |
| `style(delta): use string constructor and normalize indentation` | `GetMinWidth` + whole-file whitespace | No functional change |

## Test plan

Smoke-tested on a liquid instrument with active order flow on the flavors the indicator targets.

### Bug-fix verification

- [x] **Ghost divergence dot — `Mode = Candles`, `MinimizedMode = on`, `ShowDivergence = on`, `DivergenceBarsFilter.Enabled = on`.** On the live last bar, induce ticks that flip divergence direction between two divergent states without going through a non-divergent state (e.g. bullish-candle/bearish-delta → bearish-candle/bullish-delta). After the flip, **only one** divergence dot is visible on that bar; the previous-direction dot disappears.
- [x] **Same flip in `Mode = Bars`, `MinimizedMode = on`** — identical expectation.
- [x] **Volume-label width gate — negative-delta bar.** `ShowVolume = on`, clusters chart, `MinimizedMode = on`. On a chart zoomed so the bar is narrower than the rendered label width: a bar with **negative** delta no longer draws an oversized label that overflows the bar. With wide bars: label is drawn and fits inside the bar (no false suppression).
- [x] **Divergence dot clamping — top edge.** `ShowDivergence = on`. Apply strong vertical zoom so that an up-divergence bar's `candle.Low` projects to a `yPrice` above `Region.Top` (i.e. `GetYByPrice(candle.Low) + 10 < Region.Top`): the dot is **not** drawn outside the panel.
- [x] **Divergence dot clamping — bottom edge.** Same setup, this time forcing `yPrice` below `Region.Bottom`: dot is **not** drawn (regression check; this case already worked before).

### Regressions on adjacent surfaces

- [x] **Volume label, `MinimizedMode = off`** — `ShowVolume = on`, clusters: width gate behaves as before (no regression from the `GetMinWidth` change; the non-MinimizedMode branch was untouched).
- [x] **Alerts after refactor.** `UpAlert.Enabled = on, Value = X` and `DownAlert.Enabled = on, Value = -Y`: each alert fires once per bar on threshold crossing. Change `UpAlert.Value` / `DownAlert.Value` at runtime → `_lastBarAlert` / `_lastBarNegativeAlert` reset and the alert can re-trigger after the new threshold is crossed (this is the behaviour the lambdas guaranteed; the named handlers must keep it).
- [x] **`DivergenceBarsFilter.Enabled` toggled at runtime** — colors and divergence-candles visibility update as before (untouched in this PR).
- [x] **`Absorption.Enabled` toggled at runtime** — absorption dots appear / disappear as before (untouched in this PR).

### Mode coverage (regression only)

- [x] `Mode = Histogram`, `MinimizedMode = on/off` — divergence coloring on the histogram via `_delta.Colors[bar]` works as before.
- [x] `Mode = HighLow`, `MinimizedMode = on/off` — delta histogram (`_delta`) plus the `_diapasonHigh` / `_diapasonLow` whiskers (max / min delta of the bar) render and colorize as before. With `MinimizedMode = on` the two whiskers collapse onto the positive side because both go through `Math.Abs`.
- [x] `Mode = Candles` and `Mode = Bars`, `MinimizedMode = off` — divergence renders via `_divergenceCandles` / `_divergenceDownCandles` (this branch of `OnCalculate` was not touched).

## Notes

- Files touched: `Technical/Delta.cs` only.
- No public API changes; hidden backward-compat properties (`ShowAbsorptionDots`, `AbsorptionDeltaThreshold`, `UseAlerts`, `AlertFilter`, `UseNegativeAlerts`, `NegativeAlertFilter`) are untouched.
- The `style(delta)` commit produces a noisy whole-file diff because of tabs / spaces normalization in regions that previously mixed both. Reviewing it on its own commit, or with `?w=1` / "Ignore whitespace", makes the actual functional change in `GetMinWidth` (`new string('0', maxLength)`) trivial to verify.

## Out of scope - filter toggle immediate apply

Smoke-testing surfaced that toggling `DivergenceBarsFilter.Enabled` / `Absorption.Enabled` (or changing their values) in the indicator settings does not visually apply until either a new bar opens or the user zooms / scrolls the chart. Ticks on the live bar are not enough on their own. The historical bars do update correctly once any of those events happen,
but plain UI interaction with the filter alone is not.

This is **pre-existing behaviour, not introduced by this PR**, and was already present in the original `OnAbsorptionFilterChanged` / `OnDivergenceFilterChanged` handlers prior to any change here.

A focused investigation on a debug branch ruled out the obvious causes:

- The `PropertyChanged` handler does run and `RedrawChart()` returns   cleanly. `OnRender` is invoked immediately afterwards (verified via per-call logging).
- Adding `RecalculateValues()` from the handler triggers a full `OnCalculate(0..CurrentBar)` pass (verified via per-bar logging), which itself repopulates `_divergenceCandles[bar]` / `_absorptionCandles[bar]` inline. The orange divergence candles still do not appear.
- Manually re-populating the candle series for every historical bar via helpers called from the handler — without going through `RecalculateValues()` - also has no visible effect.
- Subscribing to the public `BaseDataSeries<T>.Changed` event from the indicator constructor shows that it does **not** fire on indexer mutations in this scenario, neither from outside `OnCalculate` nor during a `RecalculateValues`-driven pass. The per-bar invalidation channel documented in the SDK is therefore unreachable from the indicator side.
- `CandleDataSeries` is `sealed`, so exposing the protected `RaiseChanged(int bar)` of `BaseDataSeries<T>` via a subclass is not an option either.
- Evidence that the data path itself is healthy: a custom `OnRender` overlay drawing a marker for each bar where the candle series is non-empty shows the marker immediately on toggle. The data is being written; ATAS's `CandleDataSeries` painter is what does not pick up the change.
- For comparison, mutating series-level properties from an indicator property setter - such as `_candles.UpCandleColor = value` inside the `UpColor` setter - does cause an immediate visual update on
  the existing candles. The repaint mechanism that works for property-driven changes on a series invoked from an indicator property setter does not appear to extend to indexer-driven changes applied from a sub-object's `PropertyChanged` handler.
- Stronger evidence of the same split: if the user toggles `DivergenceBarsFilter.Enabled` first (which populates
  `_divergenceCandles[bar]` correctly but does not repaint) and then toggles `ShowDivergence` (an unrelated `public bool ShowDivergence { get; set; }` auto-property on the indicator that only governs custom dot drawing in `OnRender`), the orange divergence candles appear immediately. `ShowDivergence` does not touch
  `_divergenceCandles` at all — its toggle simply goes through the indicator-property-setter pipeline, which forces a repaint that reads the already-populated indexer data. This isolates the problem to the repaint pathway, not to data freshness or render correctness.

This appears to be a limitation of the public SDK surface rather than something this indicator can fix from the outside. The clean fix belongs at the SDK level - for example, exposing a public per-bar invalidation hook on `BaseDataSeries<T>`, or having the indexer setter fire the existing `Changed` event so the public channel
becomes usable from indicator code. Flagged here for upstream attention, not folded into this PR.