### PR TITLE
feat (Volume): add configurable horizontal threshold lines

### DIFF
--- a/Technical/Volume.cs
+++ b/Technical/Volume.cs
@@ -96,6 +96,30 @@ public class Volume : Indicator
 	    ResetAlertsOnNewBar = true
     };
 
+    private readonly ValueDataSeries _thrMinor = new("Volume_ThresholdMinor", "Threshold Minor")
+    {
+	    VisualType = VisualMode.Hide,
+	    ShowCurrentValue = false,
+	    IgnoredByAlerts = true,
+	    Width = 1,
+	    LineDashStyle = LineDashStyle.Dot,
+	    Color = Color.DimGray.Convert()
+    };
+
+    private readonly ValueDataSeries _thrMajor = new("Volume_ThresholdMajor", "Threshold Major")
+    {
+	    VisualType = VisualMode.Hide,
+	    ShowCurrentValue = false,
+	    IgnoredByAlerts = true,
+	    Width = 1,
+	    LineDashStyle = LineDashStyle.Solid,
+	    Color = Color.DarkGray.Convert()
+    };
+
+    private bool _showThresholdLines;
+    private decimal _fixedMinorLevel = 1000m;
+    private decimal _fixedMajorLevel = 2000m;
+
     private bool _useFilter;
 
 	protected RenderStringFormat Format = new() { Alignment = StringAlignment.Center, LineAlignment = StringAlignment.Center };
@@ -204,6 +228,67 @@ public class Volume : Indicator
     {
         get => MaxVolSeries.Color;
         set => MaxVolSeries.Color = value;
+    }
+
+    #endregion
+
+    #region Threshold
+
+    [Display(Name = "Show threshold lines", GroupName = "Thresholds", Description = "Show horizontal threshold lines on the Volume panel.")]
+    [Tab(TabName = nameof(Strings.Visualization), TabOrder = 1, ResourceType = typeof(Strings))]
+    public bool ShowThresholdLines
+    {
+        get => _showThresholdLines;
+        set
+        {
+            if (_showThresholdLines == value)
+                return;
+
+            _showThresholdLines = value;
+
+            var visual = value ? VisualMode.Line : VisualMode.Hide;
+            _thrMinor.VisualType = visual;
+            _thrMajor.VisualType = visual;
+
+            RaisePropertyChanged(nameof(ShowThresholdLines));
+            RecalculateValues();
+        }
+    }
+
+    [Display(Name = "Minor level", GroupName = "Fixed threshold", Description = "Value of the minor threshold line.")]
+    [Tab(TabName = nameof(Strings.Visualization), TabOrder = 1, ResourceType = typeof(Strings))]
+    [PostValueMode(PostValueModes.Delayed, DelayMilliseconds = 500)]
+    [Range(0, double.MaxValue)]
+    public decimal FixedMinorLevel
+    {
+        get => _fixedMinorLevel;
+        set
+        {
+            if (_fixedMinorLevel == value)
+                return;
+
+            _fixedMinorLevel = value;
+            RaisePropertyChanged(nameof(FixedMinorLevel));
+            RecalculateValues();
+        }
+    }
+
+    [Display(Name = "Major level", GroupName = "Fixed threshold", Description = "Value of the major threshold line.")]
+    [Tab(TabName = nameof(Strings.Visualization), TabOrder = 1, ResourceType = typeof(Strings))]
+    [PostValueMode(PostValueModes.Delayed, DelayMilliseconds = 500)]
+    [Range(0, double.MaxValue)]
+    public decimal FixedMajorLevel
+    {
+        get => _fixedMajorLevel;
+        set
+        {
+            if (_fixedMajorLevel == value)
+                return;
+
+            _fixedMajorLevel = value;
+            RaisePropertyChanged(nameof(FixedMajorLevel));
+            RecalculateValues();
+        }
     }
 
     #endregion
