### PR TITLE
Fix (InitialBalance): lifecycle, validation and code-health cleanups

### DIFF
--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -735,11 +735,25 @@ public class InitialBalance : Indicator
 		return GetCandle(bar - 1).Time.AddHours(InstrumentInfo.TimeZone);
     }
 
-    #endregion
+	protected override void OnDispose()
+	{
+		_ibh.PropertyChanged -= DataSeriesPropertyChanged;
+		_ibl.PropertyChanged -= DataSeriesPropertyChanged;
+		_ibm.PropertyChanged -= DataSeriesPropertyChanged;
+		_ibhx1.PropertyChanged -= DataSeriesPropertyChanged;
+		_ibhx2.PropertyChanged -= DataSeriesPropertyChanged;
+		_ibhx3.PropertyChanged -= DataSeriesPropertyChanged;
+		_iblx1.PropertyChanged -= DataSeriesPropertyChanged;
+		_iblx2.PropertyChanged -= DataSeriesPropertyChanged;
+		_iblx3.PropertyChanged -= DataSeriesPropertyChanged;
+		_mid.PropertyChanged -= DataSeriesPropertyChanged;
+	}
 
-    #region Private methods
+	#endregion
 
-    private void DataSeriesPropertyChanged(object sender, PropertyChangedEventArgs e)
+	#region Private methods
+
+	private void DataSeriesPropertyChanged(object sender, PropertyChangedEventArgs e)
 	{
 		if (!_initialized)
 			return;

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -13,8 +13,6 @@ using OFT.Attributes;
 using OFT.Localization;
 using OFT.Rendering.Settings;
 
-using Pen = CrossPen;
-
 [DisplayName("Initial Balance")]
 [Category(IndicatorCategories.VolumeOrderFlow)]
 [Display(ResourceType = typeof(Strings), Description = nameof(Strings.InitialBalanceIndDescription))]

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -616,8 +616,11 @@ public class InitialBalance : Indicator
 			_calculate = true;
 			_highLowIsSet = false;
 			_lastStartBar = bar;
-			_endTime = candleFullDateTime.AddMinutes(_period);
             _isStarted = true;
+
+            if (PeriodMode is PeriodType.Minutes)
+                _endTime = candleFullDateTime.AddMinutes(_period);
+
 
             foreach (var dataSeries in DataSeries)
                 if (dataSeries is ValueDataSeries series)

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -487,7 +487,8 @@ public class InitialBalance : Indicator
 		_iblx1.PropertyChanged += DataSeriesPropertyChanged;
 		_iblx2.PropertyChanged += DataSeriesPropertyChanged;
 		_iblx3.PropertyChanged += DataSeriesPropertyChanged;
-	}
+        _mid.PropertyChanged += DataSeriesPropertyChanged;
+    }
 
 	#endregion
 

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -297,7 +297,7 @@ public class InitialBalance : Indicator
 	}
 
 	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.EndTime),
-		GroupName = nameof(Strings.SessionTime), Description = nameof(Strings.EndTimeDescription), Order = 20)]
+		GroupName = nameof(Strings.SessionTime), Description = nameof(Strings.EndTimeDescription), Order = 25)]
 	public TimeSpan EndDate
 	{
 		get => _endDate;

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -337,7 +337,8 @@ public class InitialBalance : Indicator
     [Parameter]
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Multiplier1),
 		GroupName = nameof(Strings.Multiplier), Description = nameof(Strings.MultiplierDescription), Order = 100)]
-	public decimal X1
+    [Range(0.1, 100)]
+    public decimal X1
 	{
 		get => _x1;
 		set
@@ -350,7 +351,8 @@ public class InitialBalance : Indicator
     [Parameter]
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Multiplier2),
 		GroupName = nameof(Strings.Multiplier), Description = nameof(Strings.MultiplierDescription),Order = 110)]
