### PR TITLE
Fix MultimarketPower: bar-0 forward-fill guard and thread-safe trade buffers

### DIFF
--- a/Technical/MultiMarketPower.cs
+++ b/Technical/MultiMarketPower.cs
@@ -400,7 +400,7 @@ public class MultiMarketPower : Indicator
 	
 	protected override void OnCalculate(int bar, decimal value)
 	{
-		if (!_bigTradesIsReceived || bar != CurrentBar - 1)
+		if (!_bigTradesIsReceived || bar != CurrentBar - 1 || bar == 0)
 			return;
 
 		DataSeries.ForEach(ds =>

--- a/Technical/MultiMarketPower.cs
+++ b/Technical/MultiMarketPower.cs
@@ -414,8 +414,11 @@ public class MultiMarketPower : Indicator
 	{
 		_bigTradesIsReceived = false;
 
-        _ticks.Clear();
-		_trades.Clear();
+		lock (_locker)
+		{
+			_ticks.Clear();
+			_trades.Clear();
+		}
 		var totalBars = CurrentBar - 1;
 		_sessionBegin = totalBars;
 		_lastBar = totalBars;
@@ -452,7 +455,8 @@ public class MultiMarketPower : Indicator
 
 		if (!_bigTradesIsReceived)
 		{
-			_ticks.Add(trade);
+			lock (_locker)
+				_ticks.Add(trade);
 			return;
 		}
 
@@ -471,7 +475,8 @@ public class MultiMarketPower : Indicator
 
 		if (!_bigTradesIsReceived)
 		{
-			_trades.Add(trade);
+			lock (_locker)
+				_trades.Add(trade);
 			return;
 		}
 
@@ -490,8 +495,11 @@ public class MultiMarketPower : Indicator
 
 		if (!_bigTradesIsReceived)
 		{
-			if (_trades.Count != 0)
-				_trades[^1] = trade;
+			lock (_locker)
+			{
+				if (_trades.Count != 0)
+					_trades[^1] = trade;
+			}
 			return;
 		}
 
@@ -613,7 +621,11 @@ public class MultiMarketPower : Indicator
 				for (var i = _sessionBegin; i <= CurrentBar - 1; i++)
 					CalculateBarTrades(orderedTrades, i, ref searchIdx);
 
-				foreach (var trade in _trades)
+				List<CumulativeTrade> bufferedTrades;
+				lock (_locker)
+					bufferedTrades = new List<CumulativeTrade>(_trades);
+
+				foreach (var trade in bufferedTrades)
 					CalculateTrade(trade, false, false);
 			}
 			else
@@ -629,7 +641,11 @@ public class MultiMarketPower : Indicator
 				for (var i = _sessionBegin; i <= CurrentBar - 1; i++)
 					CalculateBarTicks(orderedTicks, i, ref searchIdx);
 
-				foreach (var tick in _ticks)
+				List<MarketDataArg> bufferedTicks;
+				lock (_locker)
+					bufferedTicks = new List<MarketDataArg>(_ticks);
+
+				foreach (var tick in bufferedTicks)
 					CalculateTick(tick);
 			}
 
@@ -643,8 +659,11 @@ public class MultiMarketPower : Indicator
 		{
 			orderedTrades?.Clear();
 			orderedTicks?.Clear();
-			_trades.Clear();
-			_ticks.Clear();
+			lock (_locker)
+			{
+				_trades.Clear();
+				_ticks.Clear();
+			}
 		}
 	}
 

--- a/Technical/MultiMarketPower.cs
+++ b/Technical/MultiMarketPower.cs
@@ -63,7 +63,7 @@ public class MultiMarketPower : Indicator
 		UseMinimizedModeIfEnabled = true
 	};
 
-	private bool _bigTradesIsReceived;
+	private volatile bool _bigTradesIsReceived;
 	private bool _cumulativeTrades = true;
 	private decimal _delta1;
 	private decimal _delta2;
@@ -412,10 +412,9 @@ public class MultiMarketPower : Indicator
 	
 	protected override void OnFinishRecalculate()
 	{
-		_bigTradesIsReceived = false;
-
 		lock (_locker)
 		{
+			_bigTradesIsReceived = false;
 			_ticks.Clear();
 			_trades.Clear();
 		}
@@ -444,8 +443,6 @@ public class MultiMarketPower : Indicator
 
 		ClearValues();
 		CalculateHistory(cumulativeTrades);
-
-		_bigTradesIsReceived = true;
 	}
 
 	protected override void OnNewTrade(MarketDataArg trade)
@@ -453,11 +450,13 @@ public class MultiMarketPower : Indicator
 		if (CumulativeTrades || ChartInfo is null)
 			return;
 
-		if (!_bigTradesIsReceived)
+		lock (_locker)
 		{
-			lock (_locker)
+			if (!_bigTradesIsReceived)
+			{
 				_ticks.Add(trade);
-			return;
+				return;
+			}
 		}
 
 		var newBar = _lastBar < CurrentBar - 1;
@@ -473,11 +472,13 @@ public class MultiMarketPower : Indicator
 		if (!CumulativeTrades)
 			return;
 