@@ -335,6 +420,9 @@ public class Volume : Indicator
 		_positive.PropertyChanged += PositiveChanged;
 		_negative.PropertyChanged += NegativeChanged;
 		_neutral.PropertyChanged += NeutralChanged;
+
+		DataSeries.Add(_thrMinor);
+		DataSeries.Add(_thrMajor);
     }
 
     #endregion
@@ -419,6 +507,12 @@ public class Volume : Indicator
 			_ => candle.Volume
 		};
 		_renderSeries[bar] = val;
+
+		if (_showThresholdLines)
+		{
+			_thrMinor[bar] = _fixedMinorLevel;
+			_thrMajor[bar] = _fixedMajorLevel;
+		}
 
 		if (bar == CurrentBar - 1)
 		{


### PR DESCRIPTION
## Summary

Adds two configurable horizontal reference lines (a minor and a major level) to the Volume indicator panel, gated by a new "Show threshold lines" toggle. Useful for volume-based confirmation rules where the trader compares each bar against fixed thresholds.

This mirrors the existing `MaximumVolume` overlay convention (which plots a dynamic line on the same panel), but with user-defined static levels instead of a rolling maximum.

<img width="1844" height="236" alt="image" src="https://github.com/user-attachments/assets/5e95f06e-742c-4b7b-9d26-ae7292074dba" />


## Changes

- New `ShowThresholdLines` toggle on the **Visualization** tab - gates rendering of both lines.
- New `FixedMinorLevel` (default `1000`) and `FixedMajorLevel` (default `2000`) `decimal` properties under a *Fixed threshold* group.
- Two new `ValueDataSeries` (`_thrMinor`, `_thrMajor`) added to `DataSeries` with `IsHidden = false`, so color / width / dash style are user-customizable from the standard DataSeries panel. Defaults: dim gray dotted (minor) and dark gray solid (major).
- Threshold values are written from `OnCalculate` only when the toggle is on. Turning the toggle off calls `SetPointOfEndLine(CurrentBar - 1)` on both series and triggers a `RecalculateValues()`, so the lines cut cleanly and stop accumulating.
- No changes to histogram calculation, alerts, color logic, or any existing public surface.

## Localization - note for reviewers

I don't have access to `Strings.resx` from outside the build pipeline, so the new UI strings are **hardcoded inside the file**, isolated in a dedicated `#region UI strings` block at the top of the class. Each constant is named so it maps 1:1 to a target resource key, and the region carries an in-code note to that effect.

Here are the 7 entries:

| Suggested key | English value |
|---|---|
| `Thresholds` | Thresholds |
| `FixedThreshold` | Fixed threshold |
| `MinorLevel` | Minor level |
| `MinorLevelDescription` | Value of the minor threshold line. |
| `MajorLevel` | Major level |
| `MajorLevelDescription` | Value of the major threshold line. |
| `ShowThresholdLinesDescription` | Show horizontal threshold lines on the Volume panel. |

The toggle label itself reuses the existing `Strings.Show` key, matching the pattern used by `ShowMaxVolume` and `ShowVolume`. Series IDs are internal, not displayed, and don't need resource entries.

## Compatibility

The file already uses `[Tab]` attributes on its existing properties (`Input`, `UseFilter`, `FilterColor`, `ShowMaxVolume`, etc.), so the indicator was already restricted to flavors that support the tab system. This PR adds three more `[Tab]`-decorated properties under that same constraint - no new compatibility restrictions are introduced.

No public API changes. Existing user templates load unchanged: the toggle defaults to off and the legacy series initialization (`_positive`, `_negative`, `_neutral`) is untouched.

## Test notes

- [x] Toggle on / off cycles cleanly: lines appear, follow level changes, disappear and stop writing when off.
- [x] Changing `FixedMinorLevel` / `FixedMajorLevel` triggers a redraw at the new level.
- [x] Color, width, and dash style can be customized from the DataSeries panel; the defaults match the dim/dark gray convention of similar reference lines.
- [x] Switching `Input` (Volume / Ticks / Ask / Bid) keeps the thresholds at the user-defined absolute values.
