### PR TITLE
fix(ClusterSearch): Remove dead members in ClusterSearch

### DIFF
--- a/Technical/ClusterSearch.cs
+++ b/Technical/ClusterSearch.cs
@@ -61,8 +61,6 @@ public partial class ClusterSearch : Indicator
 	private bool _onlyOneSelectionPerBar;
 	private Filter _pipsFromHigh = new() { Value = 100000000 };
 	private Filter _pipsFromLow = new() { Value = 100000000 };
-	private decimal _pocPrice;
-	private decimal _pocVolume;
 	private PriceLocation _priceLocation = PriceLocation.Any;
 	private int _priceRange = 1;
 	private bool _showPriceSelection = true;
@@ -423,9 +421,6 @@ public partial class ClusterSearch : Indicator
 		var candle = GetCandle(bar);
 
 		_lastSeriesBar.Clear();
-		_pocPrice = 0;
-		_pocVolume = 0;
-
 		_lastBarFormationValid = CheckBarFormation(candle);
 
 		if (!_lastBarFormationValid)
@@ -459,9 +454,6 @@ public partial class ClusterSearch : Indicator
 
 			if (pocInfo is null || pocInfo.Volume is 0)
 				return;
-
-			_pocPrice = pocInfo.Price;
-			_pocVolume = pocInfo.Volume;
 
 			var inRange = false;
 
@@ -1271,12 +1263,6 @@ public partial class ClusterSearch : Indicator
 				_renderDataSeries[i].ForEach(x => x.PriceSelectionColor = ShowPriceSelection ? _clusterPriceColor : CrossColors.Transparent);
 		}
 	}
-
-	[Browsable(false)]
-	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization), Name = nameof(Strings.ClusterSelectionTransparency), Order = 625,
-		Description = nameof(Strings.PriceSelectionTransparencyDescription))]
-	[Range(0, 100)]
-	public int Transparency { get; set; }
 
 	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization), Name = nameof(Strings.FixedSizes), Order = 640,
 		Description = nameof(Strings.FixedSizesDescription))]

--- a/Technical/ClusterSearch.cs
+++ b/Technical/ClusterSearch.cs
@@ -1264,6 +1264,16 @@ public partial class ClusterSearch : Indicator
 		}
 	}
 
+	[Browsable(false)]
+	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization), Name = nameof(Strings.ClusterSelectionTransparency), Order = 625,
+		Description = nameof(Strings.PriceSelectionTransparencyDescription))]
+	[Range(0, 100)]
+	public int Transparency
+	{
+		get => VisualObjectsTransparency;
+		set => VisualObjectsTransparency = value;
+	}
+
 	[Display(ResourceType = typeof(Strings), GroupName = nameof(Strings.Visualization), Name = nameof(Strings.FixedSizes), Order = 640,
 		Description = nameof(Strings.FixedSizesDescription))]
 	[Tab(TabName = nameof(Strings.Visualization), TabOrder = 1, ResourceType = typeof(Strings))]


### PR DESCRIPTION
### What
Removes unused members from `ClusterSearch`:

- `_pocPrice` and `_pocVolume` private fields — assigned in `CalculateBarFull`
  (the `MaxVolume`/POC branch) but never read anywhere. The POC level itself is
  still handled through `pocInfo` / `PlaceToDataSeries`; these two fields were
  redundant copies.
- `Transparency` public property (`[Browsable(false)]`) — shadowed by
  `VisualObjectsTransparency`, which is the property actually wired to the visual
  objects. `Transparency` had no readers.

### Why
Dead code: write-only fields and an unreferenced property. Removing them reduces
noise and avoids confusion with the live `VisualObjectsTransparency`.

### Behavior
No functional change. POC handling and transparency are unaffected. Builds on all
targeted flavors.