-	public decimal X2
+    [Range(0.1, 100)]
+    public decimal X2
 	{
 		get => _x2;
 		set
@@ -363,7 +365,8 @@ public class InitialBalance : Indicator
     [Parameter]
     [Display(ResourceType = typeof(Strings), Name = nameof(Strings.Multiplier3),
 		GroupName = nameof(Strings.Multiplier), Description = nameof(Strings.MultiplierDescription), Order = 120)]
-	public decimal X3
+    [Range(0.1, 100)]
+    public decimal X3
 	{
 		get => _x3;
 		set

--- a/Technical/InitialBalance.cs
+++ b/Technical/InitialBalance.cs
@@ -118,49 +118,49 @@ public class InitialBalance : Indicator
         DescriptionKey = nameof(Strings.SessionAveragePriceDescription)
     };
 
-	private RangeDataSeries _ibhx32 = new("Ibhx32", "ibhx32")
+	private readonly RangeDataSeries _ibhx32 = new("Ibhx32", "ibhx32")
 	{
 		RangeColor = System.Drawing.Color.Transparent.Convert(),
 		DrawAbovePrice = false,
 		IsHidden = true
 	};
-	private RangeDataSeries _ibhx21 = new("Ibhx21", "ibhx21")
+	private readonly RangeDataSeries _ibhx21 = new("Ibhx21", "ibhx21")
 	{
 		RangeColor = System.Drawing.Color.Transparent.Convert(),
         DrawAbovePrice = false,
         IsHidden = true
 	};
-	private RangeDataSeries _ibhx1h = new("Ibhx1h", "ibhx1h")
+	private readonly RangeDataSeries _ibhx1h = new("Ibhx1h", "ibhx1h")
 	{
 		RangeColor = System.Drawing.Color.Transparent.Convert(),
         DrawAbovePrice = false,
         IsHidden = true
 	};
-	private RangeDataSeries _ibHm = new("IbHm", "ibHm")
+	private readonly RangeDataSeries _ibHm = new("IbHm", "ibHm")
 	{
 		RangeColor = System.Drawing.Color.Transparent.Convert(),
         DrawAbovePrice = false,
         IsHidden = true
 	};
-	private RangeDataSeries _ibMl = new("IbM1", "ibM1")
+	private readonly RangeDataSeries _ibMl = new("IbM1", "ibM1")
 	{
 		RangeColor = System.Drawing.Color.Transparent.Convert(),
         DrawAbovePrice = false,
         IsHidden = true
 	};
-	private RangeDataSeries _ibl1 = new("Ibl1", "ibl1")
+	private readonly RangeDataSeries _ibl1 = new("Ibl1", "ibl1")
 	{
 		RangeColor = System.Drawing.Color.Transparent.Convert(),
         DrawAbovePrice = false,
         IsHidden = true
 	};
-	private RangeDataSeries _iblx12 = new("Ibl12", "ibl12")
+	private readonly RangeDataSeries _iblx12 = new("Ibl12", "ibl12")
 	{
 		RangeColor = System.Drawing.Color.Transparent.Convert(),
         DrawAbovePrice = false,
         IsHidden = true
 	};
-	private RangeDataSeries _iblx23 = new("Ibl23", "ibl23")
+	private readonly RangeDataSeries _iblx23 = new("Ibl23", "ibl23")
 	{
 		RangeColor = System.Drawing.Color.Transparent.Convert(),
         DrawAbovePrice = false,


### PR DESCRIPTION
# InitialBalance: lifecycle, validation and code-health cleanups

This PR bundles a set of small, self-contained fixes and clean-ups for `InitialBalance.cs`. Each commit is independent and easy to cherry-pick or revert; happy to split into separate PRs if preferred.

## Changes

1. **Release `PropertyChanged` subscriptions in `OnDispose`** — the constructor wires nine `ValueDataSeries.PropertyChanged` handlers and never detaches them, so they accumulate as zombie subscriptions across reloads. Adds the missing `OnDispose` that mirrors every `+=` with a matching `-=`.

2. **Subscribe `_mid` to `PropertyChanged` so its labels react to color changes** — `_mid` is the only series with a dedicated branch in `GetLabelTagSuffixes` that was not subscribed in the constructor. As a result, changing the Mid color in the property grid did not refresh the `"Mid"` `AddText` labels. Adds the missing subscription for parity with the other nine series.

3. **Disambiguate `StartTime` / `EndTime` display order** — both properties were declared with `Order = 20` inside the `SessionTime` group, leaving their relative order in the property grid undefined. Bumps `EndTime` to `Order = 25`.

4. **Constrain `X1` / `X2` / `X3` multipliers to a positive range** — adds `[Range(0.1, 100)]` to the three multipliers. Negative values used to invert the extension levels (IBHX* below the IB high, IBLX* above the IB low).

5. **Remove the unused `using Pen = CrossPen;` alias** — the alias is never referenced; every site uses `CrossPen` directly.

6. **Mark `RangeDataSeries` fields as `readonly`** — the eight fields are initialized at declaration and never reassigned. Matches the convention already used by the ten `ValueDataSeries` in the same file.

7. **Skip the `_endTime` assignment when `PeriodMode` is `Bars`** — in `Bars` mode the session-end check is `bar - _lastStartBar >= Period` and `_endTime` is never read. Wraps the assignment in `if (PeriodMode is PeriodType.Minutes)` so the dependency between `_endTime` and `PeriodMode` is explicit.

## End-user impact

- **Memory**: lower across reloads (fix 1).
- **UI correctness**: Mid label color now updates with its series (fix 2); `SessionTime` properties have a deterministic order (fix 3); multipliers cannot produce crossed bands (fix 4).
- **Visual output**: unchanged on existing charts.

## Open questions for the maintainers

A few decisions I would rather defer to you than take unilaterally:

### 1. What is the intended state of the `_mid` series?

`_mid` is initialized with `CrossColor.FromArgb(0, 0, 255, 0)` — `A = 0`, fully transparent — so the line and its `"Mid"` `AddText` labels are invisible by default. At the same time, the series is still calculated every bar, exposed in the property grid (color editable), described via `SessionAveragePriceDescription` and labelled in the `OnCalculate` text block. Two equally plausible interpretations:

- **Bug.** The intended default was visible (e.g. `FromArgb(255, 0, 255, 0)`). Follow-up: pick a sensible default such as `DefaultColors.Green.Convert()`.
- **Soft-deprecation.** The series is being phased out but kept around so chart templates that reference `"MidId"` still load. Follow-up: replace the alpha=0 trick with the canonical hidden-series pattern (`VisualType = VisualMode.Hide`, `IsHidden = true`) and drop the now-dead `"Mid"` `AddText` call together with the `_mid` branch in `GetLabelTagSuffixes`.

Could you confirm which one is intended? I held this fix out of the present PR on purpose and am happy to send the matching patch as a small follow-up.

### 2. Renaming the unprefixed value fields

The internal value variables `ibhx1..3`, `iblx1..3`, `mid` (lines 199–206) are the only fields in the file without the `_` prefix that the rest of the private state uses. Renaming them to e.g. `_ibhx1Value..3`, `_iblx1Value..3`, `_midValue` would make the distinction between the value (`ibhx1`) and the corresponding `ValueDataSeries` (`_ibhx1`) explicit and remove an easy-to-confuse shadow.

The change would touch every call site inside `OnCalculate` and the labels block — a noisy diff for a cosmetic gain — so I left it out of this PR. Would you take it as a separate `chore: rename internal value fields in InitialBalance` PR, or would you rather leave the current naming?

### 3. Splitting drawing concerns out of `OnCalculate` in a follow-up PR

Today `OnCalculate` mixes pure calculation (DataSeries writes) with drawing-side state management (ten `AddText` calls per bar, `DrawingRectangle` creation and per-bar mutation in `Rectangles`). The usual SDK pattern keeps `OnCalculate` for state writes and `OnRender` for read-only drawing.

Would you be open, in a future PR, to exploring whether the label management and the IB rectangle update could move to `OnRender`? I would rather check the direction is acceptable before investing in the refactor.

---

Thanks for reviewing.