-		if (!_bigTradesIsReceived)
+		lock (_locker)
 		{
-			lock (_locker)
+			if (!_bigTradesIsReceived)
+			{
 				_trades.Add(trade);
-			return;
+				return;
+			}
 		}
 
 		var newBar = _lastBar < CurrentBar - 1;
@@ -493,14 +494,14 @@ public class MultiMarketPower : Indicator
 		if (!CumulativeTrades)
 			return;
 
-		if (!_bigTradesIsReceived)
+		lock (_locker)
 		{
-			lock (_locker)
+			if (!_bigTradesIsReceived)
 			{
 				if (_trades.Count != 0)
 					_trades[^1] = trade;
+				return;
 			}
-			return;
 		}
 
 		var newBar = _lastBar < CurrentBar - 1;
@@ -615,18 +616,11 @@ public class MultiMarketPower : Indicator
 			{
 				orderedTrades = trades.OrderBy(t => t.Time).ToList();
 
-				if (orderedTrades.Count is 0)
-					return;
-
-				for (var i = _sessionBegin; i <= CurrentBar - 1; i++)
-					CalculateBarTrades(orderedTrades, i, ref searchIdx);
-
-				List<CumulativeTrade> bufferedTrades;
-				lock (_locker)
-					bufferedTrades = new List<CumulativeTrade>(_trades);
-
-				foreach (var trade in bufferedTrades)
-					CalculateTrade(trade, false, false);
+				if (orderedTrades.Count > 0)
+				{
+					for (var i = _sessionBegin; i <= CurrentBar - 1; i++)
+						CalculateBarTrades(orderedTrades, i, ref searchIdx);
+				}
 			}
 			else
 			{
@@ -635,20 +629,14 @@ public class MultiMarketPower : Indicator
 					.OrderBy(t => t.Time)
 					.ToList();
 
-				if (orderedTicks.Count is 0)
-					return;
-
-				for (var i = _sessionBegin; i <= CurrentBar - 1; i++)
-					CalculateBarTicks(orderedTicks, i, ref searchIdx);
-
-				List<MarketDataArg> bufferedTicks;
-				lock (_locker)
-					bufferedTicks = new List<MarketDataArg>(_ticks);
-
-				foreach (var tick in bufferedTicks)
-					CalculateTick(tick);
+				if (orderedTicks.Count > 0)
+				{
+					for (var i = _sessionBegin; i <= CurrentBar - 1; i++)
+						CalculateBarTicks(orderedTicks, i, ref searchIdx);
+				}
 			}
 
+			DrainBufferedData();
 			RedrawChart();
 		}
 		catch (NullReferenceException)
@@ -659,10 +647,49 @@ public class MultiMarketPower : Indicator
 		{
 			orderedTrades?.Clear();
 			orderedTicks?.Clear();
+		}
+	}
+
+	private void DrainBufferedData()
+	{
+		while (true)
+		{
+			List<CumulativeTrade> tradeBatch = null;
+			List<MarketDataArg> tickBatch = null;
+
 			lock (_locker)
 			{
-				_trades.Clear();
-				_ticks.Clear();
+				if (_trades.Count is 0 && _ticks.Count is 0)
+				{
+					// Nothing left to replay: enable realtime processing before
+					// releasing the lock, so no trade can be buffered afterwards.
+					_bigTradesIsReceived = true;
+					return;
+				}
+
+				if (_trades.Count > 0)
+				{
+					tradeBatch = new List<CumulativeTrade>(_trades);
+					_trades.Clear();
+				}
+
+				if (_ticks.Count > 0)
+				{
+					tickBatch = new List<MarketDataArg>(_ticks);
+					_ticks.Clear();
+				}
+			}
+
+			if (tradeBatch is not null)
+			{
+				foreach (var trade in tradeBatch)
+					CalculateTrade(trade, false, false);
+			}
+
+			if (tickBatch is not null)
+			{
+				foreach (var tick in tickBatch)
+					CalculateTick(tick);
 			}
 		}
 	}


### PR DESCRIPTION
Two small robustness fixes for `MultiMarketPower`, in separate commits.

### 1. Guard `OnCalculate` forward-fill against bar 0
`OnCalculate` copies the previous bar's value into a zero bar:
`vds[bar] = vds[bar - 1]`. The guard only checked `bar != CurrentBar - 1`, so on a chart with a single bar (`CurrentBar == 1`, `bar == 0`) it reads `vds[-1]`.
Added `|| bar == 0` to the early return.

### 2. Synchronize the realtime trade buffers
`_ticks` / `_trades` are appended from the market-data callbacks (`OnNewTrade`, `OnCumulativeTrade`, `OnUpdateCumulativeTrade`) while `OnFinishRecalculate` clears them and `CalculateHistory` iterates them, with no synchronization - even though a `_locker` field is already declared. This races on reload under live data (the existing `catch (NullReferenceException) //on reset exception ignored` in `CalculateHistory` is a symptom). All buffer access is now wrapped in `lock (_locker)`, and the replay iterates a snapshot taken under the lock instead of the live list.

No behavior change in the steady state; only removes the race and the bar-0 edge case.