### PR TITLE
fix(ClusterStatistic): correct max value calculations in visible-proportion mode

### DIFF
--- a/Technical/ClusterStatistic.cs
+++ b/Technical/ClusterStatistic.cs
@@ -1709,7 +1709,7 @@ public class ClusterStatistic : Indicator
 			for (var i = FirstVisibleBarNumber; i <= LastVisibleBarNumber; i++)
 			{
 				var candle = GetCandle(i);
-				maxDelta = Math.Max(candle.Delta, maxDelta);
+				maxDelta = Math.Max(Math.Abs(candle.Delta), maxDelta);
 				maxVolume = Math.Max(candle.Volume, maxVolume);
 				minDelta = Math.Min(candle.MinDelta, minDelta);
 				maxAsk = Math.Max(candle.Ask, maxAsk);

--- a/Technical/ClusterStatistic.cs
+++ b/Technical/ClusterStatistic.cs
@@ -1713,7 +1713,7 @@ public class ClusterStatistic : Indicator
 				maxVolume = Math.Max(candle.Volume, maxVolume);
 				minDelta = Math.Min(candle.MinDelta, minDelta);
 				maxAsk = Math.Max(candle.Ask, maxAsk);
-				maxBid = Math.Max(candle.Ask, maxBid);
+				maxBid = Math.Max(candle.Bid, maxBid);
 				maxMaxDelta = Math.Max(Math.Abs(candle.MaxDelta), maxMaxDelta);
 				maxMinDelta = Math.Max(Math.Abs(candle.MinDelta), maxMinDelta);
 				maxSessionDelta = Math.Max(Math.Abs(_cDelta[i]), maxSessionDelta);


### PR DESCRIPTION
## Summary

Two copy-paste bugs in `CreateMaxValues` produce incorrect color intensity on the cluster statistic table when the user enables
**Visible Proportion**. The non-VisibleProportion branch of the same method handles both cases correctly, which is what made these stand out.

## Bugs fixed

### 1. `maxBid` reads from `candle.Ask`

```csharp
// CreateMaxValues, VisibleProportion branch
maxAsk = Math.Max(candle.Ask, maxAsk);
maxBid = Math.Max(candle.Ask, maxBid);   // should be candle.Bid
```

The non-VisibleProportion path (`_maxBid` in `OnCalculate`) reads `candle.Bid` correctly. With this typo, the Bid row's rate is
normalised against Ask volumes, so on instruments with imbalanced Ask/Bid distribution the Bid column shows the wrong gradient.

### 2. `maxDelta` does not use `Math.Abs`

```csharp
// CreateMaxValues, VisibleProportion branch
var maxDelta = 0m;
...
maxDelta = Math.Max(candle.Delta, maxDelta);   // signed
```

The non-VisibleProportion path uses `Math.Max(Math.Abs(candle.Delta), _maxDelta)`, and `GetRate(DataType.Delta, …)` feeds `Math.Abs(candle.Delta)` as the value to normalise. When every visible bar has a negative delta, the signed `Math.Max` keeps `maxDelta` at its `0m` initialiser; `GetRate` then hits the `maxValue == 0` fallback (`return 10`) and flattens the gradient on the Delta row.

## Repro

1. Open Cluster Statistic on any chart and enable **Visible Proportion**.
2. Scroll the visible window to a stretch where every bar has negative delta → Delta row gradient becomes uniform (rate = 10).
3. On a market with strongly imbalanced Ask/Bid volumes, compare the Bid row gradient with the non-VisibleProportion mode → they no longer match.

## Risk

Minimal. Both changes are localised to the VisibleProportion branch of `CreateMaxValues` and align it with the existing global-mode behaviour. No public API changes, no new allocations, no flavor impact.

## Not in this PR

While reviewing the file I spotted a handful of additional findings (missing `OnDispose`, asymmetric `i == 0` guard in the same loop, `Duration` formatting without `InvariantCulture`, stale per-session last-alert values when `SessionCumMode` changes, minor whitespace).
None of them affect correctness in the same direct way as the two fixes above and they touch unrelated code paths, so I'm keeping this PR focused and will open a follow-up PR for the rest.