### PR TITLE
feat(AccountInfoDisplay): add per-trade max open PnL rows

### DIFF
--- a/Technical/AccountInfoDisplay.cs
+++ b/Technical/AccountInfoDisplay.cs
@@ -35,6 +35,10 @@ public class AccountInfoDisplay : Indicator
 
 	private Portfolio _currentPortfolio;
 
+	private bool _wasPositionOpen;
+	private decimal _currentTradeMaxOpenPnl;
+	private decimal? _lastTradeMaxOpenPnl;
+
 	#endregion
 
 	#region Properties
@@ -128,6 +132,14 @@ public class AccountInfoDisplay : Indicator
 		Description = nameof(Strings.ShowTotalPnLDescription), GroupName = nameof(Strings.Settings))]
 	public bool ShowTotalPnL { get; set; } = false;
 
+	[Display(Name = "Show max open PnL", GroupName = "Settings",
+		Description = "Show the maximum open PnL reached during the current trade.")]
+	public bool ShowMaxOpenPnL { get; set; } = false;
+
+	[Display(Name = "Show last trade max open PnL", GroupName = "Settings",
+		Description = "Keep the maximum open PnL of the last closed trade visible while flat.")]
+	public bool ShowLastTradeMaxOpenPnL { get; set; } = false;
+
 	[Display(ResourceType = typeof(Strings), Name = nameof(Strings.HorizontalPosition),
 		GroupName = nameof(Strings.LayoutGroup))]
 	public HorizontalAlignment HorizontalPosition { get; set; } = HorizontalAlignment.Left;
@@ -219,6 +231,9 @@ public class AccountInfoDisplay : Indicator
 		if (portfolio == null)
 			return;
 
+		if (ShowMaxOpenPnL || ShowLastTradeMaxOpenPnL)
+			UpdateMaxOpenPnl(portfolio);
+
 		// Build display text
 		var lines = BuildLines(portfolio);
 		if (lines.Count == 0)
@@ -267,7 +282,41 @@ public class AccountInfoDisplay : Indicator
 	private void OnPortfolioSelected(Portfolio portfolio)
 	{
 		_currentPortfolio = portfolio;
+
+		_wasPositionOpen = false;
+		_currentTradeMaxOpenPnl = 0m;
+		_lastTradeMaxOpenPnl = null;
+
 		RedrawChart();
+	}
+
+	private void UpdateMaxOpenPnl(Portfolio portfolio)
+	{
+		var position = TradingManager?.Position;
+		var security = TradingManager?.Security;
+
+		var isOpen = position != null && security != null
+			&& string.Equals(position.AccountID, portfolio.AccountID, StringComparison.Ordinal)
+			&& position.Security != null
+			&& string.Equals(position.Security.Code, security.Code, StringComparison.Ordinal)
+			&& position.IsInPosition && position.Volume != 0m;
+
+		if (isOpen)
+		{
+			if (!_wasPositionOpen)
+			{
+				_wasPositionOpen = true;
+				_currentTradeMaxOpenPnl = portfolio.OpenPnL;
+			}
+			else if (portfolio.OpenPnL > _currentTradeMaxOpenPnl)
+				_currentTradeMaxOpenPnl = portfolio.OpenPnL;
+		}
+		else if (_wasPositionOpen)
+		{
+			_wasPositionOpen = false;
+			_lastTradeMaxOpenPnl = _currentTradeMaxOpenPnl;
+			_currentTradeMaxOpenPnl = 0m;
+		}
 	}
 
 	private sealed record DisplayLine(string Label, string Value, decimal? RawForColoring);
@@ -296,6 +345,12 @@ public class AccountInfoDisplay : Indicator
 
 		if (ShowOpenPnL)
 			lines.Add(new("Open PnL", FormatCurrency(p.OpenPnL), p.OpenPnL));
+
+		if (ShowMaxOpenPnL && _wasPositionOpen)
+			lines.Add(new("Max open PnL", FormatCurrency(_currentTradeMaxOpenPnl), _currentTradeMaxOpenPnl));
+
+		if (ShowLastTradeMaxOpenPnL && !_wasPositionOpen && _lastTradeMaxOpenPnl.HasValue)
+			lines.Add(new("Last trade max PnL", FormatCurrency(_lastTradeMaxOpenPnl.Value), _lastTradeMaxOpenPnl.Value));
 
 		if (ShowClosedPnL)
 			lines.Add(new("Closed PnL", FormatCurrency(p.ClosedPnL), p.ClosedPnL));


### PR DESCRIPTION
## Summary

Adds two optional rows to the account info panel, both **disabled by default** so existing setups are unaffected:

- **Max open PnL** — the highest open PnL reached during the current trade, shown while a position is open on the selected account/instrument.
- **Last trade max PnL** — the same value for the last closed trade, kept visible while flat.

This makes it easy to see how much unrealized profit a trade reached before it was closed (maximum favorable excursion), directly on the panel traders already use to monitor PnL.

## Implementation notes

- Runtime-only tracking, no persistence: a small state machine follows flat → open → flat transitions of `TradingManager.Position` (matching account and instrument), seeds the baseline with the portfolio open PnL at entry, and updates the maximum on each render.
- State resets whenever the selected portfolio changes.
- Tracking only runs when at least one of the two toggles is enabled; with both off there is zero additional work per render.
- The diff is additive-only (55 lines) on top of current Develop; no existing behavior is modified.

## Localization

The two toggle names and row labels are declared inline, consistent with the existing row labels in this file ("Open PnL", "Balance", …). No matching keys exist in OFT.Localization yet, so they follow the same transitional pattern as the recently merged Half Gap settings in DailyLines, ready to be swapped once keys are added:

| Text | Where |
|------|-------|
| Show max open PnL / Show the maximum open PnL reached during the current trade. | toggle name / description |
| Show last trade max open PnL / Keep the maximum open PnL of the last closed trade visible while flat. | toggle name / description |
| Max open PnL, Last trade max PnL | row labels |

## Testing

Built against Alpha configuration with 0 errors. Smoke-tested on chart: row appears on position open and only increases; on close the value moves to "Last trade max PnL" and persists while flat; switching accounts clears the state; both toggles off reproduces the previous panel exactly.